### PR TITLE
TASK-868 - add support for ExpressionSets

### DIFF
--- a/KBaseSets.spec
+++ b/KBaseSets.spec
@@ -15,13 +15,28 @@ module KBaseSets {
         ws_obj_id ref;
     } DataAttachment;
 
+    /****************************** */
+    /* READS ALIGNMENTS SET */
+
+    typedef string ws_reads_align_id;
+
+    typedef structure {
+        ws_reads_align_id ref;
+        string label;
+    } ReadsAlignmentSetItem;
+
+    typedef structure {
+        string description;
+        list<ReadsAlignmentSetItem> items;
+    } ReadsAlignmentSet;
+
 
     /****************************** */
     /* READS SET */
 
     /*
         The workspace ID for a Reads data object.
-        @id ws KBaseFile.PairedEndLibrary KBaseFile.SingleEndLibrary 
+        @id ws KBaseFile.PairedEndLibrary KBaseFile.SingleEndLibrary
     */
     typedef string ws_reads_id;
 

--- a/KBaseSets.spec
+++ b/KBaseSets.spec
@@ -24,9 +24,7 @@ module KBaseSets {
     typedef string ws_expression_id;
 
     /*
-        When saving a ExpressionSet, only 'ref' is required.
-        You should never set 'info'.  'info' is provided optionally when fetching
-        the ExpressionSet.
+        @optional label data_attachments
     */
     typedef structure {
         ws_expression_id ref;

--- a/KBaseSets.spec
+++ b/KBaseSets.spec
@@ -16,6 +16,35 @@ module KBaseSets {
     } DataAttachment;
 
     /****************************** */
+    /* EXPRESSION SET */
+    /*
+        The workspace id for a ReadsAlignment data object.
+        @id ws KBaseRNASeq.RNASeqExpression
+    */
+    typedef string ws_expression_id;
+
+    /*
+        When saving a ExpressionSet, only 'ref' is required.
+        You should never set 'info'.  'info' is provided optionally when fetching
+        the ExpressionSet.
+    */
+    typedef structure {
+        ws_expression_id ref;
+        string label;
+        list <DataAttachment> data_attachments;
+    } ExpressionSetItem;
+
+    /*
+        @metadata ws description as description
+        @metadata ws length(items) as item_count
+    */
+    typedef structure {
+        string description;
+        list<ExpressionSetItem> items;
+    } ExpressionSet;
+
+
+    /****************************** */
     /* READS ALIGNMENTS SET */
 
     /*
@@ -24,11 +53,19 @@ module KBaseSets {
     */
     typedef string ws_reads_align_id;
 
+    /*
+        @optional label data_attachments
+    */
     typedef structure {
         ws_reads_align_id ref;
         string label;
+        list <DataAttachment> data_attachments;
     } ReadsAlignmentSetItem;
 
+    /*
+        @metadata ws description as description
+        @metadata ws length(items) as item_count
+    */
     typedef structure {
         string description;
         list<ReadsAlignmentSetItem> items;

--- a/KBaseSets.spec
+++ b/KBaseSets.spec
@@ -18,6 +18,10 @@ module KBaseSets {
     /****************************** */
     /* READS ALIGNMENTS SET */
 
+    /*
+        The workspace id for a ReadsAlignment data object.
+        @id ws KBaseRNASeq.RNASeqAlignment
+    */
     typedef string ws_reads_align_id;
 
     typedef structure {

--- a/SetAPI.spec
+++ b/SetAPI.spec
@@ -9,6 +9,80 @@ module SetAPI {
     /* A boolean. 0 = false, 1 = true. */
     typedef int boolean;
 
+    /* ******* READS ALIGNMENT SET METHODS ******** */
+
+    /* NOTE: data type explicitly copied from KBaseSets so type and
+    API can evolve independently */
+
+    /*
+        The workspace id for a ReadsAlignment data object.
+        @id ws KBaseRNASeq.RNASeqAlignment
+    */
+    typedef string ws_reads_align_id;
+
+    /*
+        When saving a ReadsAlignmentSet, only 'ref' is required.
+        You should never set 'info'.  'info' is provided optionally when fetching
+        the ReadsAlignmentSet.
+    */
+    typedef structure {
+        ws_reads_align_id ref;
+        string label;
+        Workspace.object_info info;
+    } ReadsAlignmentSetItem;
+
+    /*
+        When building a ReadsAlignmentSet, all ReadsAlignments must be aligned against the same
+        genome. This is not part of the object type, but enforced during a call to
+        save_reads_alignment_v1.
+        @meta ws description as description
+        @meta ws length(items) as item_count
+    */
+    typedef structure {
+        string description;
+        list<ReadsAlignmentSetItem> items;
+    } ReadsAlignmentSet;
+
+    /*
+        ref - workspace reference to ReadsAlignmentSet object.
+        include_item_info - 1 or 0, if 1 additionally provides workspace info (with
+                            metadata) for each ReadsAlignment object in the Set
+    */
+    typedef structure {
+        string ref;
+        boolean include_item_info;
+        list <string> ref_path_to_set;
+    } GetReadsAlignmentSetV1Params;
+
+    typedef structure {
+        ReadsAlignmentSet data;
+        Workspace.object_info info;
+    } GetReadsAlignmentSetV1Result;
+
+    funcdef get_reads_alignment_set_v1(GetReadsAlignmentSetV1Params params)
+        returns (GetReadsAlignmentSetV1Result) authentication optional;
+
+    /*
+        workspace_name or workspace_id - alternative options defining
+            target workspace,
+        output_object_name - workspace object name (this parameter is
+            used together with one of workspace params from above)
+    */
+    typedef structure {
+        string workspace;
+        string output_object_name;
+        ReadsAlignmentSet data;
+    } SaveReadsAlignmentSetV1Params;
+
+    typedef structure {
+        string set_ref;
+        Workspace.object_info set_info;
+    } SaveReadsAlignmentSetV1Result;
+
+    funcdef save_reads_alignment_set_v1(SaveReadsAlignmentSetV1Params params)
+        returns (SaveReadsAlignmentSetV1Result result) authentication required;
+
+
 
     /* ******* READS SET METHODS ************ */
 
@@ -28,7 +102,7 @@ module SetAPI {
 
     /*
         The workspace ID for a Reads data object.
-        @id ws KBaseFile.PairedEndLibrary KBaseFile.SingleEndLibrary 
+        @id ws KBaseFile.PairedEndLibrary KBaseFile.SingleEndLibrary
     */
     typedef string ws_reads_id;
 
@@ -74,7 +148,7 @@ module SetAPI {
         returns (GetReadsSetV1Result result) authentication optional;
 
     /*
-        workspace_name or workspace_id - alternative options defining 
+        workspace_name or workspace_id - alternative options defining
             target workspace,
         output_object_name - workspace object name (this parameter is
             used together with one of workspace params from above)
@@ -103,7 +177,7 @@ module SetAPI {
 
     /*
         The workspace ID for an Assembly object.
-        @id ws KBaseGenomeAnnotations.Assembly 
+        @id ws KBaseGenomeAnnotations.Assembly
     */
     typedef string ws_assembly_id;
 
@@ -148,7 +222,7 @@ module SetAPI {
         returns (GetAssemblySetV1Result result) authentication optional;
 
     /*
-        workspace_name or workspace_id - alternative options defining 
+        workspace_name or workspace_id - alternative options defining
             target workspace,
         output_object_name - workspace object name (this parameter is
             used together with one of workspace params from above)
@@ -176,7 +250,7 @@ module SetAPI {
 
     /*
         The workspace ID for a Genome object.
-        @id ws KBaseGenomes.Genome 
+        @id ws KBaseGenomes.Genome
     */
     typedef string ws_genome_id;
 
@@ -221,7 +295,7 @@ module SetAPI {
         returns (GetGenomeSetV1Result result) authentication optional;
 
     /*
-        workspace_name or workspace_id - alternative options defining 
+        workspace_name or workspace_id - alternative options defining
             target workspace,
         output_object_name - workspace object name (this parameter is
             used together with one of workspace params from above)
@@ -249,14 +323,14 @@ module SetAPI {
     /* ******* Generic SET METHODS ************ */
 
 
-    /* 
+    /*
         workspace - workspace name or ID (alternative to
             workspaces parameter),
         workspaces - list of workspace name ot ID (alternative to
             workspace parameter),
-        include_metadata - flag for including metadata into Set object info 
+        include_metadata - flag for including metadata into Set object info
             and into object info of items (it affects DP raw data as well),
-        include_raw_data_palettes - advanced option designed for 
+        include_raw_data_palettes - advanced option designed for
             optimization of listing methods in NarrativeService.
     */
     typedef structure {
@@ -300,13 +374,13 @@ module SetAPI {
     } ListSetResult;
 
     /* Use to get the top-level sets in a WS. Optionally can include
-    one level down members of those sets. 
+    one level down members of those sets.
     NOTE: DOES NOT PRESERVE ORDERING OF ITEM LIST IN DATA */
     funcdef list_sets(ListSetParams params)
                 returns (ListSetResult result) authentication optional;
 
 
-    
+
     typedef structure {
         ws_obj_id ref;
         list <ws_obj_id> path_to_set;

--- a/SetAPI.spec
+++ b/SetAPI.spec
@@ -9,6 +9,93 @@ module SetAPI {
     /* A boolean. 0 = false, 1 = true. */
     typedef int boolean;
 
+    /*
+        The workspace ID for a any data object.
+        @id ws
+    */
+    typedef string ws_obj_id;
+
+    typedef structure {
+        string name;
+        ws_obj_id ref;
+    } DataAttachment;
+
+
+    /* ******* EXPRESSION SET METHODS ******** */
+
+    /* NOTE: data type explicitly copied from KBaseSets so type and
+    API can evolve independently. */
+
+    /*
+        The workspace id for a ReadsAlignment data object.
+        @id ws KBaseRNASeq.RNASeqExpression
+    */
+    typedef string ws_expression_id;
+
+    /*
+        When saving a ExpressionSet, only 'ref' is required.
+        You should never set 'info'.  'info' is provided optionally when fetching
+        the ExpressionSet.
+    */
+    typedef structure {
+        ws_expression_id ref;
+        string label;
+        list<DataAttachment> data_attachments;
+        Workspace.object_info info;
+    } ExpressionSetItem;
+
+    /*
+        When building a ExpressionSet, all Expression objects must be aligned against the same
+        genome. This is not part of the object type, but enforced during a call to
+        save_expression_set_v1.
+        @meta ws description as description
+        @meta ws length(items) as item_count
+    */
+    typedef structure {
+        string description;
+        list<ExpressionSetItem> items;
+    } ExpressionSet;
+
+    /*
+        ref - workspace reference to ExpressionSet object.
+        include_item_info - 1 or 0, if 1 additionally provides workspace info (with
+                            metadata) for each Expression object in the Set
+    */
+    typedef structure {
+        string ref;
+        boolean include_item_info;
+        list <string> ref_path_to_set;
+    } GetExpressionSetV1Params;
+
+    typedef structure {
+        ExpressionSet data;
+        Workspace.object_info info;
+    } GetExpressionSetV1Result;
+
+    funcdef get_expression_set_v1(GetExpressionSetV1Params params)
+        returns (GetExpressionSetV1Result) authentication optional;
+
+    /*
+        workspace_name or workspace_id - alternative options defining
+            target workspace,
+        output_object_name - workspace object name (this parameter is
+            used together with one of workspace params from above)
+    */
+    typedef structure {
+        string workspace;
+        string output_object_name;
+        ExpressionSet data;
+    } SaveExpressionSetV1Params;
+
+    typedef structure {
+        string set_ref;
+        Workspace.object_info set_info;
+    } SaveExpressionSetV1Result;
+
+    funcdef save_expression_set_v1(SaveExpressionSetV1Params params)
+        returns (SaveExpressionSetV1Result result) authentication required;
+
+
     /* ******* READS ALIGNMENT SET METHODS ******** */
 
     /* NOTE: data type explicitly copied from KBaseSets so type and
@@ -29,12 +116,13 @@ module SetAPI {
         ws_reads_align_id ref;
         string label;
         Workspace.object_info info;
+        list<DataAttachment> data_attachments;
     } ReadsAlignmentSetItem;
 
     /*
         When building a ReadsAlignmentSet, all ReadsAlignments must be aligned against the same
         genome. This is not part of the object type, but enforced during a call to
-        save_reads_alignment_v1.
+        save_reads_alignment_set_v1.
         @meta ws description as description
         @meta ws length(items) as item_count
     */
@@ -88,17 +176,6 @@ module SetAPI {
 
     /* NOTE: data type explicitly copied from KBaseSets so type and
     API can evolve independently */
-
-    /*
-        The workspace ID for a any data object.
-        @id ws
-    */
-    typedef string ws_obj_id;
-
-    typedef structure {
-        string name;
-        ws_obj_id ref;
-    } DataAttachment;
 
     /*
         The workspace ID for a Reads data object.

--- a/lib/SetAPI/SetAPIClient.pm
+++ b/lib/SetAPI/SetAPIClient.pm
@@ -81,12 +81,19 @@ sub new
     # We create an auth token, passing through the arguments that we were (hopefully) given.
 
     {
-	my $token = Bio::KBase::AuthToken->new(@args);
+	my %arg_hash2 = @args;
+	if (exists $arg_hash2{"token"}) {
+	    $self->{token} = $arg_hash2{"token"};
+	} elsif (exists $arg_hash2{"user_id"}) {
+	    my $token = Bio::KBase::AuthToken->new(@args);
+	    if (!$token->error_message) {
+	        $self->{token} = $token->token;
+	    }
+	}
 	
-	if (!$token->error_message)
+	if (exists $self->{token})
 	{
-	    $self->{token} = $token->token;
-	    $self->{client}->{token} = $token->token;
+	    $self->{client}->{token} = $self->{token};
 	}
     }
 
@@ -99,6 +106,312 @@ sub new
 }
 
 
+
+
+=head2 get_reads_alignment_set_v1
+
+  $return = $obj->get_reads_alignment_set_v1($params)
+
+=over 4
+
+=item Parameter and return types
+
+=begin html
+
+<pre>
+$params is a SetAPI.GetReadsAlignmentSetV1Params
+$return is a SetAPI.GetReadsAlignmentSetV1Result
+GetReadsAlignmentSetV1Params is a reference to a hash where the following keys are defined:
+	ref has a value which is a string
+	include_item_info has a value which is a SetAPI.boolean
+	ref_path_to_set has a value which is a reference to a list where each element is a string
+boolean is an int
+GetReadsAlignmentSetV1Result is a reference to a hash where the following keys are defined:
+	data has a value which is a SetAPI.ReadsAlignmentSet
+	info has a value which is a Workspace.object_info
+ReadsAlignmentSet is a reference to a hash where the following keys are defined:
+	description has a value which is a string
+	items has a value which is a reference to a list where each element is a SetAPI.ReadsAlignmentSetItem
+ReadsAlignmentSetItem is a reference to a hash where the following keys are defined:
+	ref has a value which is a SetAPI.ws_reads_align_id
+	label has a value which is a string
+	info has a value which is a Workspace.object_info
+ws_reads_align_id is a string
+object_info is a reference to a list containing 11 items:
+	0: (objid) a Workspace.obj_id
+	1: (name) a Workspace.obj_name
+	2: (type) a Workspace.type_string
+	3: (save_date) a Workspace.timestamp
+	4: (version) an int
+	5: (saved_by) a Workspace.username
+	6: (wsid) a Workspace.ws_id
+	7: (workspace) a Workspace.ws_name
+	8: (chsum) a string
+	9: (size) an int
+	10: (meta) a Workspace.usermeta
+obj_id is an int
+obj_name is a string
+type_string is a string
+timestamp is a string
+username is a string
+ws_id is an int
+ws_name is a string
+usermeta is a reference to a hash where the key is a string and the value is a string
+
+</pre>
+
+=end html
+
+=begin text
+
+$params is a SetAPI.GetReadsAlignmentSetV1Params
+$return is a SetAPI.GetReadsAlignmentSetV1Result
+GetReadsAlignmentSetV1Params is a reference to a hash where the following keys are defined:
+	ref has a value which is a string
+	include_item_info has a value which is a SetAPI.boolean
+	ref_path_to_set has a value which is a reference to a list where each element is a string
+boolean is an int
+GetReadsAlignmentSetV1Result is a reference to a hash where the following keys are defined:
+	data has a value which is a SetAPI.ReadsAlignmentSet
+	info has a value which is a Workspace.object_info
+ReadsAlignmentSet is a reference to a hash where the following keys are defined:
+	description has a value which is a string
+	items has a value which is a reference to a list where each element is a SetAPI.ReadsAlignmentSetItem
+ReadsAlignmentSetItem is a reference to a hash where the following keys are defined:
+	ref has a value which is a SetAPI.ws_reads_align_id
+	label has a value which is a string
+	info has a value which is a Workspace.object_info
+ws_reads_align_id is a string
+object_info is a reference to a list containing 11 items:
+	0: (objid) a Workspace.obj_id
+	1: (name) a Workspace.obj_name
+	2: (type) a Workspace.type_string
+	3: (save_date) a Workspace.timestamp
+	4: (version) an int
+	5: (saved_by) a Workspace.username
+	6: (wsid) a Workspace.ws_id
+	7: (workspace) a Workspace.ws_name
+	8: (chsum) a string
+	9: (size) an int
+	10: (meta) a Workspace.usermeta
+obj_id is an int
+obj_name is a string
+type_string is a string
+timestamp is a string
+username is a string
+ws_id is an int
+ws_name is a string
+usermeta is a reference to a hash where the key is a string and the value is a string
+
+
+=end text
+
+=item Description
+
+
+
+=back
+
+=cut
+
+ sub get_reads_alignment_set_v1
+{
+    my($self, @args) = @_;
+
+# Authentication: optional
+
+    if ((my $n = @args) != 1)
+    {
+	Bio::KBase::Exceptions::ArgumentValidationError->throw(error =>
+							       "Invalid argument count for function get_reads_alignment_set_v1 (received $n, expecting 1)");
+    }
+    {
+	my($params) = @args;
+
+	my @_bad_arguments;
+        (ref($params) eq 'HASH') or push(@_bad_arguments, "Invalid type for argument 1 \"params\" (value was \"$params\")");
+        if (@_bad_arguments) {
+	    my $msg = "Invalid arguments passed to get_reads_alignment_set_v1:\n" . join("", map { "\t$_\n" } @_bad_arguments);
+	    Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
+								   method_name => 'get_reads_alignment_set_v1');
+	}
+    }
+
+    my $url = $self->{url};
+    my $result = $self->{client}->call($url, $self->{headers}, {
+	    method => "SetAPI.get_reads_alignment_set_v1",
+	    params => \@args,
+    });
+    if ($result) {
+	if ($result->is_error) {
+	    Bio::KBase::Exceptions::JSONRPC->throw(error => $result->error_message,
+					       code => $result->content->{error}->{code},
+					       method_name => 'get_reads_alignment_set_v1',
+					       data => $result->content->{error}->{error} # JSON::RPC::ReturnObject only supports JSONRPC 1.1 or 1.O
+					      );
+	} else {
+	    return wantarray ? @{$result->result} : $result->result->[0];
+	}
+    } else {
+        Bio::KBase::Exceptions::HTTP->throw(error => "Error invoking method get_reads_alignment_set_v1",
+					    status_line => $self->{client}->status_line,
+					    method_name => 'get_reads_alignment_set_v1',
+				       );
+    }
+}
+ 
+
+
+=head2 save_reads_alignment_set_v1
+
+  $result = $obj->save_reads_alignment_set_v1($params)
+
+=over 4
+
+=item Parameter and return types
+
+=begin html
+
+<pre>
+$params is a SetAPI.SaveReadsAlignmentSetV1Params
+$result is a SetAPI.SaveReadsAlignmentSetV1Result
+SaveReadsAlignmentSetV1Params is a reference to a hash where the following keys are defined:
+	workspace has a value which is a string
+	output_object_name has a value which is a string
+	data has a value which is a SetAPI.ReadsAlignmentSet
+ReadsAlignmentSet is a reference to a hash where the following keys are defined:
+	description has a value which is a string
+	items has a value which is a reference to a list where each element is a SetAPI.ReadsAlignmentSetItem
+ReadsAlignmentSetItem is a reference to a hash where the following keys are defined:
+	ref has a value which is a SetAPI.ws_reads_align_id
+	label has a value which is a string
+	info has a value which is a Workspace.object_info
+ws_reads_align_id is a string
+object_info is a reference to a list containing 11 items:
+	0: (objid) a Workspace.obj_id
+	1: (name) a Workspace.obj_name
+	2: (type) a Workspace.type_string
+	3: (save_date) a Workspace.timestamp
+	4: (version) an int
+	5: (saved_by) a Workspace.username
+	6: (wsid) a Workspace.ws_id
+	7: (workspace) a Workspace.ws_name
+	8: (chsum) a string
+	9: (size) an int
+	10: (meta) a Workspace.usermeta
+obj_id is an int
+obj_name is a string
+type_string is a string
+timestamp is a string
+username is a string
+ws_id is an int
+ws_name is a string
+usermeta is a reference to a hash where the key is a string and the value is a string
+SaveReadsAlignmentSetV1Result is a reference to a hash where the following keys are defined:
+	set_ref has a value which is a string
+	set_info has a value which is a Workspace.object_info
+
+</pre>
+
+=end html
+
+=begin text
+
+$params is a SetAPI.SaveReadsAlignmentSetV1Params
+$result is a SetAPI.SaveReadsAlignmentSetV1Result
+SaveReadsAlignmentSetV1Params is a reference to a hash where the following keys are defined:
+	workspace has a value which is a string
+	output_object_name has a value which is a string
+	data has a value which is a SetAPI.ReadsAlignmentSet
+ReadsAlignmentSet is a reference to a hash where the following keys are defined:
+	description has a value which is a string
+	items has a value which is a reference to a list where each element is a SetAPI.ReadsAlignmentSetItem
+ReadsAlignmentSetItem is a reference to a hash where the following keys are defined:
+	ref has a value which is a SetAPI.ws_reads_align_id
+	label has a value which is a string
+	info has a value which is a Workspace.object_info
+ws_reads_align_id is a string
+object_info is a reference to a list containing 11 items:
+	0: (objid) a Workspace.obj_id
+	1: (name) a Workspace.obj_name
+	2: (type) a Workspace.type_string
+	3: (save_date) a Workspace.timestamp
+	4: (version) an int
+	5: (saved_by) a Workspace.username
+	6: (wsid) a Workspace.ws_id
+	7: (workspace) a Workspace.ws_name
+	8: (chsum) a string
+	9: (size) an int
+	10: (meta) a Workspace.usermeta
+obj_id is an int
+obj_name is a string
+type_string is a string
+timestamp is a string
+username is a string
+ws_id is an int
+ws_name is a string
+usermeta is a reference to a hash where the key is a string and the value is a string
+SaveReadsAlignmentSetV1Result is a reference to a hash where the following keys are defined:
+	set_ref has a value which is a string
+	set_info has a value which is a Workspace.object_info
+
+
+=end text
+
+=item Description
+
+
+
+=back
+
+=cut
+
+ sub save_reads_alignment_set_v1
+{
+    my($self, @args) = @_;
+
+# Authentication: required
+
+    if ((my $n = @args) != 1)
+    {
+	Bio::KBase::Exceptions::ArgumentValidationError->throw(error =>
+							       "Invalid argument count for function save_reads_alignment_set_v1 (received $n, expecting 1)");
+    }
+    {
+	my($params) = @args;
+
+	my @_bad_arguments;
+        (ref($params) eq 'HASH') or push(@_bad_arguments, "Invalid type for argument 1 \"params\" (value was \"$params\")");
+        if (@_bad_arguments) {
+	    my $msg = "Invalid arguments passed to save_reads_alignment_set_v1:\n" . join("", map { "\t$_\n" } @_bad_arguments);
+	    Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
+								   method_name => 'save_reads_alignment_set_v1');
+	}
+    }
+
+    my $url = $self->{url};
+    my $result = $self->{client}->call($url, $self->{headers}, {
+	    method => "SetAPI.save_reads_alignment_set_v1",
+	    params => \@args,
+    });
+    if ($result) {
+	if ($result->is_error) {
+	    Bio::KBase::Exceptions::JSONRPC->throw(error => $result->error_message,
+					       code => $result->content->{error}->{code},
+					       method_name => 'save_reads_alignment_set_v1',
+					       data => $result->content->{error}->{error} # JSON::RPC::ReturnObject only supports JSONRPC 1.1 or 1.O
+					      );
+	} else {
+	    return wantarray ? @{$result->result} : $result->result->[0];
+	}
+    } else {
+        Bio::KBase::Exceptions::HTTP->throw(error => "Error invoking method save_reads_alignment_set_v1",
+					    status_line => $self->{client}->status_line,
+					    method_name => 'save_reads_alignment_set_v1',
+				       );
+    }
+}
+ 
 
 
 =head2 get_reads_set_v1
@@ -1156,7 +1469,7 @@ ws_ref is a string
 =item Description
 
 Use to get the top-level sets in a WS. Optionally can include
-one level down members of those sets. 
+one level down members of those sets.
 NOTE: DOES NOT PRESERVE ORDERING OF ITEM LIST IN DATA
 
 =back
@@ -1485,6 +1798,267 @@ an int
 
 
 
+=head2 ws_reads_align_id
+
+=over 4
+
+
+
+=item Description
+
+The workspace id for a ReadsAlignment data object.
+@id ws KBaseRNASeq.RNASeqAlignment
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a string
+</pre>
+
+=end html
+
+=begin text
+
+a string
+
+=end text
+
+=back
+
+
+
+=head2 ReadsAlignmentSetItem
+
+=over 4
+
+
+
+=item Description
+
+When saving a ReadsAlignmentSet, only 'ref' is required.
+You should never set 'info'.  'info' is provided optionally when fetching
+the ReadsAlignmentSet.
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+ref has a value which is a SetAPI.ws_reads_align_id
+label has a value which is a string
+info has a value which is a Workspace.object_info
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+ref has a value which is a SetAPI.ws_reads_align_id
+label has a value which is a string
+info has a value which is a Workspace.object_info
+
+
+=end text
+
+=back
+
+
+
+=head2 ReadsAlignmentSet
+
+=over 4
+
+
+
+=item Description
+
+When building a ReadsAlignmentSet, all ReadsAlignments must be aligned against the same
+genome. This is not part of the object type, but enforced during a call to
+save_reads_alignment_v1.
+@meta ws description as description
+@meta ws length(items) as item_count
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+description has a value which is a string
+items has a value which is a reference to a list where each element is a SetAPI.ReadsAlignmentSetItem
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+description has a value which is a string
+items has a value which is a reference to a list where each element is a SetAPI.ReadsAlignmentSetItem
+
+
+=end text
+
+=back
+
+
+
+=head2 GetReadsAlignmentSetV1Params
+
+=over 4
+
+
+
+=item Description
+
+ref - workspace reference to ReadsAlignmentSet object.
+include_item_info - 1 or 0, if 1 additionally provides workspace info (with
+                    metadata) for each ReadsAlignment object in the Set
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+ref has a value which is a string
+include_item_info has a value which is a SetAPI.boolean
+ref_path_to_set has a value which is a reference to a list where each element is a string
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+ref has a value which is a string
+include_item_info has a value which is a SetAPI.boolean
+ref_path_to_set has a value which is a reference to a list where each element is a string
+
+
+=end text
+
+=back
+
+
+
+=head2 GetReadsAlignmentSetV1Result
+
+=over 4
+
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+data has a value which is a SetAPI.ReadsAlignmentSet
+info has a value which is a Workspace.object_info
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+data has a value which is a SetAPI.ReadsAlignmentSet
+info has a value which is a Workspace.object_info
+
+
+=end text
+
+=back
+
+
+
+=head2 SaveReadsAlignmentSetV1Params
+
+=over 4
+
+
+
+=item Description
+
+workspace_name or workspace_id - alternative options defining
+    target workspace,
+output_object_name - workspace object name (this parameter is
+    used together with one of workspace params from above)
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+workspace has a value which is a string
+output_object_name has a value which is a string
+data has a value which is a SetAPI.ReadsAlignmentSet
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+workspace has a value which is a string
+output_object_name has a value which is a string
+data has a value which is a SetAPI.ReadsAlignmentSet
+
+
+=end text
+
+=back
+
+
+
+=head2 SaveReadsAlignmentSetV1Result
+
+=over 4
+
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+set_ref has a value which is a string
+set_info has a value which is a Workspace.object_info
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+set_ref has a value which is a string
+set_info has a value which is a Workspace.object_info
+
+
+=end text
+
+=back
+
+
+
 =head2 ws_obj_id
 
 =over 4
@@ -1743,7 +2317,7 @@ info has a value which is a Workspace.object_info
 
 =item Description
 
-workspace_name or workspace_id - alternative options defining 
+workspace_name or workspace_id - alternative options defining
     target workspace,
 output_object_name - workspace object name (this parameter is
     used together with one of workspace params from above)
@@ -2001,7 +2575,7 @@ info has a value which is a Workspace.object_info
 
 =item Description
 
-workspace_name or workspace_id - alternative options defining 
+workspace_name or workspace_id - alternative options defining
     target workspace,
 output_object_name - workspace object name (this parameter is
     used together with one of workspace params from above)
@@ -2259,7 +2833,7 @@ info has a value which is a Workspace.object_info
 
 =item Description
 
-workspace_name or workspace_id - alternative options defining 
+workspace_name or workspace_id - alternative options defining
     target workspace,
 output_object_name - workspace object name (this parameter is
     used together with one of workspace params from above)
@@ -2337,9 +2911,9 @@ workspace - workspace name or ID (alternative to
     workspaces parameter),
 workspaces - list of workspace name ot ID (alternative to
     workspace parameter),
-include_metadata - flag for including metadata into Set object info 
+include_metadata - flag for including metadata into Set object info
     and into object info of items (it affects DP raw data as well),
-include_raw_data_palettes - advanced option designed for 
+include_raw_data_palettes - advanced option designed for
     optimization of listing methods in NarrativeService.
 
 

--- a/lib/SetAPI/SetAPIClient.pm
+++ b/lib/SetAPI/SetAPIClient.pm
@@ -108,6 +108,332 @@ sub new
 
 
 
+=head2 get_expression_set_v1
+
+  $return = $obj->get_expression_set_v1($params)
+
+=over 4
+
+=item Parameter and return types
+
+=begin html
+
+<pre>
+$params is a SetAPI.GetExpressionSetV1Params
+$return is a SetAPI.GetExpressionSetV1Result
+GetExpressionSetV1Params is a reference to a hash where the following keys are defined:
+	ref has a value which is a string
+	include_item_info has a value which is a SetAPI.boolean
+	ref_path_to_set has a value which is a reference to a list where each element is a string
+boolean is an int
+GetExpressionSetV1Result is a reference to a hash where the following keys are defined:
+	data has a value which is a SetAPI.ExpressionSet
+	info has a value which is a Workspace.object_info
+ExpressionSet is a reference to a hash where the following keys are defined:
+	description has a value which is a string
+	items has a value which is a reference to a list where each element is a SetAPI.ExpressionSetItem
+ExpressionSetItem is a reference to a hash where the following keys are defined:
+	ref has a value which is a SetAPI.ws_expression_id
+	label has a value which is a string
+	data_attachments has a value which is a reference to a list where each element is a SetAPI.DataAttachment
+	info has a value which is a Workspace.object_info
+ws_expression_id is a string
+DataAttachment is a reference to a hash where the following keys are defined:
+	name has a value which is a string
+	ref has a value which is a SetAPI.ws_obj_id
+ws_obj_id is a string
+object_info is a reference to a list containing 11 items:
+	0: (objid) a Workspace.obj_id
+	1: (name) a Workspace.obj_name
+	2: (type) a Workspace.type_string
+	3: (save_date) a Workspace.timestamp
+	4: (version) an int
+	5: (saved_by) a Workspace.username
+	6: (wsid) a Workspace.ws_id
+	7: (workspace) a Workspace.ws_name
+	8: (chsum) a string
+	9: (size) an int
+	10: (meta) a Workspace.usermeta
+obj_id is an int
+obj_name is a string
+type_string is a string
+timestamp is a string
+username is a string
+ws_id is an int
+ws_name is a string
+usermeta is a reference to a hash where the key is a string and the value is a string
+
+</pre>
+
+=end html
+
+=begin text
+
+$params is a SetAPI.GetExpressionSetV1Params
+$return is a SetAPI.GetExpressionSetV1Result
+GetExpressionSetV1Params is a reference to a hash where the following keys are defined:
+	ref has a value which is a string
+	include_item_info has a value which is a SetAPI.boolean
+	ref_path_to_set has a value which is a reference to a list where each element is a string
+boolean is an int
+GetExpressionSetV1Result is a reference to a hash where the following keys are defined:
+	data has a value which is a SetAPI.ExpressionSet
+	info has a value which is a Workspace.object_info
+ExpressionSet is a reference to a hash where the following keys are defined:
+	description has a value which is a string
+	items has a value which is a reference to a list where each element is a SetAPI.ExpressionSetItem
+ExpressionSetItem is a reference to a hash where the following keys are defined:
+	ref has a value which is a SetAPI.ws_expression_id
+	label has a value which is a string
+	data_attachments has a value which is a reference to a list where each element is a SetAPI.DataAttachment
+	info has a value which is a Workspace.object_info
+ws_expression_id is a string
+DataAttachment is a reference to a hash where the following keys are defined:
+	name has a value which is a string
+	ref has a value which is a SetAPI.ws_obj_id
+ws_obj_id is a string
+object_info is a reference to a list containing 11 items:
+	0: (objid) a Workspace.obj_id
+	1: (name) a Workspace.obj_name
+	2: (type) a Workspace.type_string
+	3: (save_date) a Workspace.timestamp
+	4: (version) an int
+	5: (saved_by) a Workspace.username
+	6: (wsid) a Workspace.ws_id
+	7: (workspace) a Workspace.ws_name
+	8: (chsum) a string
+	9: (size) an int
+	10: (meta) a Workspace.usermeta
+obj_id is an int
+obj_name is a string
+type_string is a string
+timestamp is a string
+username is a string
+ws_id is an int
+ws_name is a string
+usermeta is a reference to a hash where the key is a string and the value is a string
+
+
+=end text
+
+=item Description
+
+
+
+=back
+
+=cut
+
+ sub get_expression_set_v1
+{
+    my($self, @args) = @_;
+
+# Authentication: optional
+
+    if ((my $n = @args) != 1)
+    {
+	Bio::KBase::Exceptions::ArgumentValidationError->throw(error =>
+							       "Invalid argument count for function get_expression_set_v1 (received $n, expecting 1)");
+    }
+    {
+	my($params) = @args;
+
+	my @_bad_arguments;
+        (ref($params) eq 'HASH') or push(@_bad_arguments, "Invalid type for argument 1 \"params\" (value was \"$params\")");
+        if (@_bad_arguments) {
+	    my $msg = "Invalid arguments passed to get_expression_set_v1:\n" . join("", map { "\t$_\n" } @_bad_arguments);
+	    Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
+								   method_name => 'get_expression_set_v1');
+	}
+    }
+
+    my $url = $self->{url};
+    my $result = $self->{client}->call($url, $self->{headers}, {
+	    method => "SetAPI.get_expression_set_v1",
+	    params => \@args,
+    });
+    if ($result) {
+	if ($result->is_error) {
+	    Bio::KBase::Exceptions::JSONRPC->throw(error => $result->error_message,
+					       code => $result->content->{error}->{code},
+					       method_name => 'get_expression_set_v1',
+					       data => $result->content->{error}->{error} # JSON::RPC::ReturnObject only supports JSONRPC 1.1 or 1.O
+					      );
+	} else {
+	    return wantarray ? @{$result->result} : $result->result->[0];
+	}
+    } else {
+        Bio::KBase::Exceptions::HTTP->throw(error => "Error invoking method get_expression_set_v1",
+					    status_line => $self->{client}->status_line,
+					    method_name => 'get_expression_set_v1',
+				       );
+    }
+}
+ 
+
+
+=head2 save_expression_set_v1
+
+  $result = $obj->save_expression_set_v1($params)
+
+=over 4
+
+=item Parameter and return types
+
+=begin html
+
+<pre>
+$params is a SetAPI.SaveExpressionSetV1Params
+$result is a SetAPI.SaveExpressionSetV1Result
+SaveExpressionSetV1Params is a reference to a hash where the following keys are defined:
+	workspace has a value which is a string
+	output_object_name has a value which is a string
+	data has a value which is a SetAPI.ExpressionSet
+ExpressionSet is a reference to a hash where the following keys are defined:
+	description has a value which is a string
+	items has a value which is a reference to a list where each element is a SetAPI.ExpressionSetItem
+ExpressionSetItem is a reference to a hash where the following keys are defined:
+	ref has a value which is a SetAPI.ws_expression_id
+	label has a value which is a string
+	data_attachments has a value which is a reference to a list where each element is a SetAPI.DataAttachment
+	info has a value which is a Workspace.object_info
+ws_expression_id is a string
+DataAttachment is a reference to a hash where the following keys are defined:
+	name has a value which is a string
+	ref has a value which is a SetAPI.ws_obj_id
+ws_obj_id is a string
+object_info is a reference to a list containing 11 items:
+	0: (objid) a Workspace.obj_id
+	1: (name) a Workspace.obj_name
+	2: (type) a Workspace.type_string
+	3: (save_date) a Workspace.timestamp
+	4: (version) an int
+	5: (saved_by) a Workspace.username
+	6: (wsid) a Workspace.ws_id
+	7: (workspace) a Workspace.ws_name
+	8: (chsum) a string
+	9: (size) an int
+	10: (meta) a Workspace.usermeta
+obj_id is an int
+obj_name is a string
+type_string is a string
+timestamp is a string
+username is a string
+ws_id is an int
+ws_name is a string
+usermeta is a reference to a hash where the key is a string and the value is a string
+SaveExpressionSetV1Result is a reference to a hash where the following keys are defined:
+	set_ref has a value which is a string
+	set_info has a value which is a Workspace.object_info
+
+</pre>
+
+=end html
+
+=begin text
+
+$params is a SetAPI.SaveExpressionSetV1Params
+$result is a SetAPI.SaveExpressionSetV1Result
+SaveExpressionSetV1Params is a reference to a hash where the following keys are defined:
+	workspace has a value which is a string
+	output_object_name has a value which is a string
+	data has a value which is a SetAPI.ExpressionSet
+ExpressionSet is a reference to a hash where the following keys are defined:
+	description has a value which is a string
+	items has a value which is a reference to a list where each element is a SetAPI.ExpressionSetItem
+ExpressionSetItem is a reference to a hash where the following keys are defined:
+	ref has a value which is a SetAPI.ws_expression_id
+	label has a value which is a string
+	data_attachments has a value which is a reference to a list where each element is a SetAPI.DataAttachment
+	info has a value which is a Workspace.object_info
+ws_expression_id is a string
+DataAttachment is a reference to a hash where the following keys are defined:
+	name has a value which is a string
+	ref has a value which is a SetAPI.ws_obj_id
+ws_obj_id is a string
+object_info is a reference to a list containing 11 items:
+	0: (objid) a Workspace.obj_id
+	1: (name) a Workspace.obj_name
+	2: (type) a Workspace.type_string
+	3: (save_date) a Workspace.timestamp
+	4: (version) an int
+	5: (saved_by) a Workspace.username
+	6: (wsid) a Workspace.ws_id
+	7: (workspace) a Workspace.ws_name
+	8: (chsum) a string
+	9: (size) an int
+	10: (meta) a Workspace.usermeta
+obj_id is an int
+obj_name is a string
+type_string is a string
+timestamp is a string
+username is a string
+ws_id is an int
+ws_name is a string
+usermeta is a reference to a hash where the key is a string and the value is a string
+SaveExpressionSetV1Result is a reference to a hash where the following keys are defined:
+	set_ref has a value which is a string
+	set_info has a value which is a Workspace.object_info
+
+
+=end text
+
+=item Description
+
+
+
+=back
+
+=cut
+
+ sub save_expression_set_v1
+{
+    my($self, @args) = @_;
+
+# Authentication: required
+
+    if ((my $n = @args) != 1)
+    {
+	Bio::KBase::Exceptions::ArgumentValidationError->throw(error =>
+							       "Invalid argument count for function save_expression_set_v1 (received $n, expecting 1)");
+    }
+    {
+	my($params) = @args;
+
+	my @_bad_arguments;
+        (ref($params) eq 'HASH') or push(@_bad_arguments, "Invalid type for argument 1 \"params\" (value was \"$params\")");
+        if (@_bad_arguments) {
+	    my $msg = "Invalid arguments passed to save_expression_set_v1:\n" . join("", map { "\t$_\n" } @_bad_arguments);
+	    Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
+								   method_name => 'save_expression_set_v1');
+	}
+    }
+
+    my $url = $self->{url};
+    my $result = $self->{client}->call($url, $self->{headers}, {
+	    method => "SetAPI.save_expression_set_v1",
+	    params => \@args,
+    });
+    if ($result) {
+	if ($result->is_error) {
+	    Bio::KBase::Exceptions::JSONRPC->throw(error => $result->error_message,
+					       code => $result->content->{error}->{code},
+					       method_name => 'save_expression_set_v1',
+					       data => $result->content->{error}->{error} # JSON::RPC::ReturnObject only supports JSONRPC 1.1 or 1.O
+					      );
+	} else {
+	    return wantarray ? @{$result->result} : $result->result->[0];
+	}
+    } else {
+        Bio::KBase::Exceptions::HTTP->throw(error => "Error invoking method save_expression_set_v1",
+					    status_line => $self->{client}->status_line,
+					    method_name => 'save_expression_set_v1',
+				       );
+    }
+}
+ 
+
+
 =head2 get_reads_alignment_set_v1
 
   $return = $obj->get_reads_alignment_set_v1($params)
@@ -136,6 +462,7 @@ ReadsAlignmentSetItem is a reference to a hash where the following keys are defi
 	ref has a value which is a SetAPI.ws_reads_align_id
 	label has a value which is a string
 	info has a value which is a Workspace.object_info
+	data_attachments has a value which is a reference to a list where each element is a SetAPI.DataAttachment
 ws_reads_align_id is a string
 object_info is a reference to a list containing 11 items:
 	0: (objid) a Workspace.obj_id
@@ -157,6 +484,10 @@ username is a string
 ws_id is an int
 ws_name is a string
 usermeta is a reference to a hash where the key is a string and the value is a string
+DataAttachment is a reference to a hash where the following keys are defined:
+	name has a value which is a string
+	ref has a value which is a SetAPI.ws_obj_id
+ws_obj_id is a string
 
 </pre>
 
@@ -181,6 +512,7 @@ ReadsAlignmentSetItem is a reference to a hash where the following keys are defi
 	ref has a value which is a SetAPI.ws_reads_align_id
 	label has a value which is a string
 	info has a value which is a Workspace.object_info
+	data_attachments has a value which is a reference to a list where each element is a SetAPI.DataAttachment
 ws_reads_align_id is a string
 object_info is a reference to a list containing 11 items:
 	0: (objid) a Workspace.obj_id
@@ -202,6 +534,10 @@ username is a string
 ws_id is an int
 ws_name is a string
 usermeta is a reference to a hash where the key is a string and the value is a string
+DataAttachment is a reference to a hash where the following keys are defined:
+	name has a value which is a string
+	ref has a value which is a SetAPI.ws_obj_id
+ws_obj_id is a string
 
 
 =end text
@@ -286,6 +622,7 @@ ReadsAlignmentSetItem is a reference to a hash where the following keys are defi
 	ref has a value which is a SetAPI.ws_reads_align_id
 	label has a value which is a string
 	info has a value which is a Workspace.object_info
+	data_attachments has a value which is a reference to a list where each element is a SetAPI.DataAttachment
 ws_reads_align_id is a string
 object_info is a reference to a list containing 11 items:
 	0: (objid) a Workspace.obj_id
@@ -307,6 +644,10 @@ username is a string
 ws_id is an int
 ws_name is a string
 usermeta is a reference to a hash where the key is a string and the value is a string
+DataAttachment is a reference to a hash where the following keys are defined:
+	name has a value which is a string
+	ref has a value which is a SetAPI.ws_obj_id
+ws_obj_id is a string
 SaveReadsAlignmentSetV1Result is a reference to a hash where the following keys are defined:
 	set_ref has a value which is a string
 	set_info has a value which is a Workspace.object_info
@@ -330,6 +671,7 @@ ReadsAlignmentSetItem is a reference to a hash where the following keys are defi
 	ref has a value which is a SetAPI.ws_reads_align_id
 	label has a value which is a string
 	info has a value which is a Workspace.object_info
+	data_attachments has a value which is a reference to a list where each element is a SetAPI.DataAttachment
 ws_reads_align_id is a string
 object_info is a reference to a list containing 11 items:
 	0: (objid) a Workspace.obj_id
@@ -351,6 +693,10 @@ username is a string
 ws_id is an int
 ws_name is a string
 usermeta is a reference to a hash where the key is a string and the value is a string
+DataAttachment is a reference to a hash where the following keys are defined:
+	name has a value which is a string
+	ref has a value which is a SetAPI.ws_obj_id
+ws_obj_id is a string
 SaveReadsAlignmentSetV1Result is a reference to a hash where the following keys are defined:
 	set_ref has a value which is a string
 	set_info has a value which is a Workspace.object_info
@@ -1798,6 +2144,333 @@ an int
 
 
 
+=head2 ws_obj_id
+
+=over 4
+
+
+
+=item Description
+
+The workspace ID for a any data object.
+@id ws
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a string
+</pre>
+
+=end html
+
+=begin text
+
+a string
+
+=end text
+
+=back
+
+
+
+=head2 DataAttachment
+
+=over 4
+
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+name has a value which is a string
+ref has a value which is a SetAPI.ws_obj_id
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+name has a value which is a string
+ref has a value which is a SetAPI.ws_obj_id
+
+
+=end text
+
+=back
+
+
+
+=head2 ws_expression_id
+
+=over 4
+
+
+
+=item Description
+
+The workspace id for a ReadsAlignment data object.
+@id ws KBaseRNASeq.RNASeqExpression
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a string
+</pre>
+
+=end html
+
+=begin text
+
+a string
+
+=end text
+
+=back
+
+
+
+=head2 ExpressionSetItem
+
+=over 4
+
+
+
+=item Description
+
+When saving a ExpressionSet, only 'ref' is required.
+You should never set 'info'.  'info' is provided optionally when fetching
+the ExpressionSet.
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+ref has a value which is a SetAPI.ws_expression_id
+label has a value which is a string
+data_attachments has a value which is a reference to a list where each element is a SetAPI.DataAttachment
+info has a value which is a Workspace.object_info
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+ref has a value which is a SetAPI.ws_expression_id
+label has a value which is a string
+data_attachments has a value which is a reference to a list where each element is a SetAPI.DataAttachment
+info has a value which is a Workspace.object_info
+
+
+=end text
+
+=back
+
+
+
+=head2 ExpressionSet
+
+=over 4
+
+
+
+=item Description
+
+When building a ExpressionSet, all Expression objects must be aligned against the same
+genome. This is not part of the object type, but enforced during a call to
+save_expression_set_v1.
+@meta ws description as description
+@meta ws length(items) as item_count
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+description has a value which is a string
+items has a value which is a reference to a list where each element is a SetAPI.ExpressionSetItem
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+description has a value which is a string
+items has a value which is a reference to a list where each element is a SetAPI.ExpressionSetItem
+
+
+=end text
+
+=back
+
+
+
+=head2 GetExpressionSetV1Params
+
+=over 4
+
+
+
+=item Description
+
+ref - workspace reference to ExpressionSet object.
+include_item_info - 1 or 0, if 1 additionally provides workspace info (with
+                    metadata) for each Expression object in the Set
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+ref has a value which is a string
+include_item_info has a value which is a SetAPI.boolean
+ref_path_to_set has a value which is a reference to a list where each element is a string
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+ref has a value which is a string
+include_item_info has a value which is a SetAPI.boolean
+ref_path_to_set has a value which is a reference to a list where each element is a string
+
+
+=end text
+
+=back
+
+
+
+=head2 GetExpressionSetV1Result
+
+=over 4
+
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+data has a value which is a SetAPI.ExpressionSet
+info has a value which is a Workspace.object_info
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+data has a value which is a SetAPI.ExpressionSet
+info has a value which is a Workspace.object_info
+
+
+=end text
+
+=back
+
+
+
+=head2 SaveExpressionSetV1Params
+
+=over 4
+
+
+
+=item Description
+
+workspace_name or workspace_id - alternative options defining
+    target workspace,
+output_object_name - workspace object name (this parameter is
+    used together with one of workspace params from above)
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+workspace has a value which is a string
+output_object_name has a value which is a string
+data has a value which is a SetAPI.ExpressionSet
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+workspace has a value which is a string
+output_object_name has a value which is a string
+data has a value which is a SetAPI.ExpressionSet
+
+
+=end text
+
+=back
+
+
+
+=head2 SaveExpressionSetV1Result
+
+=over 4
+
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+set_ref has a value which is a string
+set_info has a value which is a Workspace.object_info
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+set_ref has a value which is a string
+set_info has a value which is a Workspace.object_info
+
+
+=end text
+
+=back
+
+
+
 =head2 ws_reads_align_id
 
 =over 4
@@ -1852,6 +2525,7 @@ a reference to a hash where the following keys are defined:
 ref has a value which is a SetAPI.ws_reads_align_id
 label has a value which is a string
 info has a value which is a Workspace.object_info
+data_attachments has a value which is a reference to a list where each element is a SetAPI.DataAttachment
 
 </pre>
 
@@ -1863,6 +2537,7 @@ a reference to a hash where the following keys are defined:
 ref has a value which is a SetAPI.ws_reads_align_id
 label has a value which is a string
 info has a value which is a Workspace.object_info
+data_attachments has a value which is a reference to a list where each element is a SetAPI.DataAttachment
 
 
 =end text
@@ -1881,7 +2556,7 @@ info has a value which is a Workspace.object_info
 
 When building a ReadsAlignmentSet, all ReadsAlignments must be aligned against the same
 genome. This is not part of the object type, but enforced during a call to
-save_reads_alignment_v1.
+save_reads_alignment_set_v1.
 @meta ws description as description
 @meta ws length(items) as item_count
 
@@ -2051,70 +2726,6 @@ set_info has a value which is a Workspace.object_info
 a reference to a hash where the following keys are defined:
 set_ref has a value which is a string
 set_info has a value which is a Workspace.object_info
-
-
-=end text
-
-=back
-
-
-
-=head2 ws_obj_id
-
-=over 4
-
-
-
-=item Description
-
-The workspace ID for a any data object.
-@id ws
-
-
-=item Definition
-
-=begin html
-
-<pre>
-a string
-</pre>
-
-=end html
-
-=begin text
-
-a string
-
-=end text
-
-=back
-
-
-
-=head2 DataAttachment
-
-=over 4
-
-
-
-=item Definition
-
-=begin html
-
-<pre>
-a reference to a hash where the following keys are defined:
-name has a value which is a string
-ref has a value which is a SetAPI.ws_obj_id
-
-</pre>
-
-=end html
-
-=begin text
-
-a reference to a hash where the following keys are defined:
-name has a value which is a string
-ref has a value which is a SetAPI.ws_obj_id
 
 
 =end text

--- a/lib/SetAPI/SetAPIClient.py
+++ b/lib/SetAPI/SetAPIClient.py
@@ -33,6 +33,236 @@ class SetAPI(object):
             trust_all_ssl_certificates=trust_all_ssl_certificates,
             auth_svc=auth_svc)
 
+    def get_reads_alignment_set_v1(self, params, context=None):
+        """
+        :param params: instance of type "GetReadsAlignmentSetV1Params" (ref -
+           workspace reference to ReadsAlignmentSet object. include_item_info
+           - 1 or 0, if 1 additionally provides workspace info (with
+           metadata) for each ReadsAlignment object in the Set) -> structure:
+           parameter "ref" of String, parameter "include_item_info" of type
+           "boolean" (A boolean. 0 = false, 1 = true.), parameter
+           "ref_path_to_set" of list of String
+        :returns: instance of type "GetReadsAlignmentSetV1Result" ->
+           structure: parameter "data" of type "ReadsAlignmentSet" (When
+           building a ReadsAlignmentSet, all ReadsAlignments must be aligned
+           against the same genome. This is not part of the object type, but
+           enforced during a call to save_reads_alignment_v1. @meta ws
+           description as description @meta ws length(items) as item_count)
+           -> structure: parameter "description" of String, parameter "items"
+           of list of type "ReadsAlignmentSetItem" (When saving a
+           ReadsAlignmentSet, only 'ref' is required. You should never set
+           'info'.  'info' is provided optionally when fetching the
+           ReadsAlignmentSet.) -> structure: parameter "ref" of type
+           "ws_reads_align_id" (The workspace id for a ReadsAlignment data
+           object. @id ws KBaseRNASeq.RNASeqAlignment), parameter "label" of
+           String, parameter "info" of type "object_info" (Information about
+           an object, including user provided metadata. obj_id objid - the
+           numerical id of the object. obj_name name - the name of the
+           object. type_string type - the type of the object. timestamp
+           save_date - the save date of the object. obj_ver ver - the version
+           of the object. username saved_by - the user that saved or copied
+           the object. ws_id wsid - the workspace containing the object.
+           ws_name workspace - the workspace containing the object. string
+           chsum - the md5 checksum of the object. int size - the size of the
+           object in bytes. usermeta meta - arbitrary user-supplied metadata
+           about the object.) -> tuple of size 11: parameter "objid" of type
+           "obj_id" (The unique, permanent numerical ID of an object.),
+           parameter "name" of type "obj_name" (A string used as a name for
+           an object. Any string consisting of alphanumeric characters and
+           the characters |._- that is not an integer is acceptable.),
+           parameter "type" of type "type_string" (A type string. Specifies
+           the type and its version in a single string in the format
+           [module].[typename]-[major].[minor]: module - a string. The module
+           name of the typespec containing the type. typename - a string. The
+           name of the type as assigned by the typedef statement. major - an
+           integer. The major version of the type. A change in the major
+           version implies the type has changed in a non-backwards compatible
+           way. minor - an integer. The minor version of the type. A change
+           in the minor version implies that the type has changed in a way
+           that is backwards compatible with previous type definitions. In
+           many cases, the major and minor versions are optional, and if not
+           provided the most recent version will be used. Example:
+           MyModule.MyType-3.1), parameter "save_date" of type "timestamp" (A
+           time in the format YYYY-MM-DDThh:mm:ssZ, where Z is either the
+           character Z (representing the UTC timezone) or the difference in
+           time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500
+           (EST time) 2013-04-03T08:56:32+0000 (UTC time)
+           2013-04-03T08:56:32Z (UTC time)), parameter "version" of Long,
+           parameter "saved_by" of type "username" (Login name of a KBase
+           user account.), parameter "wsid" of type "ws_id" (The unique,
+           permanent numerical ID of a workspace.), parameter "workspace" of
+           type "ws_name" (A string used as a name for a workspace. Any
+           string consisting of alphanumeric characters and "_", ".", or "-"
+           that is not an integer is acceptable. The name may optionally be
+           prefixed with the workspace owner's user name and a colon, e.g.
+           kbasetest:my_workspace.), parameter "chsum" of String, parameter
+           "size" of Long, parameter "meta" of type "usermeta" (User provided
+           metadata about an object. Arbitrary key-value pairs provided by
+           the user.) -> mapping from String to String, parameter "info" of
+           type "object_info" (Information about an object, including user
+           provided metadata. obj_id objid - the numerical id of the object.
+           obj_name name - the name of the object. type_string type - the
+           type of the object. timestamp save_date - the save date of the
+           object. obj_ver ver - the version of the object. username saved_by
+           - the user that saved or copied the object. ws_id wsid - the
+           workspace containing the object. ws_name workspace - the workspace
+           containing the object. string chsum - the md5 checksum of the
+           object. int size - the size of the object in bytes. usermeta meta
+           - arbitrary user-supplied metadata about the object.) -> tuple of
+           size 11: parameter "objid" of type "obj_id" (The unique, permanent
+           numerical ID of an object.), parameter "name" of type "obj_name"
+           (A string used as a name for an object. Any string consisting of
+           alphanumeric characters and the characters |._- that is not an
+           integer is acceptable.), parameter "type" of type "type_string" (A
+           type string. Specifies the type and its version in a single string
+           in the format [module].[typename]-[major].[minor]: module - a
+           string. The module name of the typespec containing the type.
+           typename - a string. The name of the type as assigned by the
+           typedef statement. major - an integer. The major version of the
+           type. A change in the major version implies the type has changed
+           in a non-backwards compatible way. minor - an integer. The minor
+           version of the type. A change in the minor version implies that
+           the type has changed in a way that is backwards compatible with
+           previous type definitions. In many cases, the major and minor
+           versions are optional, and if not provided the most recent version
+           will be used. Example: MyModule.MyType-3.1), parameter "save_date"
+           of type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ,
+           where Z is either the character Z (representing the UTC timezone)
+           or the difference in time to UTC in the format +/-HHMM, eg:
+           2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC
+           time) 2013-04-03T08:56:32Z (UTC time)), parameter "version" of
+           Long, parameter "saved_by" of type "username" (Login name of a
+           KBase user account.), parameter "wsid" of type "ws_id" (The
+           unique, permanent numerical ID of a workspace.), parameter
+           "workspace" of type "ws_name" (A string used as a name for a
+           workspace. Any string consisting of alphanumeric characters and
+           "_", ".", or "-" that is not an integer is acceptable. The name
+           may optionally be prefixed with the workspace owner's user name
+           and a colon, e.g. kbasetest:my_workspace.), parameter "chsum" of
+           String, parameter "size" of Long, parameter "meta" of type
+           "usermeta" (User provided metadata about an object. Arbitrary
+           key-value pairs provided by the user.) -> mapping from String to
+           String
+        """
+        return self._client.call_method(
+            'SetAPI.get_reads_alignment_set_v1',
+            [params], self._service_ver, context)
+
+    def save_reads_alignment_set_v1(self, params, context=None):
+        """
+        :param params: instance of type "SaveReadsAlignmentSetV1Params"
+           (workspace_name or workspace_id - alternative options defining
+           target workspace, output_object_name - workspace object name (this
+           parameter is used together with one of workspace params from
+           above)) -> structure: parameter "workspace" of String, parameter
+           "output_object_name" of String, parameter "data" of type
+           "ReadsAlignmentSet" (When building a ReadsAlignmentSet, all
+           ReadsAlignments must be aligned against the same genome. This is
+           not part of the object type, but enforced during a call to
+           save_reads_alignment_v1. @meta ws description as description @meta
+           ws length(items) as item_count) -> structure: parameter
+           "description" of String, parameter "items" of list of type
+           "ReadsAlignmentSetItem" (When saving a ReadsAlignmentSet, only
+           'ref' is required. You should never set 'info'.  'info' is
+           provided optionally when fetching the ReadsAlignmentSet.) ->
+           structure: parameter "ref" of type "ws_reads_align_id" (The
+           workspace id for a ReadsAlignment data object. @id ws
+           KBaseRNASeq.RNASeqAlignment), parameter "label" of String,
+           parameter "info" of type "object_info" (Information about an
+           object, including user provided metadata. obj_id objid - the
+           numerical id of the object. obj_name name - the name of the
+           object. type_string type - the type of the object. timestamp
+           save_date - the save date of the object. obj_ver ver - the version
+           of the object. username saved_by - the user that saved or copied
+           the object. ws_id wsid - the workspace containing the object.
+           ws_name workspace - the workspace containing the object. string
+           chsum - the md5 checksum of the object. int size - the size of the
+           object in bytes. usermeta meta - arbitrary user-supplied metadata
+           about the object.) -> tuple of size 11: parameter "objid" of type
+           "obj_id" (The unique, permanent numerical ID of an object.),
+           parameter "name" of type "obj_name" (A string used as a name for
+           an object. Any string consisting of alphanumeric characters and
+           the characters |._- that is not an integer is acceptable.),
+           parameter "type" of type "type_string" (A type string. Specifies
+           the type and its version in a single string in the format
+           [module].[typename]-[major].[minor]: module - a string. The module
+           name of the typespec containing the type. typename - a string. The
+           name of the type as assigned by the typedef statement. major - an
+           integer. The major version of the type. A change in the major
+           version implies the type has changed in a non-backwards compatible
+           way. minor - an integer. The minor version of the type. A change
+           in the minor version implies that the type has changed in a way
+           that is backwards compatible with previous type definitions. In
+           many cases, the major and minor versions are optional, and if not
+           provided the most recent version will be used. Example:
+           MyModule.MyType-3.1), parameter "save_date" of type "timestamp" (A
+           time in the format YYYY-MM-DDThh:mm:ssZ, where Z is either the
+           character Z (representing the UTC timezone) or the difference in
+           time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500
+           (EST time) 2013-04-03T08:56:32+0000 (UTC time)
+           2013-04-03T08:56:32Z (UTC time)), parameter "version" of Long,
+           parameter "saved_by" of type "username" (Login name of a KBase
+           user account.), parameter "wsid" of type "ws_id" (The unique,
+           permanent numerical ID of a workspace.), parameter "workspace" of
+           type "ws_name" (A string used as a name for a workspace. Any
+           string consisting of alphanumeric characters and "_", ".", or "-"
+           that is not an integer is acceptable. The name may optionally be
+           prefixed with the workspace owner's user name and a colon, e.g.
+           kbasetest:my_workspace.), parameter "chsum" of String, parameter
+           "size" of Long, parameter "meta" of type "usermeta" (User provided
+           metadata about an object. Arbitrary key-value pairs provided by
+           the user.) -> mapping from String to String
+        :returns: instance of type "SaveReadsAlignmentSetV1Result" ->
+           structure: parameter "set_ref" of String, parameter "set_info" of
+           type "object_info" (Information about an object, including user
+           provided metadata. obj_id objid - the numerical id of the object.
+           obj_name name - the name of the object. type_string type - the
+           type of the object. timestamp save_date - the save date of the
+           object. obj_ver ver - the version of the object. username saved_by
+           - the user that saved or copied the object. ws_id wsid - the
+           workspace containing the object. ws_name workspace - the workspace
+           containing the object. string chsum - the md5 checksum of the
+           object. int size - the size of the object in bytes. usermeta meta
+           - arbitrary user-supplied metadata about the object.) -> tuple of
+           size 11: parameter "objid" of type "obj_id" (The unique, permanent
+           numerical ID of an object.), parameter "name" of type "obj_name"
+           (A string used as a name for an object. Any string consisting of
+           alphanumeric characters and the characters |._- that is not an
+           integer is acceptable.), parameter "type" of type "type_string" (A
+           type string. Specifies the type and its version in a single string
+           in the format [module].[typename]-[major].[minor]: module - a
+           string. The module name of the typespec containing the type.
+           typename - a string. The name of the type as assigned by the
+           typedef statement. major - an integer. The major version of the
+           type. A change in the major version implies the type has changed
+           in a non-backwards compatible way. minor - an integer. The minor
+           version of the type. A change in the minor version implies that
+           the type has changed in a way that is backwards compatible with
+           previous type definitions. In many cases, the major and minor
+           versions are optional, and if not provided the most recent version
+           will be used. Example: MyModule.MyType-3.1), parameter "save_date"
+           of type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ,
+           where Z is either the character Z (representing the UTC timezone)
+           or the difference in time to UTC in the format +/-HHMM, eg:
+           2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC
+           time) 2013-04-03T08:56:32Z (UTC time)), parameter "version" of
+           Long, parameter "saved_by" of type "username" (Login name of a
+           KBase user account.), parameter "wsid" of type "ws_id" (The
+           unique, permanent numerical ID of a workspace.), parameter
+           "workspace" of type "ws_name" (A string used as a name for a
+           workspace. Any string consisting of alphanumeric characters and
+           "_", ".", or "-" that is not an integer is acceptable. The name
+           may optionally be prefixed with the workspace owner's user name
+           and a colon, e.g. kbasetest:my_workspace.), parameter "chsum" of
+           String, parameter "size" of Long, parameter "meta" of type
+           "usermeta" (User provided metadata about an object. Arbitrary
+           key-value pairs provided by the user.) -> mapping from String to
+           String
+        """
+        return self._client.call_method(
+            'SetAPI.save_reads_alignment_set_v1',
+            [params], self._service_ver, context)
+
     def get_reads_set_v1(self, params, context=None):
         """
         :param params: instance of type "GetReadsSetV1Params" (ref -
@@ -709,7 +939,7 @@ class SetAPI(object):
     def list_sets(self, params, context=None):
         """
         Use to get the top-level sets in a WS. Optionally can include
-        one level down members of those sets. 
+        one level down members of those sets.
         NOTE: DOES NOT PRESERVE ORDERING OF ITEM LIST IN DATA
         :param params: instance of type "ListSetParams" (workspace -
            workspace name or ID (alternative to workspaces parameter),

--- a/lib/SetAPI/SetAPIClient.py
+++ b/lib/SetAPI/SetAPIClient.py
@@ -33,55 +33,57 @@ class SetAPI(object):
             trust_all_ssl_certificates=trust_all_ssl_certificates,
             auth_svc=auth_svc)
 
-    def get_reads_alignment_set_v1(self, params, context=None):
+    def get_expression_set_v1(self, params, context=None):
         """
-        :param params: instance of type "GetReadsAlignmentSetV1Params" (ref -
-           workspace reference to ReadsAlignmentSet object. include_item_info
-           - 1 or 0, if 1 additionally provides workspace info (with
-           metadata) for each ReadsAlignment object in the Set) -> structure:
-           parameter "ref" of String, parameter "include_item_info" of type
-           "boolean" (A boolean. 0 = false, 1 = true.), parameter
-           "ref_path_to_set" of list of String
-        :returns: instance of type "GetReadsAlignmentSetV1Result" ->
-           structure: parameter "data" of type "ReadsAlignmentSet" (When
-           building a ReadsAlignmentSet, all ReadsAlignments must be aligned
-           against the same genome. This is not part of the object type, but
-           enforced during a call to save_reads_alignment_v1. @meta ws
-           description as description @meta ws length(items) as item_count)
-           -> structure: parameter "description" of String, parameter "items"
-           of list of type "ReadsAlignmentSetItem" (When saving a
-           ReadsAlignmentSet, only 'ref' is required. You should never set
-           'info'.  'info' is provided optionally when fetching the
-           ReadsAlignmentSet.) -> structure: parameter "ref" of type
-           "ws_reads_align_id" (The workspace id for a ReadsAlignment data
-           object. @id ws KBaseRNASeq.RNASeqAlignment), parameter "label" of
-           String, parameter "info" of type "object_info" (Information about
-           an object, including user provided metadata. obj_id objid - the
-           numerical id of the object. obj_name name - the name of the
-           object. type_string type - the type of the object. timestamp
-           save_date - the save date of the object. obj_ver ver - the version
-           of the object. username saved_by - the user that saved or copied
-           the object. ws_id wsid - the workspace containing the object.
-           ws_name workspace - the workspace containing the object. string
-           chsum - the md5 checksum of the object. int size - the size of the
-           object in bytes. usermeta meta - arbitrary user-supplied metadata
-           about the object.) -> tuple of size 11: parameter "objid" of type
-           "obj_id" (The unique, permanent numerical ID of an object.),
-           parameter "name" of type "obj_name" (A string used as a name for
-           an object. Any string consisting of alphanumeric characters and
-           the characters |._- that is not an integer is acceptable.),
-           parameter "type" of type "type_string" (A type string. Specifies
-           the type and its version in a single string in the format
-           [module].[typename]-[major].[minor]: module - a string. The module
-           name of the typespec containing the type. typename - a string. The
-           name of the type as assigned by the typedef statement. major - an
-           integer. The major version of the type. A change in the major
-           version implies the type has changed in a non-backwards compatible
-           way. minor - an integer. The minor version of the type. A change
-           in the minor version implies that the type has changed in a way
-           that is backwards compatible with previous type definitions. In
-           many cases, the major and minor versions are optional, and if not
-           provided the most recent version will be used. Example:
+        :param params: instance of type "GetExpressionSetV1Params" (ref -
+           workspace reference to ExpressionSet object. include_item_info - 1
+           or 0, if 1 additionally provides workspace info (with metadata)
+           for each Expression object in the Set) -> structure: parameter
+           "ref" of String, parameter "include_item_info" of type "boolean"
+           (A boolean. 0 = false, 1 = true.), parameter "ref_path_to_set" of
+           list of String
+        :returns: instance of type "GetExpressionSetV1Result" -> structure:
+           parameter "data" of type "ExpressionSet" (When building a
+           ExpressionSet, all Expression objects must be aligned against the
+           same genome. This is not part of the object type, but enforced
+           during a call to save_expression_set_v1. @meta ws description as
+           description @meta ws length(items) as item_count) -> structure:
+           parameter "description" of String, parameter "items" of list of
+           type "ExpressionSetItem" (When saving a ExpressionSet, only 'ref'
+           is required. You should never set 'info'.  'info' is provided
+           optionally when fetching the ExpressionSet.) -> structure:
+           parameter "ref" of type "ws_expression_id" (The workspace id for a
+           ReadsAlignment data object. @id ws KBaseRNASeq.RNASeqExpression),
+           parameter "label" of String, parameter "data_attachments" of list
+           of type "DataAttachment" -> structure: parameter "name" of String,
+           parameter "ref" of type "ws_obj_id" (The workspace ID for a any
+           data object. @id ws), parameter "info" of type "object_info"
+           (Information about an object, including user provided metadata.
+           obj_id objid - the numerical id of the object. obj_name name - the
+           name of the object. type_string type - the type of the object.
+           timestamp save_date - the save date of the object. obj_ver ver -
+           the version of the object. username saved_by - the user that saved
+           or copied the object. ws_id wsid - the workspace containing the
+           object. ws_name workspace - the workspace containing the object.
+           string chsum - the md5 checksum of the object. int size - the size
+           of the object in bytes. usermeta meta - arbitrary user-supplied
+           metadata about the object.) -> tuple of size 11: parameter "objid"
+           of type "obj_id" (The unique, permanent numerical ID of an
+           object.), parameter "name" of type "obj_name" (A string used as a
+           name for an object. Any string consisting of alphanumeric
+           characters and the characters |._- that is not an integer is
+           acceptable.), parameter "type" of type "type_string" (A type
+           string. Specifies the type and its version in a single string in
+           the format [module].[typename]-[major].[minor]: module - a string.
+           The module name of the typespec containing the type. typename - a
+           string. The name of the type as assigned by the typedef statement.
+           major - an integer. The major version of the type. A change in the
+           major version implies the type has changed in a non-backwards
+           compatible way. minor - an integer. The minor version of the type.
+           A change in the minor version implies that the type has changed in
+           a way that is backwards compatible with previous type definitions.
+           In many cases, the major and minor versions are optional, and if
+           not provided the most recent version will be used. Example:
            MyModule.MyType-3.1), parameter "save_date" of type "timestamp" (A
            time in the format YYYY-MM-DDThh:mm:ssZ, where Z is either the
            character Z (representing the UTC timezone) or the difference in
@@ -145,6 +147,241 @@ class SetAPI(object):
            String
         """
         return self._client.call_method(
+            'SetAPI.get_expression_set_v1',
+            [params], self._service_ver, context)
+
+    def save_expression_set_v1(self, params, context=None):
+        """
+        :param params: instance of type "SaveExpressionSetV1Params"
+           (workspace_name or workspace_id - alternative options defining
+           target workspace, output_object_name - workspace object name (this
+           parameter is used together with one of workspace params from
+           above)) -> structure: parameter "workspace" of String, parameter
+           "output_object_name" of String, parameter "data" of type
+           "ExpressionSet" (When building a ExpressionSet, all Expression
+           objects must be aligned against the same genome. This is not part
+           of the object type, but enforced during a call to
+           save_expression_set_v1. @meta ws description as description @meta
+           ws length(items) as item_count) -> structure: parameter
+           "description" of String, parameter "items" of list of type
+           "ExpressionSetItem" (When saving a ExpressionSet, only 'ref' is
+           required. You should never set 'info'.  'info' is provided
+           optionally when fetching the ExpressionSet.) -> structure:
+           parameter "ref" of type "ws_expression_id" (The workspace id for a
+           ReadsAlignment data object. @id ws KBaseRNASeq.RNASeqExpression),
+           parameter "label" of String, parameter "data_attachments" of list
+           of type "DataAttachment" -> structure: parameter "name" of String,
+           parameter "ref" of type "ws_obj_id" (The workspace ID for a any
+           data object. @id ws), parameter "info" of type "object_info"
+           (Information about an object, including user provided metadata.
+           obj_id objid - the numerical id of the object. obj_name name - the
+           name of the object. type_string type - the type of the object.
+           timestamp save_date - the save date of the object. obj_ver ver -
+           the version of the object. username saved_by - the user that saved
+           or copied the object. ws_id wsid - the workspace containing the
+           object. ws_name workspace - the workspace containing the object.
+           string chsum - the md5 checksum of the object. int size - the size
+           of the object in bytes. usermeta meta - arbitrary user-supplied
+           metadata about the object.) -> tuple of size 11: parameter "objid"
+           of type "obj_id" (The unique, permanent numerical ID of an
+           object.), parameter "name" of type "obj_name" (A string used as a
+           name for an object. Any string consisting of alphanumeric
+           characters and the characters |._- that is not an integer is
+           acceptable.), parameter "type" of type "type_string" (A type
+           string. Specifies the type and its version in a single string in
+           the format [module].[typename]-[major].[minor]: module - a string.
+           The module name of the typespec containing the type. typename - a
+           string. The name of the type as assigned by the typedef statement.
+           major - an integer. The major version of the type. A change in the
+           major version implies the type has changed in a non-backwards
+           compatible way. minor - an integer. The minor version of the type.
+           A change in the minor version implies that the type has changed in
+           a way that is backwards compatible with previous type definitions.
+           In many cases, the major and minor versions are optional, and if
+           not provided the most recent version will be used. Example:
+           MyModule.MyType-3.1), parameter "save_date" of type "timestamp" (A
+           time in the format YYYY-MM-DDThh:mm:ssZ, where Z is either the
+           character Z (representing the UTC timezone) or the difference in
+           time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500
+           (EST time) 2013-04-03T08:56:32+0000 (UTC time)
+           2013-04-03T08:56:32Z (UTC time)), parameter "version" of Long,
+           parameter "saved_by" of type "username" (Login name of a KBase
+           user account.), parameter "wsid" of type "ws_id" (The unique,
+           permanent numerical ID of a workspace.), parameter "workspace" of
+           type "ws_name" (A string used as a name for a workspace. Any
+           string consisting of alphanumeric characters and "_", ".", or "-"
+           that is not an integer is acceptable. The name may optionally be
+           prefixed with the workspace owner's user name and a colon, e.g.
+           kbasetest:my_workspace.), parameter "chsum" of String, parameter
+           "size" of Long, parameter "meta" of type "usermeta" (User provided
+           metadata about an object. Arbitrary key-value pairs provided by
+           the user.) -> mapping from String to String
+        :returns: instance of type "SaveExpressionSetV1Result" -> structure:
+           parameter "set_ref" of String, parameter "set_info" of type
+           "object_info" (Information about an object, including user
+           provided metadata. obj_id objid - the numerical id of the object.
+           obj_name name - the name of the object. type_string type - the
+           type of the object. timestamp save_date - the save date of the
+           object. obj_ver ver - the version of the object. username saved_by
+           - the user that saved or copied the object. ws_id wsid - the
+           workspace containing the object. ws_name workspace - the workspace
+           containing the object. string chsum - the md5 checksum of the
+           object. int size - the size of the object in bytes. usermeta meta
+           - arbitrary user-supplied metadata about the object.) -> tuple of
+           size 11: parameter "objid" of type "obj_id" (The unique, permanent
+           numerical ID of an object.), parameter "name" of type "obj_name"
+           (A string used as a name for an object. Any string consisting of
+           alphanumeric characters and the characters |._- that is not an
+           integer is acceptable.), parameter "type" of type "type_string" (A
+           type string. Specifies the type and its version in a single string
+           in the format [module].[typename]-[major].[minor]: module - a
+           string. The module name of the typespec containing the type.
+           typename - a string. The name of the type as assigned by the
+           typedef statement. major - an integer. The major version of the
+           type. A change in the major version implies the type has changed
+           in a non-backwards compatible way. minor - an integer. The minor
+           version of the type. A change in the minor version implies that
+           the type has changed in a way that is backwards compatible with
+           previous type definitions. In many cases, the major and minor
+           versions are optional, and if not provided the most recent version
+           will be used. Example: MyModule.MyType-3.1), parameter "save_date"
+           of type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ,
+           where Z is either the character Z (representing the UTC timezone)
+           or the difference in time to UTC in the format +/-HHMM, eg:
+           2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC
+           time) 2013-04-03T08:56:32Z (UTC time)), parameter "version" of
+           Long, parameter "saved_by" of type "username" (Login name of a
+           KBase user account.), parameter "wsid" of type "ws_id" (The
+           unique, permanent numerical ID of a workspace.), parameter
+           "workspace" of type "ws_name" (A string used as a name for a
+           workspace. Any string consisting of alphanumeric characters and
+           "_", ".", or "-" that is not an integer is acceptable. The name
+           may optionally be prefixed with the workspace owner's user name
+           and a colon, e.g. kbasetest:my_workspace.), parameter "chsum" of
+           String, parameter "size" of Long, parameter "meta" of type
+           "usermeta" (User provided metadata about an object. Arbitrary
+           key-value pairs provided by the user.) -> mapping from String to
+           String
+        """
+        return self._client.call_method(
+            'SetAPI.save_expression_set_v1',
+            [params], self._service_ver, context)
+
+    def get_reads_alignment_set_v1(self, params, context=None):
+        """
+        :param params: instance of type "GetReadsAlignmentSetV1Params" (ref -
+           workspace reference to ReadsAlignmentSet object. include_item_info
+           - 1 or 0, if 1 additionally provides workspace info (with
+           metadata) for each ReadsAlignment object in the Set) -> structure:
+           parameter "ref" of String, parameter "include_item_info" of type
+           "boolean" (A boolean. 0 = false, 1 = true.), parameter
+           "ref_path_to_set" of list of String
+        :returns: instance of type "GetReadsAlignmentSetV1Result" ->
+           structure: parameter "data" of type "ReadsAlignmentSet" (When
+           building a ReadsAlignmentSet, all ReadsAlignments must be aligned
+           against the same genome. This is not part of the object type, but
+           enforced during a call to save_reads_alignment_set_v1. @meta ws
+           description as description @meta ws length(items) as item_count)
+           -> structure: parameter "description" of String, parameter "items"
+           of list of type "ReadsAlignmentSetItem" (When saving a
+           ReadsAlignmentSet, only 'ref' is required. You should never set
+           'info'.  'info' is provided optionally when fetching the
+           ReadsAlignmentSet.) -> structure: parameter "ref" of type
+           "ws_reads_align_id" (The workspace id for a ReadsAlignment data
+           object. @id ws KBaseRNASeq.RNASeqAlignment), parameter "label" of
+           String, parameter "info" of type "object_info" (Information about
+           an object, including user provided metadata. obj_id objid - the
+           numerical id of the object. obj_name name - the name of the
+           object. type_string type - the type of the object. timestamp
+           save_date - the save date of the object. obj_ver ver - the version
+           of the object. username saved_by - the user that saved or copied
+           the object. ws_id wsid - the workspace containing the object.
+           ws_name workspace - the workspace containing the object. string
+           chsum - the md5 checksum of the object. int size - the size of the
+           object in bytes. usermeta meta - arbitrary user-supplied metadata
+           about the object.) -> tuple of size 11: parameter "objid" of type
+           "obj_id" (The unique, permanent numerical ID of an object.),
+           parameter "name" of type "obj_name" (A string used as a name for
+           an object. Any string consisting of alphanumeric characters and
+           the characters |._- that is not an integer is acceptable.),
+           parameter "type" of type "type_string" (A type string. Specifies
+           the type and its version in a single string in the format
+           [module].[typename]-[major].[minor]: module - a string. The module
+           name of the typespec containing the type. typename - a string. The
+           name of the type as assigned by the typedef statement. major - an
+           integer. The major version of the type. A change in the major
+           version implies the type has changed in a non-backwards compatible
+           way. minor - an integer. The minor version of the type. A change
+           in the minor version implies that the type has changed in a way
+           that is backwards compatible with previous type definitions. In
+           many cases, the major and minor versions are optional, and if not
+           provided the most recent version will be used. Example:
+           MyModule.MyType-3.1), parameter "save_date" of type "timestamp" (A
+           time in the format YYYY-MM-DDThh:mm:ssZ, where Z is either the
+           character Z (representing the UTC timezone) or the difference in
+           time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500
+           (EST time) 2013-04-03T08:56:32+0000 (UTC time)
+           2013-04-03T08:56:32Z (UTC time)), parameter "version" of Long,
+           parameter "saved_by" of type "username" (Login name of a KBase
+           user account.), parameter "wsid" of type "ws_id" (The unique,
+           permanent numerical ID of a workspace.), parameter "workspace" of
+           type "ws_name" (A string used as a name for a workspace. Any
+           string consisting of alphanumeric characters and "_", ".", or "-"
+           that is not an integer is acceptable. The name may optionally be
+           prefixed with the workspace owner's user name and a colon, e.g.
+           kbasetest:my_workspace.), parameter "chsum" of String, parameter
+           "size" of Long, parameter "meta" of type "usermeta" (User provided
+           metadata about an object. Arbitrary key-value pairs provided by
+           the user.) -> mapping from String to String, parameter
+           "data_attachments" of list of type "DataAttachment" -> structure:
+           parameter "name" of String, parameter "ref" of type "ws_obj_id"
+           (The workspace ID for a any data object. @id ws), parameter "info"
+           of type "object_info" (Information about an object, including user
+           provided metadata. obj_id objid - the numerical id of the object.
+           obj_name name - the name of the object. type_string type - the
+           type of the object. timestamp save_date - the save date of the
+           object. obj_ver ver - the version of the object. username saved_by
+           - the user that saved or copied the object. ws_id wsid - the
+           workspace containing the object. ws_name workspace - the workspace
+           containing the object. string chsum - the md5 checksum of the
+           object. int size - the size of the object in bytes. usermeta meta
+           - arbitrary user-supplied metadata about the object.) -> tuple of
+           size 11: parameter "objid" of type "obj_id" (The unique, permanent
+           numerical ID of an object.), parameter "name" of type "obj_name"
+           (A string used as a name for an object. Any string consisting of
+           alphanumeric characters and the characters |._- that is not an
+           integer is acceptable.), parameter "type" of type "type_string" (A
+           type string. Specifies the type and its version in a single string
+           in the format [module].[typename]-[major].[minor]: module - a
+           string. The module name of the typespec containing the type.
+           typename - a string. The name of the type as assigned by the
+           typedef statement. major - an integer. The major version of the
+           type. A change in the major version implies the type has changed
+           in a non-backwards compatible way. minor - an integer. The minor
+           version of the type. A change in the minor version implies that
+           the type has changed in a way that is backwards compatible with
+           previous type definitions. In many cases, the major and minor
+           versions are optional, and if not provided the most recent version
+           will be used. Example: MyModule.MyType-3.1), parameter "save_date"
+           of type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ,
+           where Z is either the character Z (representing the UTC timezone)
+           or the difference in time to UTC in the format +/-HHMM, eg:
+           2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC
+           time) 2013-04-03T08:56:32Z (UTC time)), parameter "version" of
+           Long, parameter "saved_by" of type "username" (Login name of a
+           KBase user account.), parameter "wsid" of type "ws_id" (The
+           unique, permanent numerical ID of a workspace.), parameter
+           "workspace" of type "ws_name" (A string used as a name for a
+           workspace. Any string consisting of alphanumeric characters and
+           "_", ".", or "-" that is not an integer is acceptable. The name
+           may optionally be prefixed with the workspace owner's user name
+           and a colon, e.g. kbasetest:my_workspace.), parameter "chsum" of
+           String, parameter "size" of Long, parameter "meta" of type
+           "usermeta" (User provided metadata about an object. Arbitrary
+           key-value pairs provided by the user.) -> mapping from String to
+           String
+        """
+        return self._client.call_method(
             'SetAPI.get_reads_alignment_set_v1',
             [params], self._service_ver, context)
 
@@ -159,8 +396,8 @@ class SetAPI(object):
            "ReadsAlignmentSet" (When building a ReadsAlignmentSet, all
            ReadsAlignments must be aligned against the same genome. This is
            not part of the object type, but enforced during a call to
-           save_reads_alignment_v1. @meta ws description as description @meta
-           ws length(items) as item_count) -> structure: parameter
+           save_reads_alignment_set_v1. @meta ws description as description
+           @meta ws length(items) as item_count) -> structure: parameter
            "description" of String, parameter "items" of list of type
            "ReadsAlignmentSetItem" (When saving a ReadsAlignmentSet, only
            'ref' is required. You should never set 'info'.  'info' is
@@ -211,7 +448,10 @@ class SetAPI(object):
            kbasetest:my_workspace.), parameter "chsum" of String, parameter
            "size" of Long, parameter "meta" of type "usermeta" (User provided
            metadata about an object. Arbitrary key-value pairs provided by
-           the user.) -> mapping from String to String
+           the user.) -> mapping from String to String, parameter
+           "data_attachments" of list of type "DataAttachment" -> structure:
+           parameter "name" of String, parameter "ref" of type "ws_obj_id"
+           (The workspace ID for a any data object. @id ws)
         :returns: instance of type "SaveReadsAlignmentSetV1Result" ->
            structure: parameter "set_ref" of String, parameter "set_info" of
            type "object_info" (Information about an object, including user

--- a/lib/SetAPI/SetAPIImpl.py
+++ b/lib/SetAPI/SetAPIImpl.py
@@ -8,6 +8,7 @@ from SetAPI.reads.ReadsSetInterfaceV1 import ReadsSetInterfaceV1
 from SetAPI.assembly.AssemblySetInterfaceV1 import AssemblySetInterfaceV1
 from SetAPI.genome.GenomeSetInterfaceV1 import GenomeSetInterfaceV1
 from SetAPI.readsalignment.ReadsAlignmentSetInterfaceV1 import ReadsAlignmentSetInterfaceV1
+from SetAPI.expression.ExpressionSetInterfaceV1 import ExpressionSetInterfaceV1
 from SetAPI.generic.GenericSetNavigator import GenericSetNavigator
 from SetAPI.generic.DynamicServiceCache import DynamicServiceCache
 
@@ -21,7 +22,7 @@ class SetAPI:
     SetAPI
 
     Module Description:
-    
+
     '''
 
     ######## WARNING FOR GEVENT USERS ####### noqa
@@ -32,7 +33,7 @@ class SetAPI:
     ######################################### noqa
     VERSION = "0.1.2"
     GIT_URL = "https://github.com/briehl/SetAPI"
-    GIT_COMMIT_HASH = "128eb2174281f940ecc82cedd71b1d771e65d8ed"
+    GIT_COMMIT_HASH = "5ea5831ed75e5c5659893e6534b5d1ca2de014a3"
 
     #BEGIN_CLASS_HEADER
     #END_CLASS_HEADER
@@ -167,6 +168,11 @@ class SetAPI:
         # ctx is the context object
         # return variables are: returnVal
         #BEGIN get_expression_set_v1
+
+        ws = Workspace(self.workspaceURL, token=ctx['token'])
+        esi = ExpressionSetInterfaceV1(ws)
+        returnVal = esi.get_reads_alignment_set(ctx, params)
+
         #END get_expression_set_v1
 
         # At some point might do deeper type checking...
@@ -292,6 +298,11 @@ class SetAPI:
         # ctx is the context object
         # return variables are: result
         #BEGIN save_expression_set_v1
+
+        ws = Workspace(self.workspaceURL, token=ctx['token'])
+        esi = ExpressionSetInterfaceV1(ws)
+        result = esi.save_expression_set(ctx, params)
+
         #END save_expression_set_v1
 
         # At some point might do deeper type checking...

--- a/lib/SetAPI/SetAPIImpl.py
+++ b/lib/SetAPI/SetAPIImpl.py
@@ -6,6 +6,7 @@ from biokbase.workspace.client import Workspace
 from SetAPI.reads.ReadsSetInterfaceV1 import ReadsSetInterfaceV1
 from SetAPI.assembly.AssemblySetInterfaceV1 import AssemblySetInterfaceV1
 from SetAPI.genome.GenomeSetInterfaceV1 import GenomeSetInterfaceV1
+from SetAPI.readsalignment.ReadsAlignmentSetInterfaceV1 import ReadsAlignmentSetInterfaceV1
 from SetAPI.generic.GenericSetNavigator import GenericSetNavigator
 from SetAPI.generic.DynamicServiceCache import DynamicServiceCache
 
@@ -19,7 +20,7 @@ class SetAPI:
     SetAPI
 
     Module Description:
-    
+
     '''
 
     ######## WARNING FOR GEVENT USERS ####### noqa
@@ -28,9 +29,9 @@ class SetAPI:
     # state. A method could easily clobber the state set by another while
     # the latter method is running.
     ######################################### noqa
-    VERSION = "0.1.1"
-    GIT_URL = "https://github.com/rsutormin/SetAPI"
-    GIT_COMMIT_HASH = "c0110961bfb3e14a33d70b630e0deb69d6b93373"
+    VERSION = "0.1.2"
+    GIT_URL = "https://github.com/kbaseapps/SetAPI"
+    GIT_COMMIT_HASH = "66c78fada08b8bd2ac3b1ecdb6c5dbd3a0fc9d9b"
 
     #BEGIN_CLASS_HEADER
     #END_CLASS_HEADER
@@ -42,12 +43,263 @@ class SetAPI:
         self.workspaceURL = config['workspace-url']
         self.serviceWizardURL = config['service-wizard']
         self.dataPaletteServiceVersion = config['datapaletteservice-version']
-        self.dataPaletteCache = DynamicServiceCache(self.serviceWizardURL, 
-                                                      self.dataPaletteServiceVersion, 
+        self.dataPaletteCache = DynamicServiceCache(self.serviceWizardURL,
+                                                      self.dataPaletteServiceVersion,
                                                       'DataPaletteService')
         #END_CONSTRUCTOR
         pass
 
+
+    def get_reads_alignment_set_v1(self, ctx, params):
+        """
+        :param params: instance of type "GetReadsAlignmentSetV1Params" (ref -
+           workspace reference to ReadsAlignmentSet object. include_item_info
+           - 1 or 0, if 1 additionally provides workspace info (with
+           metadata) for each ReadsAlignment object in the Set) -> structure:
+           parameter "ref" of String, parameter "include_item_info" of type
+           "boolean" (A boolean. 0 = false, 1 = true.), parameter
+           "ref_path_to_set" of list of String
+        :returns: instance of type "GetReadsAlignmentSetV1Result" ->
+           structure: parameter "data" of type "ReadsAlignmentSet" (When
+           building a ReadsAlignmentSet, all ReadsAlignments must be aligned
+           against the same genome. This is not part of the object type, but
+           enforced during a call to save_reads_alignment_v1. @meta ws
+           description as description @meta ws length(items) as item_count)
+           -> structure: parameter "description" of String, parameter "items"
+           of list of type "ReadsAlignmentSetItem" (When saving a
+           ReadsAlignmentSet, only 'ref' is required. You should never set
+           'info'.  'info' is provided optionally when fetching the
+           ReadsAlignmentSet.) -> structure: parameter "ref" of type
+           "ws_reads_align_id" (The workspace id for a ReadsAlignment data
+           object. @id ws KBaseRNASeq.RNASeqAlignment), parameter "label" of
+           String, parameter "info" of type "object_info" (Information about
+           an object, including user provided metadata. obj_id objid - the
+           numerical id of the object. obj_name name - the name of the
+           object. type_string type - the type of the object. timestamp
+           save_date - the save date of the object. obj_ver ver - the version
+           of the object. username saved_by - the user that saved or copied
+           the object. ws_id wsid - the workspace containing the object.
+           ws_name workspace - the workspace containing the object. string
+           chsum - the md5 checksum of the object. int size - the size of the
+           object in bytes. usermeta meta - arbitrary user-supplied metadata
+           about the object.) -> tuple of size 11: parameter "objid" of type
+           "obj_id" (The unique, permanent numerical ID of an object.),
+           parameter "name" of type "obj_name" (A string used as a name for
+           an object. Any string consisting of alphanumeric characters and
+           the characters |._- that is not an integer is acceptable.),
+           parameter "type" of type "type_string" (A type string. Specifies
+           the type and its version in a single string in the format
+           [module].[typename]-[major].[minor]: module - a string. The module
+           name of the typespec containing the type. typename - a string. The
+           name of the type as assigned by the typedef statement. major - an
+           integer. The major version of the type. A change in the major
+           version implies the type has changed in a non-backwards compatible
+           way. minor - an integer. The minor version of the type. A change
+           in the minor version implies that the type has changed in a way
+           that is backwards compatible with previous type definitions. In
+           many cases, the major and minor versions are optional, and if not
+           provided the most recent version will be used. Example:
+           MyModule.MyType-3.1), parameter "save_date" of type "timestamp" (A
+           time in the format YYYY-MM-DDThh:mm:ssZ, where Z is either the
+           character Z (representing the UTC timezone) or the difference in
+           time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500
+           (EST time) 2013-04-03T08:56:32+0000 (UTC time)
+           2013-04-03T08:56:32Z (UTC time)), parameter "version" of Long,
+           parameter "saved_by" of type "username" (Login name of a KBase
+           user account.), parameter "wsid" of type "ws_id" (The unique,
+           permanent numerical ID of a workspace.), parameter "workspace" of
+           type "ws_name" (A string used as a name for a workspace. Any
+           string consisting of alphanumeric characters and "_", ".", or "-"
+           that is not an integer is acceptable. The name may optionally be
+           prefixed with the workspace owner's user name and a colon, e.g.
+           kbasetest:my_workspace.), parameter "chsum" of String, parameter
+           "size" of Long, parameter "meta" of type "usermeta" (User provided
+           metadata about an object. Arbitrary key-value pairs provided by
+           the user.) -> mapping from String to String, parameter "info" of
+           type "object_info" (Information about an object, including user
+           provided metadata. obj_id objid - the numerical id of the object.
+           obj_name name - the name of the object. type_string type - the
+           type of the object. timestamp save_date - the save date of the
+           object. obj_ver ver - the version of the object. username saved_by
+           - the user that saved or copied the object. ws_id wsid - the
+           workspace containing the object. ws_name workspace - the workspace
+           containing the object. string chsum - the md5 checksum of the
+           object. int size - the size of the object in bytes. usermeta meta
+           - arbitrary user-supplied metadata about the object.) -> tuple of
+           size 11: parameter "objid" of type "obj_id" (The unique, permanent
+           numerical ID of an object.), parameter "name" of type "obj_name"
+           (A string used as a name for an object. Any string consisting of
+           alphanumeric characters and the characters |._- that is not an
+           integer is acceptable.), parameter "type" of type "type_string" (A
+           type string. Specifies the type and its version in a single string
+           in the format [module].[typename]-[major].[minor]: module - a
+           string. The module name of the typespec containing the type.
+           typename - a string. The name of the type as assigned by the
+           typedef statement. major - an integer. The major version of the
+           type. A change in the major version implies the type has changed
+           in a non-backwards compatible way. minor - an integer. The minor
+           version of the type. A change in the minor version implies that
+           the type has changed in a way that is backwards compatible with
+           previous type definitions. In many cases, the major and minor
+           versions are optional, and if not provided the most recent version
+           will be used. Example: MyModule.MyType-3.1), parameter "save_date"
+           of type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ,
+           where Z is either the character Z (representing the UTC timezone)
+           or the difference in time to UTC in the format +/-HHMM, eg:
+           2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC
+           time) 2013-04-03T08:56:32Z (UTC time)), parameter "version" of
+           Long, parameter "saved_by" of type "username" (Login name of a
+           KBase user account.), parameter "wsid" of type "ws_id" (The
+           unique, permanent numerical ID of a workspace.), parameter
+           "workspace" of type "ws_name" (A string used as a name for a
+           workspace. Any string consisting of alphanumeric characters and
+           "_", ".", or "-" that is not an integer is acceptable. The name
+           may optionally be prefixed with the workspace owner's user name
+           and a colon, e.g. kbasetest:my_workspace.), parameter "chsum" of
+           String, parameter "size" of Long, parameter "meta" of type
+           "usermeta" (User provided metadata about an object. Arbitrary
+           key-value pairs provided by the user.) -> mapping from String to
+           String
+        """
+        # ctx is the context object
+        # return variables are: returnVal
+        #BEGIN get_reads_alignment_set_v1
+
+        ws = Workspace(self.workspaceURL, token=ctx['token'])
+        rasi = ReadsAlignmentSetInterfaceV1(ws)
+        result = rasi.get_reads_alignment_set(ctx, params)
+
+        #END get_reads_alignment_set_v1
+
+        # At some point might do deeper type checking...
+        if not isinstance(returnVal, dict):
+            raise ValueError('Method get_reads_alignment_set_v1 return value ' +
+                             'returnVal is not type dict as required.')
+        # return the results
+        return [returnVal]
+
+    def save_reads_alignment_set_v1(self, ctx, params):
+        """
+        :param params: instance of type "SaveReadsAlignmentSetV1Params"
+           (workspace_name or workspace_id - alternative options defining
+           target workspace, output_object_name - workspace object name (this
+           parameter is used together with one of workspace params from
+           above)) -> structure: parameter "workspace" of String, parameter
+           "output_object_name" of String, parameter "data" of type
+           "ReadsAlignmentSet" (When building a ReadsAlignmentSet, all
+           ReadsAlignments must be aligned against the same genome. This is
+           not part of the object type, but enforced during a call to
+           save_reads_alignment_v1. @meta ws description as description @meta
+           ws length(items) as item_count) -> structure: parameter
+           "description" of String, parameter "items" of list of type
+           "ReadsAlignmentSetItem" (When saving a ReadsAlignmentSet, only
+           'ref' is required. You should never set 'info'.  'info' is
+           provided optionally when fetching the ReadsAlignmentSet.) ->
+           structure: parameter "ref" of type "ws_reads_align_id" (The
+           workspace id for a ReadsAlignment data object. @id ws
+           KBaseRNASeq.RNASeqAlignment), parameter "label" of String,
+           parameter "info" of type "object_info" (Information about an
+           object, including user provided metadata. obj_id objid - the
+           numerical id of the object. obj_name name - the name of the
+           object. type_string type - the type of the object. timestamp
+           save_date - the save date of the object. obj_ver ver - the version
+           of the object. username saved_by - the user that saved or copied
+           the object. ws_id wsid - the workspace containing the object.
+           ws_name workspace - the workspace containing the object. string
+           chsum - the md5 checksum of the object. int size - the size of the
+           object in bytes. usermeta meta - arbitrary user-supplied metadata
+           about the object.) -> tuple of size 11: parameter "objid" of type
+           "obj_id" (The unique, permanent numerical ID of an object.),
+           parameter "name" of type "obj_name" (A string used as a name for
+           an object. Any string consisting of alphanumeric characters and
+           the characters |._- that is not an integer is acceptable.),
+           parameter "type" of type "type_string" (A type string. Specifies
+           the type and its version in a single string in the format
+           [module].[typename]-[major].[minor]: module - a string. The module
+           name of the typespec containing the type. typename - a string. The
+           name of the type as assigned by the typedef statement. major - an
+           integer. The major version of the type. A change in the major
+           version implies the type has changed in a non-backwards compatible
+           way. minor - an integer. The minor version of the type. A change
+           in the minor version implies that the type has changed in a way
+           that is backwards compatible with previous type definitions. In
+           many cases, the major and minor versions are optional, and if not
+           provided the most recent version will be used. Example:
+           MyModule.MyType-3.1), parameter "save_date" of type "timestamp" (A
+           time in the format YYYY-MM-DDThh:mm:ssZ, where Z is either the
+           character Z (representing the UTC timezone) or the difference in
+           time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500
+           (EST time) 2013-04-03T08:56:32+0000 (UTC time)
+           2013-04-03T08:56:32Z (UTC time)), parameter "version" of Long,
+           parameter "saved_by" of type "username" (Login name of a KBase
+           user account.), parameter "wsid" of type "ws_id" (The unique,
+           permanent numerical ID of a workspace.), parameter "workspace" of
+           type "ws_name" (A string used as a name for a workspace. Any
+           string consisting of alphanumeric characters and "_", ".", or "-"
+           that is not an integer is acceptable. The name may optionally be
+           prefixed with the workspace owner's user name and a colon, e.g.
+           kbasetest:my_workspace.), parameter "chsum" of String, parameter
+           "size" of Long, parameter "meta" of type "usermeta" (User provided
+           metadata about an object. Arbitrary key-value pairs provided by
+           the user.) -> mapping from String to String
+        :returns: instance of type "SaveReadsAlignmentSetV1Result" ->
+           structure: parameter "set_ref" of String, parameter "set_info" of
+           type "object_info" (Information about an object, including user
+           provided metadata. obj_id objid - the numerical id of the object.
+           obj_name name - the name of the object. type_string type - the
+           type of the object. timestamp save_date - the save date of the
+           object. obj_ver ver - the version of the object. username saved_by
+           - the user that saved or copied the object. ws_id wsid - the
+           workspace containing the object. ws_name workspace - the workspace
+           containing the object. string chsum - the md5 checksum of the
+           object. int size - the size of the object in bytes. usermeta meta
+           - arbitrary user-supplied metadata about the object.) -> tuple of
+           size 11: parameter "objid" of type "obj_id" (The unique, permanent
+           numerical ID of an object.), parameter "name" of type "obj_name"
+           (A string used as a name for an object. Any string consisting of
+           alphanumeric characters and the characters |._- that is not an
+           integer is acceptable.), parameter "type" of type "type_string" (A
+           type string. Specifies the type and its version in a single string
+           in the format [module].[typename]-[major].[minor]: module - a
+           string. The module name of the typespec containing the type.
+           typename - a string. The name of the type as assigned by the
+           typedef statement. major - an integer. The major version of the
+           type. A change in the major version implies the type has changed
+           in a non-backwards compatible way. minor - an integer. The minor
+           version of the type. A change in the minor version implies that
+           the type has changed in a way that is backwards compatible with
+           previous type definitions. In many cases, the major and minor
+           versions are optional, and if not provided the most recent version
+           will be used. Example: MyModule.MyType-3.1), parameter "save_date"
+           of type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ,
+           where Z is either the character Z (representing the UTC timezone)
+           or the difference in time to UTC in the format +/-HHMM, eg:
+           2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC
+           time) 2013-04-03T08:56:32Z (UTC time)), parameter "version" of
+           Long, parameter "saved_by" of type "username" (Login name of a
+           KBase user account.), parameter "wsid" of type "ws_id" (The
+           unique, permanent numerical ID of a workspace.), parameter
+           "workspace" of type "ws_name" (A string used as a name for a
+           workspace. Any string consisting of alphanumeric characters and
+           "_", ".", or "-" that is not an integer is acceptable. The name
+           may optionally be prefixed with the workspace owner's user name
+           and a colon, e.g. kbasetest:my_workspace.), parameter "chsum" of
+           String, parameter "size" of Long, parameter "meta" of type
+           "usermeta" (User provided metadata about an object. Arbitrary
+           key-value pairs provided by the user.) -> mapping from String to
+           String
+        """
+        # ctx is the context object
+        # return variables are: result
+        #BEGIN save_reads_alignment_set_v1
+        #END save_reads_alignment_set_v1
+
+        # At some point might do deeper type checking...
+        if not isinstance(result, dict):
+            raise ValueError('Method save_reads_alignment_set_v1 return value ' +
+                             'result is not type dict as required.')
+        # return the results
+        return [result]
 
     def get_reads_set_v1(self, ctx, params):
         """
@@ -799,7 +1051,7 @@ class SetAPI:
     def list_sets(self, ctx, params):
         """
         Use to get the top-level sets in a WS. Optionally can include
-        one level down members of those sets. 
+        one level down members of those sets.
         NOTE: DOES NOT PRESERVE ORDERING OF ITEM LIST IN DATA
         :param params: instance of type "ListSetParams" (workspace -
            workspace name or ID (alternative to workspaces parameter),
@@ -969,7 +1221,7 @@ class SetAPI:
         #BEGIN list_sets
 
         ws = Workspace(self.workspaceURL, token=ctx['token'])
-        gsn = GenericSetNavigator(ws, data_palette_cache=self.dataPaletteCache, 
+        gsn = GenericSetNavigator(ws, data_palette_cache=self.dataPaletteCache,
                                   token=ctx['token'])
         result = gsn.list_sets(params)
 
@@ -1107,7 +1359,7 @@ class SetAPI:
         return [result]
     def status(self, ctx):
         #BEGIN_STATUS
-        returnVal = {'state': "OK", 'message': "", 'version': self.VERSION, 
+        returnVal = {'state': "OK", 'message': "", 'version': self.VERSION,
                      'git_url': self.GIT_URL, 'git_commit_hash': self.GIT_COMMIT_HASH}
         #END_STATUS
         return [returnVal]

--- a/lib/SetAPI/SetAPIImpl.py
+++ b/lib/SetAPI/SetAPIImpl.py
@@ -171,7 +171,7 @@ class SetAPI:
 
         ws = Workspace(self.workspaceURL, token=ctx['token'])
         esi = ExpressionSetInterfaceV1(ws)
-        returnVal = esi.get_reads_alignment_set(ctx, params)
+        returnVal = esi.get_expression_set(ctx, params)
 
         #END get_expression_set_v1
 

--- a/lib/SetAPI/SetAPIImpl.py
+++ b/lib/SetAPI/SetAPIImpl.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 #BEGIN_HEADER
 
-from biokbase.workspace.client import Workspace
+# from biokbase.workspace.client import Workspace
+from Workspace.WorkspaceClient import Workspace
 
 from SetAPI.reads.ReadsSetInterfaceV1 import ReadsSetInterfaceV1
 from SetAPI.assembly.AssemblySetInterfaceV1 import AssemblySetInterfaceV1
@@ -292,6 +293,9 @@ class SetAPI:
         # ctx is the context object
         # return variables are: result
         #BEGIN save_reads_alignment_set_v1
+        ws = Workspace(self.workspaceURL, token=ctx['token'])
+        rasi = ReadsAlignmentSetInterfaceV1(ws)
+        result = rasi.save_reads_alignment_set(ctx, params)
         #END save_reads_alignment_set_v1
 
         # At some point might do deeper type checking...

--- a/lib/SetAPI/SetAPIImpl.py
+++ b/lib/SetAPI/SetAPIImpl.py
@@ -168,7 +168,7 @@ class SetAPI:
 
         ws = Workspace(self.workspaceURL, token=ctx['token'])
         rasi = ReadsAlignmentSetInterfaceV1(ws)
-        result = rasi.get_reads_alignment_set(ctx, params)
+        returnVal = rasi.get_reads_alignment_set(ctx, params)
 
         #END get_reads_alignment_set_v1
 

--- a/lib/SetAPI/SetAPIImpl.py
+++ b/lib/SetAPI/SetAPIImpl.py
@@ -21,7 +21,7 @@ class SetAPI:
     SetAPI
 
     Module Description:
-
+    
     '''
 
     ######## WARNING FOR GEVENT USERS ####### noqa
@@ -31,8 +31,8 @@ class SetAPI:
     # the latter method is running.
     ######################################### noqa
     VERSION = "0.1.2"
-    GIT_URL = "https://github.com/kbaseapps/SetAPI"
-    GIT_COMMIT_HASH = "66c78fada08b8bd2ac3b1ecdb6c5dbd3a0fc9d9b"
+    GIT_URL = "https://github.com/briehl/SetAPI"
+    GIT_COMMIT_HASH = "128eb2174281f940ecc82cedd71b1d771e65d8ed"
 
     #BEGIN_CLASS_HEADER
     #END_CLASS_HEADER
@@ -51,6 +51,256 @@ class SetAPI:
         pass
 
 
+    def get_expression_set_v1(self, ctx, params):
+        """
+        :param params: instance of type "GetExpressionSetV1Params" (ref -
+           workspace reference to ExpressionSet object. include_item_info - 1
+           or 0, if 1 additionally provides workspace info (with metadata)
+           for each Expression object in the Set) -> structure: parameter
+           "ref" of String, parameter "include_item_info" of type "boolean"
+           (A boolean. 0 = false, 1 = true.), parameter "ref_path_to_set" of
+           list of String
+        :returns: instance of type "GetExpressionSetV1Result" -> structure:
+           parameter "data" of type "ExpressionSet" (When building a
+           ExpressionSet, all Expression objects must be aligned against the
+           same genome. This is not part of the object type, but enforced
+           during a call to save_expression_set_v1. @meta ws description as
+           description @meta ws length(items) as item_count) -> structure:
+           parameter "description" of String, parameter "items" of list of
+           type "ExpressionSetItem" (When saving a ExpressionSet, only 'ref'
+           is required. You should never set 'info'.  'info' is provided
+           optionally when fetching the ExpressionSet.) -> structure:
+           parameter "ref" of type "ws_expression_id" (The workspace id for a
+           ReadsAlignment data object. @id ws KBaseRNASeq.RNASeqExpression),
+           parameter "label" of String, parameter "data_attachments" of list
+           of type "DataAttachment" -> structure: parameter "name" of String,
+           parameter "ref" of type "ws_obj_id" (The workspace ID for a any
+           data object. @id ws), parameter "info" of type "object_info"
+           (Information about an object, including user provided metadata.
+           obj_id objid - the numerical id of the object. obj_name name - the
+           name of the object. type_string type - the type of the object.
+           timestamp save_date - the save date of the object. obj_ver ver -
+           the version of the object. username saved_by - the user that saved
+           or copied the object. ws_id wsid - the workspace containing the
+           object. ws_name workspace - the workspace containing the object.
+           string chsum - the md5 checksum of the object. int size - the size
+           of the object in bytes. usermeta meta - arbitrary user-supplied
+           metadata about the object.) -> tuple of size 11: parameter "objid"
+           of type "obj_id" (The unique, permanent numerical ID of an
+           object.), parameter "name" of type "obj_name" (A string used as a
+           name for an object. Any string consisting of alphanumeric
+           characters and the characters |._- that is not an integer is
+           acceptable.), parameter "type" of type "type_string" (A type
+           string. Specifies the type and its version in a single string in
+           the format [module].[typename]-[major].[minor]: module - a string.
+           The module name of the typespec containing the type. typename - a
+           string. The name of the type as assigned by the typedef statement.
+           major - an integer. The major version of the type. A change in the
+           major version implies the type has changed in a non-backwards
+           compatible way. minor - an integer. The minor version of the type.
+           A change in the minor version implies that the type has changed in
+           a way that is backwards compatible with previous type definitions.
+           In many cases, the major and minor versions are optional, and if
+           not provided the most recent version will be used. Example:
+           MyModule.MyType-3.1), parameter "save_date" of type "timestamp" (A
+           time in the format YYYY-MM-DDThh:mm:ssZ, where Z is either the
+           character Z (representing the UTC timezone) or the difference in
+           time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500
+           (EST time) 2013-04-03T08:56:32+0000 (UTC time)
+           2013-04-03T08:56:32Z (UTC time)), parameter "version" of Long,
+           parameter "saved_by" of type "username" (Login name of a KBase
+           user account.), parameter "wsid" of type "ws_id" (The unique,
+           permanent numerical ID of a workspace.), parameter "workspace" of
+           type "ws_name" (A string used as a name for a workspace. Any
+           string consisting of alphanumeric characters and "_", ".", or "-"
+           that is not an integer is acceptable. The name may optionally be
+           prefixed with the workspace owner's user name and a colon, e.g.
+           kbasetest:my_workspace.), parameter "chsum" of String, parameter
+           "size" of Long, parameter "meta" of type "usermeta" (User provided
+           metadata about an object. Arbitrary key-value pairs provided by
+           the user.) -> mapping from String to String, parameter "info" of
+           type "object_info" (Information about an object, including user
+           provided metadata. obj_id objid - the numerical id of the object.
+           obj_name name - the name of the object. type_string type - the
+           type of the object. timestamp save_date - the save date of the
+           object. obj_ver ver - the version of the object. username saved_by
+           - the user that saved or copied the object. ws_id wsid - the
+           workspace containing the object. ws_name workspace - the workspace
+           containing the object. string chsum - the md5 checksum of the
+           object. int size - the size of the object in bytes. usermeta meta
+           - arbitrary user-supplied metadata about the object.) -> tuple of
+           size 11: parameter "objid" of type "obj_id" (The unique, permanent
+           numerical ID of an object.), parameter "name" of type "obj_name"
+           (A string used as a name for an object. Any string consisting of
+           alphanumeric characters and the characters |._- that is not an
+           integer is acceptable.), parameter "type" of type "type_string" (A
+           type string. Specifies the type and its version in a single string
+           in the format [module].[typename]-[major].[minor]: module - a
+           string. The module name of the typespec containing the type.
+           typename - a string. The name of the type as assigned by the
+           typedef statement. major - an integer. The major version of the
+           type. A change in the major version implies the type has changed
+           in a non-backwards compatible way. minor - an integer. The minor
+           version of the type. A change in the minor version implies that
+           the type has changed in a way that is backwards compatible with
+           previous type definitions. In many cases, the major and minor
+           versions are optional, and if not provided the most recent version
+           will be used. Example: MyModule.MyType-3.1), parameter "save_date"
+           of type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ,
+           where Z is either the character Z (representing the UTC timezone)
+           or the difference in time to UTC in the format +/-HHMM, eg:
+           2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC
+           time) 2013-04-03T08:56:32Z (UTC time)), parameter "version" of
+           Long, parameter "saved_by" of type "username" (Login name of a
+           KBase user account.), parameter "wsid" of type "ws_id" (The
+           unique, permanent numerical ID of a workspace.), parameter
+           "workspace" of type "ws_name" (A string used as a name for a
+           workspace. Any string consisting of alphanumeric characters and
+           "_", ".", or "-" that is not an integer is acceptable. The name
+           may optionally be prefixed with the workspace owner's user name
+           and a colon, e.g. kbasetest:my_workspace.), parameter "chsum" of
+           String, parameter "size" of Long, parameter "meta" of type
+           "usermeta" (User provided metadata about an object. Arbitrary
+           key-value pairs provided by the user.) -> mapping from String to
+           String
+        """
+        # ctx is the context object
+        # return variables are: returnVal
+        #BEGIN get_expression_set_v1
+        #END get_expression_set_v1
+
+        # At some point might do deeper type checking...
+        if not isinstance(returnVal, dict):
+            raise ValueError('Method get_expression_set_v1 return value ' +
+                             'returnVal is not type dict as required.')
+        # return the results
+        return [returnVal]
+
+    def save_expression_set_v1(self, ctx, params):
+        """
+        :param params: instance of type "SaveExpressionSetV1Params"
+           (workspace_name or workspace_id - alternative options defining
+           target workspace, output_object_name - workspace object name (this
+           parameter is used together with one of workspace params from
+           above)) -> structure: parameter "workspace" of String, parameter
+           "output_object_name" of String, parameter "data" of type
+           "ExpressionSet" (When building a ExpressionSet, all Expression
+           objects must be aligned against the same genome. This is not part
+           of the object type, but enforced during a call to
+           save_expression_set_v1. @meta ws description as description @meta
+           ws length(items) as item_count) -> structure: parameter
+           "description" of String, parameter "items" of list of type
+           "ExpressionSetItem" (When saving a ExpressionSet, only 'ref' is
+           required. You should never set 'info'.  'info' is provided
+           optionally when fetching the ExpressionSet.) -> structure:
+           parameter "ref" of type "ws_expression_id" (The workspace id for a
+           ReadsAlignment data object. @id ws KBaseRNASeq.RNASeqExpression),
+           parameter "label" of String, parameter "data_attachments" of list
+           of type "DataAttachment" -> structure: parameter "name" of String,
+           parameter "ref" of type "ws_obj_id" (The workspace ID for a any
+           data object. @id ws), parameter "info" of type "object_info"
+           (Information about an object, including user provided metadata.
+           obj_id objid - the numerical id of the object. obj_name name - the
+           name of the object. type_string type - the type of the object.
+           timestamp save_date - the save date of the object. obj_ver ver -
+           the version of the object. username saved_by - the user that saved
+           or copied the object. ws_id wsid - the workspace containing the
+           object. ws_name workspace - the workspace containing the object.
+           string chsum - the md5 checksum of the object. int size - the size
+           of the object in bytes. usermeta meta - arbitrary user-supplied
+           metadata about the object.) -> tuple of size 11: parameter "objid"
+           of type "obj_id" (The unique, permanent numerical ID of an
+           object.), parameter "name" of type "obj_name" (A string used as a
+           name for an object. Any string consisting of alphanumeric
+           characters and the characters |._- that is not an integer is
+           acceptable.), parameter "type" of type "type_string" (A type
+           string. Specifies the type and its version in a single string in
+           the format [module].[typename]-[major].[minor]: module - a string.
+           The module name of the typespec containing the type. typename - a
+           string. The name of the type as assigned by the typedef statement.
+           major - an integer. The major version of the type. A change in the
+           major version implies the type has changed in a non-backwards
+           compatible way. minor - an integer. The minor version of the type.
+           A change in the minor version implies that the type has changed in
+           a way that is backwards compatible with previous type definitions.
+           In many cases, the major and minor versions are optional, and if
+           not provided the most recent version will be used. Example:
+           MyModule.MyType-3.1), parameter "save_date" of type "timestamp" (A
+           time in the format YYYY-MM-DDThh:mm:ssZ, where Z is either the
+           character Z (representing the UTC timezone) or the difference in
+           time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500
+           (EST time) 2013-04-03T08:56:32+0000 (UTC time)
+           2013-04-03T08:56:32Z (UTC time)), parameter "version" of Long,
+           parameter "saved_by" of type "username" (Login name of a KBase
+           user account.), parameter "wsid" of type "ws_id" (The unique,
+           permanent numerical ID of a workspace.), parameter "workspace" of
+           type "ws_name" (A string used as a name for a workspace. Any
+           string consisting of alphanumeric characters and "_", ".", or "-"
+           that is not an integer is acceptable. The name may optionally be
+           prefixed with the workspace owner's user name and a colon, e.g.
+           kbasetest:my_workspace.), parameter "chsum" of String, parameter
+           "size" of Long, parameter "meta" of type "usermeta" (User provided
+           metadata about an object. Arbitrary key-value pairs provided by
+           the user.) -> mapping from String to String
+        :returns: instance of type "SaveExpressionSetV1Result" -> structure:
+           parameter "set_ref" of String, parameter "set_info" of type
+           "object_info" (Information about an object, including user
+           provided metadata. obj_id objid - the numerical id of the object.
+           obj_name name - the name of the object. type_string type - the
+           type of the object. timestamp save_date - the save date of the
+           object. obj_ver ver - the version of the object. username saved_by
+           - the user that saved or copied the object. ws_id wsid - the
+           workspace containing the object. ws_name workspace - the workspace
+           containing the object. string chsum - the md5 checksum of the
+           object. int size - the size of the object in bytes. usermeta meta
+           - arbitrary user-supplied metadata about the object.) -> tuple of
+           size 11: parameter "objid" of type "obj_id" (The unique, permanent
+           numerical ID of an object.), parameter "name" of type "obj_name"
+           (A string used as a name for an object. Any string consisting of
+           alphanumeric characters and the characters |._- that is not an
+           integer is acceptable.), parameter "type" of type "type_string" (A
+           type string. Specifies the type and its version in a single string
+           in the format [module].[typename]-[major].[minor]: module - a
+           string. The module name of the typespec containing the type.
+           typename - a string. The name of the type as assigned by the
+           typedef statement. major - an integer. The major version of the
+           type. A change in the major version implies the type has changed
+           in a non-backwards compatible way. minor - an integer. The minor
+           version of the type. A change in the minor version implies that
+           the type has changed in a way that is backwards compatible with
+           previous type definitions. In many cases, the major and minor
+           versions are optional, and if not provided the most recent version
+           will be used. Example: MyModule.MyType-3.1), parameter "save_date"
+           of type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ,
+           where Z is either the character Z (representing the UTC timezone)
+           or the difference in time to UTC in the format +/-HHMM, eg:
+           2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC
+           time) 2013-04-03T08:56:32Z (UTC time)), parameter "version" of
+           Long, parameter "saved_by" of type "username" (Login name of a
+           KBase user account.), parameter "wsid" of type "ws_id" (The
+           unique, permanent numerical ID of a workspace.), parameter
+           "workspace" of type "ws_name" (A string used as a name for a
+           workspace. Any string consisting of alphanumeric characters and
+           "_", ".", or "-" that is not an integer is acceptable. The name
+           may optionally be prefixed with the workspace owner's user name
+           and a colon, e.g. kbasetest:my_workspace.), parameter "chsum" of
+           String, parameter "size" of Long, parameter "meta" of type
+           "usermeta" (User provided metadata about an object. Arbitrary
+           key-value pairs provided by the user.) -> mapping from String to
+           String
+        """
+        # ctx is the context object
+        # return variables are: result
+        #BEGIN save_expression_set_v1
+        #END save_expression_set_v1
+
+        # At some point might do deeper type checking...
+        if not isinstance(result, dict):
+            raise ValueError('Method save_expression_set_v1 return value ' +
+                             'result is not type dict as required.')
+        # return the results
+        return [result]
+
     def get_reads_alignment_set_v1(self, ctx, params):
         """
         :param params: instance of type "GetReadsAlignmentSetV1Params" (ref -
@@ -64,7 +314,7 @@ class SetAPI:
            structure: parameter "data" of type "ReadsAlignmentSet" (When
            building a ReadsAlignmentSet, all ReadsAlignments must be aligned
            against the same genome. This is not part of the object type, but
-           enforced during a call to save_reads_alignment_v1. @meta ws
+           enforced during a call to save_reads_alignment_set_v1. @meta ws
            description as description @meta ws length(items) as item_count)
            -> structure: parameter "description" of String, parameter "items"
            of list of type "ReadsAlignmentSetItem" (When saving a
@@ -116,8 +366,11 @@ class SetAPI:
            kbasetest:my_workspace.), parameter "chsum" of String, parameter
            "size" of Long, parameter "meta" of type "usermeta" (User provided
            metadata about an object. Arbitrary key-value pairs provided by
-           the user.) -> mapping from String to String, parameter "info" of
-           type "object_info" (Information about an object, including user
+           the user.) -> mapping from String to String, parameter
+           "data_attachments" of list of type "DataAttachment" -> structure:
+           parameter "name" of String, parameter "ref" of type "ws_obj_id"
+           (The workspace ID for a any data object. @id ws), parameter "info"
+           of type "object_info" (Information about an object, including user
            provided metadata. obj_id objid - the numerical id of the object.
            obj_name name - the name of the object. type_string type - the
            type of the object. timestamp save_date - the save date of the
@@ -190,8 +443,8 @@ class SetAPI:
            "ReadsAlignmentSet" (When building a ReadsAlignmentSet, all
            ReadsAlignments must be aligned against the same genome. This is
            not part of the object type, but enforced during a call to
-           save_reads_alignment_v1. @meta ws description as description @meta
-           ws length(items) as item_count) -> structure: parameter
+           save_reads_alignment_set_v1. @meta ws description as description
+           @meta ws length(items) as item_count) -> structure: parameter
            "description" of String, parameter "items" of list of type
            "ReadsAlignmentSetItem" (When saving a ReadsAlignmentSet, only
            'ref' is required. You should never set 'info'.  'info' is
@@ -242,7 +495,10 @@ class SetAPI:
            kbasetest:my_workspace.), parameter "chsum" of String, parameter
            "size" of Long, parameter "meta" of type "usermeta" (User provided
            metadata about an object. Arbitrary key-value pairs provided by
-           the user.) -> mapping from String to String
+           the user.) -> mapping from String to String, parameter
+           "data_attachments" of list of type "DataAttachment" -> structure:
+           parameter "name" of String, parameter "ref" of type "ws_obj_id"
+           (The workspace ID for a any data object. @id ws)
         :returns: instance of type "SaveReadsAlignmentSetV1Result" ->
            structure: parameter "set_ref" of String, parameter "set_info" of
            type "object_info" (Information about an object, including user

--- a/lib/SetAPI/SetAPIServer.py
+++ b/lib/SetAPI/SetAPIServer.py
@@ -333,6 +333,14 @@ class Application(object):
         self.serverlog.set_log_level(6)
         self.rpc_service = JSONRPCServiceCustom()
         self.method_authentication = dict()
+        self.rpc_service.add(impl_SetAPI.get_expression_set_v1,
+                             name='SetAPI.get_expression_set_v1',
+                             types=[dict])
+        self.method_authentication['SetAPI.get_expression_set_v1'] = 'optional'  # noqa
+        self.rpc_service.add(impl_SetAPI.save_expression_set_v1,
+                             name='SetAPI.save_expression_set_v1',
+                             types=[dict])
+        self.method_authentication['SetAPI.save_expression_set_v1'] = 'required'  # noqa
         self.rpc_service.add(impl_SetAPI.get_reads_alignment_set_v1,
                              name='SetAPI.get_reads_alignment_set_v1',
                              types=[dict])

--- a/lib/SetAPI/SetAPIServer.py
+++ b/lib/SetAPI/SetAPIServer.py
@@ -333,6 +333,14 @@ class Application(object):
         self.serverlog.set_log_level(6)
         self.rpc_service = JSONRPCServiceCustom()
         self.method_authentication = dict()
+        self.rpc_service.add(impl_SetAPI.get_reads_alignment_set_v1,
+                             name='SetAPI.get_reads_alignment_set_v1',
+                             types=[dict])
+        self.method_authentication['SetAPI.get_reads_alignment_set_v1'] = 'optional'  # noqa
+        self.rpc_service.add(impl_SetAPI.save_reads_alignment_set_v1,
+                             name='SetAPI.save_reads_alignment_set_v1',
+                             types=[dict])
+        self.method_authentication['SetAPI.save_reads_alignment_set_v1'] = 'required'  # noqa
         self.rpc_service.add(impl_SetAPI.get_reads_set_v1,
                              name='SetAPI.get_reads_set_v1',
                              types=[dict])

--- a/lib/SetAPI/readsalignment/ReadsAlignmentSetInterfaceV1.py
+++ b/lib/SetAPI/readsalignment/ReadsAlignmentSetInterfaceV1.py
@@ -1,0 +1,57 @@
+"""
+An interface for handling sets of ReadsAlignments.
+"""
+from SetAPI.generic.SetInterfaceV1 import SetInterfaceV1
+from biokbase.workspace.client import Workspace
+
+
+class ReadsAlignmentSetInterfaceV1:
+    def __init__(self, workspace_client):
+        self.workspace_client = workspace_client
+        self.set_interface = SetInterfaceV1(workspace_client)
+
+    def save_reads_alignment_set(self, ctx, params):
+        if 'data' in params:
+            self._validate_reads_set_data(params['data'])
+        else:
+            raise ValueError('"data" parameter field required to save a ReadsAlignmentSet')
+
+        save_result = self.setInterface.save_set(
+                'KBaseSets.ReadsAlignmentSet',
+                ctx['provenance'],
+                params
+            )
+        info = save_result[0]
+        return {
+            'set_ref': str(info[6]) + '/' + str(info[0]) + '/' + str(info[4]),
+            'set_info': info
+        }
+
+    def _validate_reads_alignment_set_data(self, data):
+        # Normalize the object, make empty strings where necessary
+        if "description" not in data:
+            data["description"] = ""
+
+        if "items" not in data or len(data.get("items", [])) == 0:
+            raise ValueError("A ReadsAlignmentSet must contain at least one ReadsAlignment reference.")
+
+        refs = list()
+        for item in data["items"]:
+            refs.append(item["ref"])
+            if "label" not in item:
+                item["label"] = ""
+
+        ref_list = list(map(lambda r: {"ref": r}, refs))
+
+        # Get all the genome ids from our ReadsAlignment references (it's the genome_id key in
+        # the object metadata). Make a set out of them.
+        # If there's 0 or more than 1 item in the set, then either those items are bad, or they're
+        # aligned against different genomes.
+        info = self.workspace_client.get_object_info3({"objects": ref_list, "includeMetadata": 1})
+        num_genomes = len(set([item[10]["genome_id"] for item in info["infos"]]))
+        if num_genomes == 0 or num_genomes > 1:
+            raise ValueError("All ReadsAlignments in the set should be aligned against the same genome reference.")
+
+
+    def get_reads_alignment_set(self, ctx, params):
+        pass

--- a/lib/SetAPI/readsalignment/ReadsAlignmentSetInterfaceV1.py
+++ b/lib/SetAPI/readsalignment/ReadsAlignmentSetInterfaceV1.py
@@ -75,7 +75,7 @@ class ReadsAlignmentSetInterfaceV1:
 
     def _check_get_reads_alignment_set_params(self, params):
         if 'ref' not in params or params['ref'] is None:
-            raise ValueError('"ref" parameter field specifiying the reads set is required')
+            raise ValueError('"ref" parameter field specifiying the reads alignment set is required')
         elif not check_reference(params['ref']):
             raise ValueError('"ref" parameter must be a valid workspace reference')
         if 'include_item_info' in params:

--- a/lib/SetAPI/readsalignment/ReadsAlignmentSetInterfaceV1.py
+++ b/lib/SetAPI/readsalignment/ReadsAlignmentSetInterfaceV1.py
@@ -2,6 +2,7 @@
 An interface for handling sets of ReadsAlignments.
 """
 from SetAPI.generic.SetInterfaceV1 import SetInterfaceV1
+from SetAPI.util import check_reference
 
 
 class ReadsAlignmentSetInterfaceV1:
@@ -10,7 +11,7 @@ class ReadsAlignmentSetInterfaceV1:
         self.set_interface = SetInterfaceV1(workspace_client)
 
     def save_reads_alignment_set(self, ctx, params):
-        if 'data' in params:
+        if 'data' in params and params['data'] is not None:
             self._validate_reads_alignment_set_data(params['data'])
         else:
             raise ValueError('"data" parameter field required to save a ReadsAlignmentSet')
@@ -73,8 +74,10 @@ class ReadsAlignmentSetInterfaceV1:
         return set_data
 
     def _check_get_reads_alignment_set_params(self, params):
-        if 'ref' not in params:
+        if 'ref' not in params or params['ref'] is None:
             raise ValueError('"ref" parameter field specifiying the reads set is required')
+        elif not check_reference(params['ref']):
+            raise ValueError('"ref" parameter must be a valid workspace reference')
         if 'include_item_info' in params:
             if params['include_item_info'] not in [0, 1]:
                 raise ValueError('"include_item_info" parameter field can only be set to 0 or 1')

--- a/lib/SetAPI/readsalignment/ReadsAlignmentSetInterfaceV1.py
+++ b/lib/SetAPI/readsalignment/ReadsAlignmentSetInterfaceV1.py
@@ -2,7 +2,6 @@
 An interface for handling sets of ReadsAlignments.
 """
 from SetAPI.generic.SetInterfaceV1 import SetInterfaceV1
-from biokbase.workspace.client import Workspace
 
 
 class ReadsAlignmentSetInterfaceV1:
@@ -12,11 +11,11 @@ class ReadsAlignmentSetInterfaceV1:
 
     def save_reads_alignment_set(self, ctx, params):
         if 'data' in params:
-            self._validate_reads_set_data(params['data'])
+            self._validate_reads_alignment_set_data(params['data'])
         else:
             raise ValueError('"data" parameter field required to save a ReadsAlignmentSet')
 
-        save_result = self.setInterface.save_set(
+        save_result = self.set_interface.save_set(
                 'KBaseSets.ReadsAlignmentSet',
                 ctx['provenance'],
                 params

--- a/lib/SetAPI/util.py
+++ b/lib/SetAPI/util.py
@@ -1,0 +1,15 @@
+"""
+This module contains some utility functions for the SetAPI.
+"""
+import re
+
+
+def check_reference(ref):
+    """
+    Returns True if ref looks like an actual object reference: xx/yy/zz or xx/yy
+    Returns False otherwise.
+    """
+    obj_ref_regex = re.compile("^(?P<wsid>\d+)\/(?P<objid>\d+)(\/(?P<ver>\d+))?$")
+    if ref is None or not obj_ref_regex.match(ref):
+        return False
+    return True

--- a/lib/Workspace/WorkspaceClient.py
+++ b/lib/Workspace/WorkspaceClient.py
@@ -69,26 +69,28 @@ class Workspace(object):
            workspace. ws_id id - the numerical ID of the workspace. ws_name
            workspace - name of the workspace. username owner - name of the
            user who owns (e.g. created) this workspace. timestamp moddate -
-           date when the workspace was last modified. int objects - the
-           number of objects created in this workspace, including objects
-           that have been deleted. permission user_permission - permissions
-           for the authenticated user of this workspace. permission
-           globalread - whether this workspace is globally readable.
-           lock_status lockstat - the status of the workspace lock. usermeta
-           metadata - arbitrary user-supplied metadata about the workspace.)
-           -> tuple of size 9: parameter "id" of type "ws_id" (The unique,
-           permanent numerical ID of a workspace.), parameter "workspace" of
-           type "ws_name" (A string used as a name for a workspace. Any
-           string consisting of alphanumeric characters and "_", ".", or "-"
-           that is not an integer is acceptable. The name may optionally be
-           prefixed with the workspace owner's user name and a colon, e.g.
+           date when the workspace was last modified. int max_objid - the
+           maximum object ID appearing in this workspace. Since cloning a
+           workspace preserves object IDs, this number may be greater than
+           the number of objects in a newly cloned workspace. permission
+           user_permission - permissions for the authenticated user of this
+           workspace. permission globalread - whether this workspace is
+           globally readable. lock_status lockstat - the status of the
+           workspace lock. usermeta metadata - arbitrary user-supplied
+           metadata about the workspace.) -> tuple of size 9: parameter "id"
+           of type "ws_id" (The unique, permanent numerical ID of a
+           workspace.), parameter "workspace" of type "ws_name" (A string
+           used as a name for a workspace. Any string consisting of
+           alphanumeric characters and "_", ".", or "-" that is not an
+           integer is acceptable. The name may optionally be prefixed with
+           the workspace owner's user name and a colon, e.g.
            kbasetest:my_workspace.), parameter "owner" of type "username"
            (Login name of a KBase user account.), parameter "moddate" of type
            "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is
            either the character Z (representing the UTC timezone) or the
            difference in time to UTC in the format +/-HHMM, eg:
            2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC
-           time) 2013-04-03T08:56:32Z (UTC time)), parameter "object" of
+           time) 2013-04-03T08:56:32Z (UTC time)), parameter "max_objid" of
            Long, parameter "user_permission" of type "permission" (Represents
            the permissions a user or users have to a workspace: 'a' -
            administrator. All operations allowed. 'w' - read/write. 'r' -
@@ -117,12 +119,10 @@ class Workspace(object):
            overwritten. list<string> remove - these keys will be removed from
            the workspace metadata key/value pairs.) -> structure: parameter
            "wsi" of type "WorkspaceIdentity" (A workspace identifier. Select
-           a workspace by one, and only one, of the numerical id or name,
-           where the name can also be a KBase ID including the numerical id,
-           e.g. kb|ws.35. ws_id id - the numerical ID of the workspace.
-           ws_name workspace - name of the workspace or the workspace ID in
-           KBase format, e.g. kb|ws.78.) -> structure: parameter "workspace"
-           of type "ws_name" (A string used as a name for a workspace. Any
+           a workspace by one, and only one, of the numerical id or name.
+           ws_id id - the numerical ID of the workspace. ws_name workspace -
+           the name of the workspace.) -> structure: parameter "workspace" of
+           type "ws_name" (A string used as a name for a workspace. Any
            string consisting of alphanumeric characters and "_", ".", or "-"
            that is not an integer is acceptable. The name may optionally be
            prefixed with the workspace owner's user name and a colon, e.g.
@@ -150,13 +150,15 @@ class Workspace(object):
            A free-text description of the new workspace, 1000 characters max.
            Longer strings will be mercilessly and brutally truncated.
            usermeta meta - arbitrary user-supplied metadata for the
-           workspace.) -> structure: parameter "wsi" of type
+           workspace. list<ObjectIdentity> exclude - exclude the specified
+           objects from the cloned workspace. Either an object ID or a object
+           name must be specified in each ObjectIdentity - any supplied
+           reference strings, workspace names or IDs, and versions are
+           ignored.) -> structure: parameter "wsi" of type
            "WorkspaceIdentity" (A workspace identifier. Select a workspace by
-           one, and only one, of the numerical id or name, where the name can
-           also be a KBase ID including the numerical id, e.g. kb|ws.35.
-           ws_id id - the numerical ID of the workspace. ws_name workspace -
-           name of the workspace or the workspace ID in KBase format, e.g.
-           kb|ws.78.) -> structure: parameter "workspace" of type "ws_name"
+           one, and only one, of the numerical id or name. ws_id id - the
+           numerical ID of the workspace. ws_name workspace - the name of the
+           workspace.) -> structure: parameter "workspace" of type "ws_name"
            (A string used as a name for a workspace. Any string consisting of
            alphanumeric characters and "_", ".", or "-" that is not an
            integer is acceptable. The name may optionally be prefixed with
@@ -173,31 +175,63 @@ class Workspace(object):
            'w' - read/write. 'r' - read. 'n' - no permissions.), parameter
            "description" of String, parameter "meta" of type "usermeta" (User
            provided metadata about an object. Arbitrary key-value pairs
-           provided by the user.) -> mapping from String to String
+           provided by the user.) -> mapping from String to String, parameter
+           "exclude" of list of type "ObjectIdentity" (An object identifier.
+           Select an object by either: One, and only one, of the numerical id
+           or name of the workspace. ws_id wsid - the numerical ID of the
+           workspace. ws_name workspace - the name of the workspace. AND One,
+           and only one, of the numerical id or name of the object. obj_id
+           objid- the numerical ID of the object. obj_name name - name of the
+           object. OPTIONALLY obj_ver ver - the version of the object. OR an
+           object reference string: obj_ref ref - an object reference
+           string.) -> structure: parameter "workspace" of type "ws_name" (A
+           string used as a name for a workspace. Any string consisting of
+           alphanumeric characters and "_", ".", or "-" that is not an
+           integer is acceptable. The name may optionally be prefixed with
+           the workspace owner's user name and a colon, e.g.
+           kbasetest:my_workspace.), parameter "wsid" of type "ws_id" (The
+           unique, permanent numerical ID of a workspace.), parameter "name"
+           of type "obj_name" (A string used as a name for an object. Any
+           string consisting of alphanumeric characters and the characters
+           |._- that is not an integer is acceptable.), parameter "objid" of
+           type "obj_id" (The unique, permanent numerical ID of an object.),
+           parameter "ver" of type "obj_ver" (An object version. The version
+           of the object, starting at 1.), parameter "ref" of type "obj_ref"
+           (A string that uniquely identifies an object in the workspace
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
+           third version of an object called MyFirstObject in the workspace
+           called MyFirstWorkspace. 42/Panic/1 would identify the first
+           version of the object name Panic in workspace with id 42.
+           Towel/1/6 would identify the 6th version of the object with id 1
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.)
         :returns: instance of type "workspace_info" (Information about a
            workspace. ws_id id - the numerical ID of the workspace. ws_name
            workspace - name of the workspace. username owner - name of the
            user who owns (e.g. created) this workspace. timestamp moddate -
-           date when the workspace was last modified. int objects - the
-           number of objects created in this workspace, including objects
-           that have been deleted. permission user_permission - permissions
-           for the authenticated user of this workspace. permission
-           globalread - whether this workspace is globally readable.
-           lock_status lockstat - the status of the workspace lock. usermeta
-           metadata - arbitrary user-supplied metadata about the workspace.)
-           -> tuple of size 9: parameter "id" of type "ws_id" (The unique,
-           permanent numerical ID of a workspace.), parameter "workspace" of
-           type "ws_name" (A string used as a name for a workspace. Any
-           string consisting of alphanumeric characters and "_", ".", or "-"
-           that is not an integer is acceptable. The name may optionally be
-           prefixed with the workspace owner's user name and a colon, e.g.
+           date when the workspace was last modified. int max_objid - the
+           maximum object ID appearing in this workspace. Since cloning a
+           workspace preserves object IDs, this number may be greater than
+           the number of objects in a newly cloned workspace. permission
+           user_permission - permissions for the authenticated user of this
+           workspace. permission globalread - whether this workspace is
+           globally readable. lock_status lockstat - the status of the
+           workspace lock. usermeta metadata - arbitrary user-supplied
+           metadata about the workspace.) -> tuple of size 9: parameter "id"
+           of type "ws_id" (The unique, permanent numerical ID of a
+           workspace.), parameter "workspace" of type "ws_name" (A string
+           used as a name for a workspace. Any string consisting of
+           alphanumeric characters and "_", ".", or "-" that is not an
+           integer is acceptable. The name may optionally be prefixed with
+           the workspace owner's user name and a colon, e.g.
            kbasetest:my_workspace.), parameter "owner" of type "username"
            (Login name of a KBase user account.), parameter "moddate" of type
            "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is
            either the character Z (representing the UTC timezone) or the
            difference in time to UTC in the format +/-HHMM, eg:
            2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC
-           time) 2013-04-03T08:56:32Z (UTC time)), parameter "object" of
+           time) 2013-04-03T08:56:32Z (UTC time)), parameter "max_objid" of
            Long, parameter "user_permission" of type "permission" (Represents
            the permissions a user or users have to a workspace: 'a' -
            administrator. All operations allowed. 'w' - read/write. 'r' -
@@ -220,17 +254,15 @@ class Workspace(object):
         Lock a workspace, preventing further changes.
                 WARNING: Locking a workspace is permanent. A workspace, once locked,
                 cannot be unlocked.
-                
+
                 The only changes allowed for a locked workspace are changing user
                 based permissions or making a private workspace globally readable,
                 thus permanently publishing the workspace. A locked, globally readable
                 workspace cannot be made private.
         :param wsi: instance of type "WorkspaceIdentity" (A workspace
            identifier. Select a workspace by one, and only one, of the
-           numerical id or name, where the name can also be a KBase ID
-           including the numerical id, e.g. kb|ws.35. ws_id id - the
-           numerical ID of the workspace. ws_name workspace - name of the
-           workspace or the workspace ID in KBase format, e.g. kb|ws.78.) ->
+           numerical id or name. ws_id id - the numerical ID of the
+           workspace. ws_name workspace - the name of the workspace.) ->
            structure: parameter "workspace" of type "ws_name" (A string used
            as a name for a workspace. Any string consisting of alphanumeric
            characters and "_", ".", or "-" that is not an integer is
@@ -242,26 +274,28 @@ class Workspace(object):
            workspace. ws_id id - the numerical ID of the workspace. ws_name
            workspace - name of the workspace. username owner - name of the
            user who owns (e.g. created) this workspace. timestamp moddate -
-           date when the workspace was last modified. int objects - the
-           number of objects created in this workspace, including objects
-           that have been deleted. permission user_permission - permissions
-           for the authenticated user of this workspace. permission
-           globalread - whether this workspace is globally readable.
-           lock_status lockstat - the status of the workspace lock. usermeta
-           metadata - arbitrary user-supplied metadata about the workspace.)
-           -> tuple of size 9: parameter "id" of type "ws_id" (The unique,
-           permanent numerical ID of a workspace.), parameter "workspace" of
-           type "ws_name" (A string used as a name for a workspace. Any
-           string consisting of alphanumeric characters and "_", ".", or "-"
-           that is not an integer is acceptable. The name may optionally be
-           prefixed with the workspace owner's user name and a colon, e.g.
+           date when the workspace was last modified. int max_objid - the
+           maximum object ID appearing in this workspace. Since cloning a
+           workspace preserves object IDs, this number may be greater than
+           the number of objects in a newly cloned workspace. permission
+           user_permission - permissions for the authenticated user of this
+           workspace. permission globalread - whether this workspace is
+           globally readable. lock_status lockstat - the status of the
+           workspace lock. usermeta metadata - arbitrary user-supplied
+           metadata about the workspace.) -> tuple of size 9: parameter "id"
+           of type "ws_id" (The unique, permanent numerical ID of a
+           workspace.), parameter "workspace" of type "ws_name" (A string
+           used as a name for a workspace. Any string consisting of
+           alphanumeric characters and "_", ".", or "-" that is not an
+           integer is acceptable. The name may optionally be prefixed with
+           the workspace owner's user name and a colon, e.g.
            kbasetest:my_workspace.), parameter "owner" of type "username"
            (Login name of a KBase user account.), parameter "moddate" of type
            "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is
            either the character Z (representing the UTC timezone) or the
            difference in time to UTC in the format +/-HHMM, eg:
            2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC
-           time) 2013-04-03T08:56:32Z (UTC time)), parameter "object" of
+           time) 2013-04-03T08:56:32Z (UTC time)), parameter "max_objid" of
            Long, parameter "user_permission" of type "permission" (Represents
            the permissions a user or users have to a workspace: 'a' -
            administrator. All operations allowed. 'w' - read/write. 'r' -
@@ -282,24 +316,23 @@ class Workspace(object):
     def get_workspacemeta(self, params, context=None):
         """
         Retrieves the metadata associated with the specified workspace.
-        Provided for backwards compatibility. 
+        Provided for backwards compatibility.
         @deprecated Workspace.get_workspace_info
-        :param params: instance of type "get_workspacemeta_params" (Input
-           parameters for the "get_workspacemeta" function. Provided for
-           backwards compatibility. One, and only one of: ws_name workspace -
-           name of the workspace or the workspace ID in KBase format, e.g.
-           kb|ws.78. ws_id id - the numerical ID of the workspace. Optional
-           arguments: string auth - the authentication token of the KBase
-           account accessing the workspace. Overrides the client provided
-           authorization credentials if they exist. @deprecated
-           Workspace.WorkspaceIdentity) -> structure: parameter "workspace"
-           of type "ws_name" (A string used as a name for a workspace. Any
-           string consisting of alphanumeric characters and "_", ".", or "-"
-           that is not an integer is acceptable. The name may optionally be
-           prefixed with the workspace owner's user name and a colon, e.g.
-           kbasetest:my_workspace.), parameter "id" of type "ws_id" (The
-           unique, permanent numerical ID of a workspace.), parameter "auth"
-           of String
+        :param params: instance of type "get_workspacemeta_params"
+           (DEPRECATED Input parameters for the "get_workspacemeta" function.
+           Provided for backwards compatibility. One, and only one of:
+           ws_name workspace - name of the workspace. ws_id id - the
+           numerical ID of the workspace. Optional arguments: string auth -
+           the authentication token of the KBase account accessing the
+           workspace. Overrides the client provided authorization credentials
+           if they exist. @deprecated Workspace.WorkspaceIdentity) ->
+           structure: parameter "workspace" of type "ws_name" (A string used
+           as a name for a workspace. Any string consisting of alphanumeric
+           characters and "_", ".", or "-" that is not an integer is
+           acceptable. The name may optionally be prefixed with the workspace
+           owner's user name and a colon, e.g. kbasetest:my_workspace.),
+           parameter "id" of type "ws_id" (The unique, permanent numerical ID
+           of a workspace.), parameter "auth" of String
         :returns: instance of type "workspace_metadata" (Meta data associated
            with a workspace. Provided for backwards compatibility. To be
            replaced by workspace_info. ws_name id - name of the workspace
@@ -341,10 +374,8 @@ class Workspace(object):
         Get information associated with a workspace.
         :param wsi: instance of type "WorkspaceIdentity" (A workspace
            identifier. Select a workspace by one, and only one, of the
-           numerical id or name, where the name can also be a KBase ID
-           including the numerical id, e.g. kb|ws.35. ws_id id - the
-           numerical ID of the workspace. ws_name workspace - name of the
-           workspace or the workspace ID in KBase format, e.g. kb|ws.78.) ->
+           numerical id or name. ws_id id - the numerical ID of the
+           workspace. ws_name workspace - the name of the workspace.) ->
            structure: parameter "workspace" of type "ws_name" (A string used
            as a name for a workspace. Any string consisting of alphanumeric
            characters and "_", ".", or "-" that is not an integer is
@@ -356,26 +387,28 @@ class Workspace(object):
            workspace. ws_id id - the numerical ID of the workspace. ws_name
            workspace - name of the workspace. username owner - name of the
            user who owns (e.g. created) this workspace. timestamp moddate -
-           date when the workspace was last modified. int objects - the
-           number of objects created in this workspace, including objects
-           that have been deleted. permission user_permission - permissions
-           for the authenticated user of this workspace. permission
-           globalread - whether this workspace is globally readable.
-           lock_status lockstat - the status of the workspace lock. usermeta
-           metadata - arbitrary user-supplied metadata about the workspace.)
-           -> tuple of size 9: parameter "id" of type "ws_id" (The unique,
-           permanent numerical ID of a workspace.), parameter "workspace" of
-           type "ws_name" (A string used as a name for a workspace. Any
-           string consisting of alphanumeric characters and "_", ".", or "-"
-           that is not an integer is acceptable. The name may optionally be
-           prefixed with the workspace owner's user name and a colon, e.g.
+           date when the workspace was last modified. int max_objid - the
+           maximum object ID appearing in this workspace. Since cloning a
+           workspace preserves object IDs, this number may be greater than
+           the number of objects in a newly cloned workspace. permission
+           user_permission - permissions for the authenticated user of this
+           workspace. permission globalread - whether this workspace is
+           globally readable. lock_status lockstat - the status of the
+           workspace lock. usermeta metadata - arbitrary user-supplied
+           metadata about the workspace.) -> tuple of size 9: parameter "id"
+           of type "ws_id" (The unique, permanent numerical ID of a
+           workspace.), parameter "workspace" of type "ws_name" (A string
+           used as a name for a workspace. Any string consisting of
+           alphanumeric characters and "_", ".", or "-" that is not an
+           integer is acceptable. The name may optionally be prefixed with
+           the workspace owner's user name and a colon, e.g.
            kbasetest:my_workspace.), parameter "owner" of type "username"
            (Login name of a KBase user account.), parameter "moddate" of type
            "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is
            either the character Z (representing the UTC timezone) or the
            difference in time to UTC in the format +/-HHMM, eg:
            2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC
-           time) 2013-04-03T08:56:32Z (UTC time)), parameter "object" of
+           time) 2013-04-03T08:56:32Z (UTC time)), parameter "max_objid" of
            Long, parameter "user_permission" of type "permission" (Represents
            the permissions a user or users have to a workspace: 'a' -
            administrator. All operations allowed. 'w' - read/write. 'r' -
@@ -398,10 +431,8 @@ class Workspace(object):
         Get a workspace's description.
         :param wsi: instance of type "WorkspaceIdentity" (A workspace
            identifier. Select a workspace by one, and only one, of the
-           numerical id or name, where the name can also be a KBase ID
-           including the numerical id, e.g. kb|ws.35. ws_id id - the
-           numerical ID of the workspace. ws_name workspace - name of the
-           workspace or the workspace ID in KBase format, e.g. kb|ws.78.) ->
+           numerical id or name. ws_id id - the numerical ID of the
+           workspace. ws_name workspace - the name of the workspace.) ->
            structure: parameter "workspace" of type "ws_name" (A string used
            as a name for a workspace. Any string consisting of alphanumeric
            characters and "_", ".", or "-" that is not an integer is
@@ -421,12 +452,11 @@ class Workspace(object):
         :param params: instance of type "SetPermissionsParams" (Input
            parameters for the "set_permissions" function. One, and only one,
            of the following is required: ws_id id - the numerical ID of the
-           workspace. ws_name workspace - name of the workspace or the
-           workspace ID in KBase format, e.g. kb|ws.78. Required arguments:
-           permission new_permission - the permission to assign to the users.
-           list<username> users - the users whose permissions will be
-           altered.) -> structure: parameter "workspace" of type "ws_name" (A
-           string used as a name for a workspace. Any string consisting of
+           workspace. ws_name workspace - the name of the workspace. Required
+           arguments: permission new_permission - the permission to assign to
+           the users. list<username> users - the users whose permissions will
+           be altered.) -> structure: parameter "workspace" of type "ws_name"
+           (A string used as a name for a workspace. Any string consisting of
            alphanumeric characters and "_", ".", or "-" that is not an
            integer is acceptable. The name may optionally be prefixed with
            the workspace owner's user name and a colon, e.g.
@@ -448,22 +478,21 @@ class Workspace(object):
         :param params: instance of type "SetGlobalPermissionsParams" (Input
            parameters for the "set_global_permission" function. One, and only
            one, of the following is required: ws_id id - the numerical ID of
-           the workspace. ws_name workspace - name of the workspace or the
-           workspace ID in KBase format, e.g. kb|ws.78. Required arguments:
-           permission new_permission - the permission to assign to all users,
-           either 'n' or 'r'. 'r' means that all users will be able to read
-           the workspace; otherwise users must have specific permission to
-           access the workspace.) -> structure: parameter "workspace" of type
-           "ws_name" (A string used as a name for a workspace. Any string
-           consisting of alphanumeric characters and "_", ".", or "-" that is
-           not an integer is acceptable. The name may optionally be prefixed
-           with the workspace owner's user name and a colon, e.g.
-           kbasetest:my_workspace.), parameter "id" of type "ws_id" (The
-           unique, permanent numerical ID of a workspace.), parameter
-           "new_permission" of type "permission" (Represents the permissions
-           a user or users have to a workspace: 'a' - administrator. All
-           operations allowed. 'w' - read/write. 'r' - read. 'n' - no
-           permissions.)
+           the workspace. ws_name workspace - the name of the workspace.
+           Required arguments: permission new_permission - the permission to
+           assign to all users, either 'n' or 'r'. 'r' means that all users
+           will be able to read the workspace; otherwise users must have
+           specific permission to access the workspace.) -> structure:
+           parameter "workspace" of type "ws_name" (A string used as a name
+           for a workspace. Any string consisting of alphanumeric characters
+           and "_", ".", or "-" that is not an integer is acceptable. The
+           name may optionally be prefixed with the workspace owner's user
+           name and a colon, e.g. kbasetest:my_workspace.), parameter "id" of
+           type "ws_id" (The unique, permanent numerical ID of a workspace.),
+           parameter "new_permission" of type "permission" (Represents the
+           permissions a user or users have to a workspace: 'a' -
+           administrator. All operations allowed. 'w' - read/write. 'r' -
+           read. 'n' - no permissions.)
         """
         return self._client.call_method(
             'Workspace.set_global_permission',
@@ -475,16 +504,15 @@ class Workspace(object):
         :param params: instance of type "SetWorkspaceDescriptionParams"
            (Input parameters for the "set_workspace_description" function.
            One, and only one, of the following is required: ws_id id - the
-           numerical ID of the workspace. ws_name workspace - name of the
-           workspace or the workspace ID in KBase format, e.g. kb|ws.78.
-           Optional arguments: string description - A free-text description
-           of the workspace, 1000 characters max. Longer strings will be
-           mercilessly and brutally truncated. If omitted, the description is
-           set to null.) -> structure: parameter "workspace" of type
-           "ws_name" (A string used as a name for a workspace. Any string
-           consisting of alphanumeric characters and "_", ".", or "-" that is
-           not an integer is acceptable. The name may optionally be prefixed
-           with the workspace owner's user name and a colon, e.g.
+           numerical ID of the workspace. ws_name workspace - the name of the
+           workspace. Optional arguments: string description - A free-text
+           description of the workspace, 1000 characters max. Longer strings
+           will be mercilessly and brutally truncated. If omitted, the
+           description is set to null.) -> structure: parameter "workspace"
+           of type "ws_name" (A string used as a name for a workspace. Any
+           string consisting of alphanumeric characters and "_", ".", or "-"
+           that is not an integer is acceptable. The name may optionally be
+           prefixed with the workspace owner's user name and a colon, e.g.
            kbasetest:my_workspace.), parameter "id" of type "ws_id" (The
            unique, permanent numerical ID of a workspace.), parameter
            "description" of String
@@ -501,11 +529,9 @@ class Workspace(object):
            the workspaces for which to return the permissions, maximum 1000.)
            -> structure: parameter "workspaces" of list of type
            "WorkspaceIdentity" (A workspace identifier. Select a workspace by
-           one, and only one, of the numerical id or name, where the name can
-           also be a KBase ID including the numerical id, e.g. kb|ws.35.
-           ws_id id - the numerical ID of the workspace. ws_name workspace -
-           name of the workspace or the workspace ID in KBase format, e.g.
-           kb|ws.78.) -> structure: parameter "workspace" of type "ws_name"
+           one, and only one, of the numerical id or name. ws_id id - the
+           numerical ID of the workspace. ws_name workspace - the name of the
+           workspace.) -> structure: parameter "workspace" of type "ws_name"
            (A string used as a name for a workspace. Any string consisting of
            alphanumeric characters and "_", ".", or "-" that is not an
            integer is acceptable. The name may optionally be prefixed with
@@ -527,12 +553,11 @@ class Workspace(object):
     def get_permissions(self, wsi, context=None):
         """
         Get permissions for a workspace.
+        @deprecated get_permissions_mass
         :param wsi: instance of type "WorkspaceIdentity" (A workspace
            identifier. Select a workspace by one, and only one, of the
-           numerical id or name, where the name can also be a KBase ID
-           including the numerical id, e.g. kb|ws.35. ws_id id - the
-           numerical ID of the workspace. ws_name workspace - name of the
-           workspace or the workspace ID in KBase format, e.g. kb|ws.78.) ->
+           numerical id or name. ws_id id - the numerical ID of the
+           workspace. ws_name workspace - the name of the workspace.) ->
            structure: parameter "workspace" of type "ws_name" (A string used
            as a name for a workspace. Any string consisting of alphanumeric
            characters and "_", ".", or "-" that is not an integer is
@@ -605,22 +630,23 @@ class Workspace(object):
            the object is stored string ref - Deprecated. Always returns the
            empty string. string chsum - the md5 checksum of the object.
            usermeta metadata - arbitrary user-supplied metadata about the
-           object. obj_id objid - the numerical id of the object.) -> tuple
-           of size 12: parameter "id" of type "obj_name" (A string used as a
-           name for an object. Any string consisting of alphanumeric
-           characters and the characters |._- that is not an integer is
-           acceptable.), parameter "type" of type "type_string" (A type
-           string. Specifies the type and its version in a single string in
-           the format [module].[typename]-[major].[minor]: module - a string.
-           The module name of the typespec containing the type. typename - a
-           string. The name of the type as assigned by the typedef statement.
-           major - an integer. The major version of the type. A change in the
-           major version implies the type has changed in a non-backwards
-           compatible way. minor - an integer. The minor version of the type.
-           A change in the minor version implies that the type has changed in
-           a way that is backwards compatible with previous type definitions.
-           In many cases, the major and minor versions are optional, and if
-           not provided the most recent version will be used. Example:
+           object. obj_id objid - the numerical id of the object. @deprecated
+           object_info) -> tuple of size 12: parameter "id" of type
+           "obj_name" (A string used as a name for an object. Any string
+           consisting of alphanumeric characters and the characters |._- that
+           is not an integer is acceptable.), parameter "type" of type
+           "type_string" (A type string. Specifies the type and its version
+           in a single string in the format
+           [module].[typename]-[major].[minor]: module - a string. The module
+           name of the typespec containing the type. typename - a string. The
+           name of the type as assigned by the typedef statement. major - an
+           integer. The major version of the type. A change in the major
+           version implies the type has changed in a non-backwards compatible
+           way. minor - an integer. The minor version of the type. A change
+           in the minor version implies that the type has changed in a way
+           that is backwards compatible with previous type definitions. In
+           many cases, the major and minor versions are optional, and if not
+           provided the most recent version will be used. Example:
            MyModule.MyType-3.1), parameter "moddate" of type "timestamp" (A
            time in the format YYYY-MM-DDThh:mm:ssZ, where Z is either the
            character Z (representing the UTC timezone) or the difference in
@@ -652,33 +678,30 @@ class Workspace(object):
         :param params: instance of type "SaveObjectsParams" (Input parameters
            for the "save_objects" function. One, and only one, of the
            following is required: ws_id id - the numerical ID of the
-           workspace. ws_name workspace - name of the workspace or the
-           workspace ID in KBase format, e.g. kb|ws.78. Required arguments:
-           list<ObjectSaveData> objects - the objects to save.) -> structure:
-           parameter "workspace" of type "ws_name" (A string used as a name
-           for a workspace. Any string consisting of alphanumeric characters
-           and "_", ".", or "-" that is not an integer is acceptable. The
-           name may optionally be prefixed with the workspace owner's user
-           name and a colon, e.g. kbasetest:my_workspace.), parameter "id" of
-           type "ws_id" (The unique, permanent numerical ID of a workspace.),
-           parameter "objects" of list of type "ObjectSaveData" (An object
-           and associated data required for saving. Required arguments:
-           type_string type - the type of the object. Omit the version
-           information to use the latest version. UnspecifiedObject data -
-           the object data. Optional arguments: One of an object name or id.
-           If no name or id is provided the name will be set to 'auto' with
-           the object id appended as a string, possibly with -\d+ appended if
-           that object id already exists as a name. obj_name name - the name
-           of the object. obj_id objid - the id of the object to save over.
-           usermeta meta - arbitrary user-supplied metadata for the object,
-           not to exceed 16kb; if the object type specifies automatic
-           metadata extraction with the 'meta ws' annotation, and your
-           metadata name conflicts, then your metadata will be silently
-           overwritten. list<ProvenanceAction> provenance - provenance data
-           for the object. boolean hidden - true if this object should not be
-           listed when listing workspace objects.) -> structure: parameter
-           "type" of type "type_string" (A type string. Specifies the type
-           and its version in a single string in the format
+           workspace. ws_name workspace - the name of the workspace. Required
+           arguments: list<ObjectSaveData> objects - the objects to save.) ->
+           structure: parameter "workspace" of type "ws_name" (A string used
+           as a name for a workspace. Any string consisting of alphanumeric
+           characters and "_", ".", or "-" that is not an integer is
+           acceptable. The name may optionally be prefixed with the workspace
+           owner's user name and a colon, e.g. kbasetest:my_workspace.),
+           parameter "id" of type "ws_id" (The unique, permanent numerical ID
+           of a workspace.), parameter "objects" of list of type
+           "ObjectSaveData" (An object and associated data required for
+           saving. Required arguments: type_string type - the type of the
+           object. Omit the version information to use the latest version.
+           UnspecifiedObject data - the object data. One, and only one, of:
+           obj_name name - the name of the object. obj_id objid - the id of
+           the object to save over. Optional arguments: usermeta meta -
+           arbitrary user-supplied metadata for the object, not to exceed
+           16kb; if the object type specifies automatic metadata extraction
+           with the 'meta ws' annotation, and your metadata name conflicts,
+           then your metadata will be silently overwritten.
+           list<ProvenanceAction> provenance - provenance data for the
+           object. boolean hidden - true if this object should not be listed
+           when listing workspace objects.) -> structure: parameter "type" of
+           type "type_string" (A type string. Specifies the type and its
+           version in a single string in the format
            [module].[typename]-[major].[minor]: module - a string. The module
            name of the typespec containing the type. typename - a string. The
            name of the type as assigned by the typedef statement. major - an
@@ -723,22 +746,23 @@ class Workspace(object):
            the command line provided to the script that performed this
            action. If workspace objects were provided in the command line,
            also put the object reference in the input_ws_object list.
-           list<obj_ref> input_ws_objects - the workspace objects that were
-           used as input to this action; typically these will also be present
-           as parts of the method_params or the script_command_line
-           arguments. list<obj_ref> resolved_ws_objects - the workspace
-           objects ids from input_ws_objects resolved to permanent workspace
-           object references by the workspace service. list<string>
-           intermediate_incoming - if the previous action produced output
-           that 1) was not stored in a referrable way, and 2) is used as
-           input for this action, provide it with an arbitrary and unique ID
-           here, in the order of the input arguments to this action. These
-           IDs can be used in the method_params argument. list<string>
-           intermediate_outgoing - if this action produced output that 1) was
-           not stored in a referrable way, and 2) is used as input for the
-           next action, provide it with an arbitrary and unique ID here, in
-           the order of the output values from this action. These IDs can be
-           used in the intermediate_incoming argument in the next action.
+           list<ref_string> input_ws_objects - the workspace objects that
+           were used as input to this action; typically these will also be
+           present as parts of the method_params or the script_command_line
+           arguments. A reference path into the object graph may be supplied.
+           list<obj_ref> resolved_ws_objects - the workspace objects ids from
+           input_ws_objects resolved to permanent workspace object references
+           by the workspace service. list<string> intermediate_incoming - if
+           the previous action produced output that 1) was not stored in a
+           referrable way, and 2) is used as input for this action, provide
+           it with an arbitrary and unique ID here, in the order of the input
+           arguments to this action. These IDs can be used in the
+           method_params argument. list<string> intermediate_outgoing - if
+           this action produced output that 1) was not stored in a referrable
+           way, and 2) is used as input for the next action, provide it with
+           an arbitrary and unique ID here, in the order of the output values
+           from this action. These IDs can be used in the
+           intermediate_incoming argument in the next action.
            list<ExternalDataUnit> external_data - data external to the
            workspace that was either imported to the workspace or used to
            create a workspace object. list<SubAction> subactions - the
@@ -756,37 +780,30 @@ class Workspace(object):
            of String, parameter "method" of String, parameter "method_params"
            of list of unspecified object, parameter "script" of String,
            parameter "script_ver" of String, parameter "script_command_line"
-           of String, parameter "input_ws_objects" of list of type "obj_ref"
-           (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           of String, parameter "input_ws_objects" of list of type
+           "ref_string" (A chain of objects with references to one another as
+           a string. A single string that is semantically identical to
+           ref_chain above. Represents a path from one workspace object to
+           another through an arbitrarily number of intermediate objects
+           where each object has a dependency or provenance reference to the
+           next object. Each entry is an obj_ref as defined earlier. Entries
+           are separated by semicolons. Whitespace is ignored. Examples:
+           3/5/6; kbaseuser:myworkspace/myobject; 5/myobject/2 aworkspace/6),
+           parameter "resolved_ws_objects" of list of type "obj_ref" (A
+           string that uniquely identifies an object in the workspace
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
            third version of an object called MyFirstObject in the workspace
            called MyFirstWorkspace. 42/Panic/1 would identify the first
            version of the object name Panic in workspace with id 42.
            Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "resolved_ws_objects" of list of
-           type "obj_ref" (A string that uniquely identifies an object in the
-           workspace service. There are two ways to uniquely identify an
-           object in one string: "[ws_name or id]/[obj_name or id]/[obj_ver]"
-           - for example, "MyFirstWorkspace/MyFirstObject/3" would identify
-           the third version of an object called MyFirstObject in the
-           workspace called MyFirstWorkspace. 42/Panic/1 would identify the
-           first version of the object name Panic in workspace with id 42.
-           Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "intermediate_incoming" of list of
-           String, parameter "intermediate_outgoing" of list of String,
-           parameter "external_data" of list of type "ExternalDataUnit" (An
-           external data unit. A piece of data from a source outside the
-           Workspace. On input, only one of the resource_release_date or
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.), parameter
+           "intermediate_incoming" of list of String, parameter
+           "intermediate_outgoing" of list of String, parameter
+           "external_data" of list of type "ExternalDataUnit" (An external
+           data unit. A piece of data from a source outside the Workspace. On
+           input, only one of the resource_release_date or
            resource_release_epoch may be supplied. Both are supplied on
            output. string resource_name - the name of the resource, for
            example JGI. string resource_url - the url of the resource, for
@@ -924,29 +941,30 @@ class Workspace(object):
            Always returns the empty string. string chsum - the md5 checksum
            of the object. usermeta metadata - arbitrary user-supplied
            metadata about the object. obj_id objid - the numerical id of the
-           object.) -> tuple of size 12: parameter "id" of type "obj_name" (A
-           string used as a name for an object. Any string consisting of
-           alphanumeric characters and the characters |._- that is not an
-           integer is acceptable.), parameter "type" of type "type_string" (A
-           type string. Specifies the type and its version in a single string
-           in the format [module].[typename]-[major].[minor]: module - a
-           string. The module name of the typespec containing the type.
-           typename - a string. The name of the type as assigned by the
-           typedef statement. major - an integer. The major version of the
-           type. A change in the major version implies the type has changed
-           in a non-backwards compatible way. minor - an integer. The minor
-           version of the type. A change in the minor version implies that
-           the type has changed in a way that is backwards compatible with
-           previous type definitions. In many cases, the major and minor
-           versions are optional, and if not provided the most recent version
-           will be used. Example: MyModule.MyType-3.1), parameter "moddate"
-           of type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ,
-           where Z is either the character Z (representing the UTC timezone)
-           or the difference in time to UTC in the format +/-HHMM, eg:
-           2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC
-           time) 2013-04-03T08:56:32Z (UTC time)), parameter "instance" of
-           Long, parameter "command" of String, parameter "lastmodifier" of
-           type "username" (Login name of a KBase user account.), parameter
+           object. @deprecated object_info) -> tuple of size 12: parameter
+           "id" of type "obj_name" (A string used as a name for an object.
+           Any string consisting of alphanumeric characters and the
+           characters |._- that is not an integer is acceptable.), parameter
+           "type" of type "type_string" (A type string. Specifies the type
+           and its version in a single string in the format
+           [module].[typename]-[major].[minor]: module - a string. The module
+           name of the typespec containing the type. typename - a string. The
+           name of the type as assigned by the typedef statement. major - an
+           integer. The major version of the type. A change in the major
+           version implies the type has changed in a non-backwards compatible
+           way. minor - an integer. The minor version of the type. A change
+           in the minor version implies that the type has changed in a way
+           that is backwards compatible with previous type definitions. In
+           many cases, the major and minor versions are optional, and if not
+           provided the most recent version will be used. Example:
+           MyModule.MyType-3.1), parameter "moddate" of type "timestamp" (A
+           time in the format YYYY-MM-DDThh:mm:ssZ, where Z is either the
+           character Z (representing the UTC timezone) or the difference in
+           time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500
+           (EST time) 2013-04-03T08:56:32+0000 (UTC time)
+           2013-04-03T08:56:32Z (UTC time)), parameter "instance" of Long,
+           parameter "command" of String, parameter "lastmodifier" of type
+           "username" (Login name of a KBase user account.), parameter
            "owner" of type "username" (Login name of a KBase user account.),
            parameter "workspace" of type "ws_name" (A string used as a name
            for a workspace. Any string consisting of alphanumeric characters
@@ -970,11 +988,9 @@ class Workspace(object):
         @deprecated Workspace.get_objects2
         :param object_ids: instance of list of type "ObjectIdentity" (An
            object identifier. Select an object by either: One, and only one,
-           of the numerical id or name of the workspace, where the name can
-           also be a KBase ID including the numerical id, e.g. kb|ws.35.
-           ws_id wsid - the numerical ID of the workspace. ws_name workspace
-           - name of the workspace or the workspace ID in KBase format, e.g.
-           kb|ws.78. AND One, and only one, of the numerical id or name of
+           of the numerical id or name of the workspace. ws_id wsid - the
+           numerical ID of the workspace. ws_name workspace - the name of the
+           workspace. AND One, and only one, of the numerical id or name of
            the object. obj_id objid- the numerical ID of the object. obj_name
            name - name of the object. OPTIONALLY obj_ver ver - the version of
            the object. OR an object reference string: obj_ref ref - an object
@@ -992,18 +1008,14 @@ class Workspace(object):
            parameter "ver" of type "obj_ver" (An object version. The version
            of the object, starting at 1.), parameter "ref" of type "obj_ref"
            (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
            third version of an object called MyFirstObject in the workspace
            called MyFirstWorkspace. 42/Panic/1 would identify the first
            version of the object name Panic in workspace with id 42.
            Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.)
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.)
         :returns: instance of list of type "ObjectProvenanceInfo" (DEPRECATED
            The provenance and supplemental info for an object. object_info
            info - information about the object. list<ProvenanceAction>
@@ -1093,12 +1105,13 @@ class Workspace(object):
            script_command_line - the command line provided to the script that
            performed this action. If workspace objects were provided in the
            command line, also put the object reference in the input_ws_object
-           list. list<obj_ref> input_ws_objects - the workspace objects that
-           were used as input to this action; typically these will also be
-           present as parts of the method_params or the script_command_line
-           arguments. list<obj_ref> resolved_ws_objects - the workspace
-           objects ids from input_ws_objects resolved to permanent workspace
-           object references by the workspace service. list<string>
+           list. list<ref_string> input_ws_objects - the workspace objects
+           that were used as input to this action; typically these will also
+           be present as parts of the method_params or the
+           script_command_line arguments. A reference path into the object
+           graph may be supplied. list<obj_ref> resolved_ws_objects - the
+           workspace objects ids from input_ws_objects resolved to permanent
+           workspace object references by the workspace service. list<string>
            intermediate_incoming - if the previous action produced output
            that 1) was not stored in a referrable way, and 2) is used as
            input for this action, provide it with an arbitrary and unique ID
@@ -1126,37 +1139,30 @@ class Workspace(object):
            of String, parameter "method" of String, parameter "method_params"
            of list of unspecified object, parameter "script" of String,
            parameter "script_ver" of String, parameter "script_command_line"
-           of String, parameter "input_ws_objects" of list of type "obj_ref"
-           (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           of String, parameter "input_ws_objects" of list of type
+           "ref_string" (A chain of objects with references to one another as
+           a string. A single string that is semantically identical to
+           ref_chain above. Represents a path from one workspace object to
+           another through an arbitrarily number of intermediate objects
+           where each object has a dependency or provenance reference to the
+           next object. Each entry is an obj_ref as defined earlier. Entries
+           are separated by semicolons. Whitespace is ignored. Examples:
+           3/5/6; kbaseuser:myworkspace/myobject; 5/myobject/2 aworkspace/6),
+           parameter "resolved_ws_objects" of list of type "obj_ref" (A
+           string that uniquely identifies an object in the workspace
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
            third version of an object called MyFirstObject in the workspace
            called MyFirstWorkspace. 42/Panic/1 would identify the first
            version of the object name Panic in workspace with id 42.
            Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "resolved_ws_objects" of list of
-           type "obj_ref" (A string that uniquely identifies an object in the
-           workspace service. There are two ways to uniquely identify an
-           object in one string: "[ws_name or id]/[obj_name or id]/[obj_ver]"
-           - for example, "MyFirstWorkspace/MyFirstObject/3" would identify
-           the third version of an object called MyFirstObject in the
-           workspace called MyFirstWorkspace. 42/Panic/1 would identify the
-           first version of the object name Panic in workspace with id 42.
-           Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "intermediate_incoming" of list of
-           String, parameter "intermediate_outgoing" of list of String,
-           parameter "external_data" of list of type "ExternalDataUnit" (An
-           external data unit. A piece of data from a source outside the
-           Workspace. On input, only one of the resource_release_date or
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.), parameter
+           "intermediate_incoming" of list of String, parameter
+           "intermediate_outgoing" of list of String, parameter
+           "external_data" of list of type "ExternalDataUnit" (An external
+           data unit. A piece of data from a source outside the Workspace. On
+           input, only one of the resource_release_date or
            resource_release_epoch may be supplied. Both are supplied on
            output. string resource_name - the name of the resource, for
            example JGI. string resource_url - the url of the resource, for
@@ -1211,37 +1217,30 @@ class Workspace(object):
            time)), parameter "epoch" of type "epoch" (A Unix epoch (the time
            since 00:00:00 1/1/1970 UTC) in milliseconds.), parameter "refs"
            of list of type "obj_ref" (A string that uniquely identifies an
-           object in the workspace service. There are two ways to uniquely
-           identify an object in one string: "[ws_name or id]/[obj_name or
-           id]/[obj_ver]" - for example, "MyFirstWorkspace/MyFirstObject/3"
-           would identify the third version of an object called MyFirstObject
-           in the workspace called MyFirstWorkspace. 42/Panic/1 would
-           identify the first version of the object name Panic in workspace
-           with id 42. Towel/1/6 would identify the 6th version of the object
-           with id 1 in the Towel workspace.
-           "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]" - for example,
-           "kb|ws.23.obj.567.ver.2" would identify the second version of an
-           object with id 567 in a workspace with id 23. In all cases, if the
-           version number is omitted, the latest version of the object is
-           assumed.), parameter "copied" of type "obj_ref" (A string that
-           uniquely identifies an object in the workspace service. There are
-           two ways to uniquely identify an object in one string: "[ws_name
-           or id]/[obj_name or id]/[obj_ver]" - for example,
-           "MyFirstWorkspace/MyFirstObject/3" would identify the third
-           version of an object called MyFirstObject in the workspace called
+           object in the workspace service. The format is [ws_name or
+           id]/[obj_name or id]/[obj_ver]. For example,
+           MyFirstWorkspace/MyFirstObject/3 would identify the third version
+           of an object called MyFirstObject in the workspace called
            MyFirstWorkspace. 42/Panic/1 would identify the first version of
            the object name Panic in workspace with id 42. Towel/1/6 would
            identify the 6th version of the object with id 1 in the Towel
-           workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]" - for
-           example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "copy_source_inaccessible" of type
-           "boolean" (A boolean. 0 = false, other = true.), parameter
-           "extracted_ids" of mapping from type "id_type" (An id type (e.g.
-           from a typespec @id annotation: @id [idtype])) to list of type
-           "extracted_id" (An id extracted from an object.), parameter
-           "handle_error" of String, parameter "handle_stacktrace" of String
+           workspace.If the version number is omitted, the latest version of
+           the object is assumed.), parameter "copied" of type "obj_ref" (A
+           string that uniquely identifies an object in the workspace
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
+           third version of an object called MyFirstObject in the workspace
+           called MyFirstWorkspace. 42/Panic/1 would identify the first
+           version of the object name Panic in workspace with id 42.
+           Towel/1/6 would identify the 6th version of the object with id 1
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.), parameter
+           "copy_source_inaccessible" of type "boolean" (A boolean. 0 =
+           false, other = true.), parameter "extracted_ids" of mapping from
+           type "id_type" (An id type (e.g. from a typespec @id annotation:
+           @id [idtype])) to list of type "extracted_id" (An id extracted
+           from an object.), parameter "handle_error" of String, parameter
+           "handle_stacktrace" of String
         """
         return self._client.call_method(
             'Workspace.get_object_provenance',
@@ -1254,11 +1253,9 @@ class Workspace(object):
         @deprecated Workspace.get_objects2
         :param object_ids: instance of list of type "ObjectIdentity" (An
            object identifier. Select an object by either: One, and only one,
-           of the numerical id or name of the workspace, where the name can
-           also be a KBase ID including the numerical id, e.g. kb|ws.35.
-           ws_id wsid - the numerical ID of the workspace. ws_name workspace
-           - name of the workspace or the workspace ID in KBase format, e.g.
-           kb|ws.78. AND One, and only one, of the numerical id or name of
+           of the numerical id or name of the workspace. ws_id wsid - the
+           numerical ID of the workspace. ws_name workspace - the name of the
+           workspace. AND One, and only one, of the numerical id or name of
            the object. obj_id objid- the numerical ID of the object. obj_name
            name - name of the object. OPTIONALLY obj_ver ver - the version of
            the object. OR an object reference string: obj_ref ref - an object
@@ -1276,29 +1273,27 @@ class Workspace(object):
            parameter "ver" of type "obj_ver" (An object version. The version
            of the object, starting at 1.), parameter "ref" of type "obj_ref"
            (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
            third version of an object called MyFirstObject in the workspace
            called MyFirstWorkspace. 42/Panic/1 would identify the first
            version of the object name Panic in workspace with id 42.
            Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.)
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.)
         :returns: instance of list of type "ObjectData" (The data and
            supplemental info for an object. UnspecifiedObject data - the
            object's data or subset data. object_info info - information about
-           the object. list<ProvenanceAction> provenance - the object's
+           the object. list<obj_ref> path - the path to the object through
+           the object reference graph. All the references in the path are
+           absolute. list<ProvenanceAction> provenance - the object's
            provenance. username creator - the user that first saved the
            object to the workspace. ws_id orig_wsid - the id of the workspace
            in which this object was originally saved. Missing for objects
            saved prior to version 0.4.1. timestamp created - the date the
            object was first saved to the workspace. epoch epoch - the date
-           the object was first saved to the workspace. list<obj_ref> - the
-           references contained within the object. obj_ref copied - the
+           the object was first saved to the workspace. list<obj_ref> refs -
+           the references contained within the object. obj_ref copied - the
            reference of the source object if this object is a copy and the
            copy source exists and is accessible. null otherwise. boolean
            copy_source_inaccessible - true if the object was copied from
@@ -1351,97 +1346,101 @@ class Workspace(object):
            kbasetest:my_workspace.), parameter "chsum" of String, parameter
            "size" of Long, parameter "meta" of type "usermeta" (User provided
            metadata about an object. Arbitrary key-value pairs provided by
-           the user.) -> mapping from String to String, parameter
-           "provenance" of list of type "ProvenanceAction" (A provenance
-           action. A provenance action (PA) is an action taken while
-           transforming one data object to another. There may be several PAs
-           taken in series. A PA is typically running a script, running an
-           api command, etc. All of the following fields are optional, but
-           more information provided equates to better data provenance.
-           resolved_ws_objects should never be set by the user; it is set by
-           the workspace service when returning data. On input, only one of
-           the time or epoch may be supplied. Both are supplied on output.
-           The maximum size of the entire provenance object, including all
-           actions, is 1MB. timestamp time - the time the action was started
-           epoch epoch - the time the action was started. string caller - the
-           name or id of the invoker of this provenance action. In most
-           cases, this will be the same for all PAs. string service - the
-           name of the service that performed this action. string service_ver
-           - the version of the service that performed this action. string
-           method - the method of the service that performed this action.
-           list<UnspecifiedObject> method_params - the parameters of the
-           method that performed this action. If an object in the parameters
-           is a workspace object, also put the object reference in the
-           input_ws_object list. string script - the name of the script that
-           performed this action. string script_ver - the version of the
-           script that performed this action. string script_command_line -
-           the command line provided to the script that performed this
-           action. If workspace objects were provided in the command line,
-           also put the object reference in the input_ws_object list.
-           list<obj_ref> input_ws_objects - the workspace objects that were
-           used as input to this action; typically these will also be present
-           as parts of the method_params or the script_command_line
-           arguments. list<obj_ref> resolved_ws_objects - the workspace
-           objects ids from input_ws_objects resolved to permanent workspace
-           object references by the workspace service. list<string>
-           intermediate_incoming - if the previous action produced output
-           that 1) was not stored in a referrable way, and 2) is used as
-           input for this action, provide it with an arbitrary and unique ID
-           here, in the order of the input arguments to this action. These
-           IDs can be used in the method_params argument. list<string>
-           intermediate_outgoing - if this action produced output that 1) was
-           not stored in a referrable way, and 2) is used as input for the
-           next action, provide it with an arbitrary and unique ID here, in
-           the order of the output values from this action. These IDs can be
-           used in the intermediate_incoming argument in the next action.
-           list<ExternalDataUnit> external_data - data external to the
-           workspace that was either imported to the workspace or used to
-           create a workspace object. list<SubAction> subactions - the
-           subactions taken as a part of this action. mapping<string, string>
-           custom - user definable custom provenance fields and their values.
-           string description - a free text description of this action.) ->
-           structure: parameter "time" of type "timestamp" (A time in the
-           format YYYY-MM-DDThh:mm:ssZ, where Z is either the character Z
-           (representing the UTC timezone) or the difference in time to UTC
-           in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time)
-           2013-04-03T08:56:32+0000 (UTC time) 2013-04-03T08:56:32Z (UTC
-           time)), parameter "epoch" of type "epoch" (A Unix epoch (the time
-           since 00:00:00 1/1/1970 UTC) in milliseconds.), parameter "caller"
-           of String, parameter "service" of String, parameter "service_ver"
-           of String, parameter "method" of String, parameter "method_params"
-           of list of unspecified object, parameter "script" of String,
-           parameter "script_ver" of String, parameter "script_command_line"
-           of String, parameter "input_ws_objects" of list of type "obj_ref"
-           (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           the user.) -> mapping from String to String, parameter "path" of
+           list of type "obj_ref" (A string that uniquely identifies an
+           object in the workspace service. The format is [ws_name or
+           id]/[obj_name or id]/[obj_ver]. For example,
+           MyFirstWorkspace/MyFirstObject/3 would identify the third version
+           of an object called MyFirstObject in the workspace called
+           MyFirstWorkspace. 42/Panic/1 would identify the first version of
+           the object name Panic in workspace with id 42. Towel/1/6 would
+           identify the 6th version of the object with id 1 in the Towel
+           workspace.If the version number is omitted, the latest version of
+           the object is assumed.), parameter "provenance" of list of type
+           "ProvenanceAction" (A provenance action. A provenance action (PA)
+           is an action taken while transforming one data object to another.
+           There may be several PAs taken in series. A PA is typically
+           running a script, running an api command, etc. All of the
+           following fields are optional, but more information provided
+           equates to better data provenance. resolved_ws_objects should
+           never be set by the user; it is set by the workspace service when
+           returning data. On input, only one of the time or epoch may be
+           supplied. Both are supplied on output. The maximum size of the
+           entire provenance object, including all actions, is 1MB. timestamp
+           time - the time the action was started epoch epoch - the time the
+           action was started. string caller - the name or id of the invoker
+           of this provenance action. In most cases, this will be the same
+           for all PAs. string service - the name of the service that
+           performed this action. string service_ver - the version of the
+           service that performed this action. string method - the method of
+           the service that performed this action. list<UnspecifiedObject>
+           method_params - the parameters of the method that performed this
+           action. If an object in the parameters is a workspace object, also
+           put the object reference in the input_ws_object list. string
+           script - the name of the script that performed this action. string
+           script_ver - the version of the script that performed this action.
+           string script_command_line - the command line provided to the
+           script that performed this action. If workspace objects were
+           provided in the command line, also put the object reference in the
+           input_ws_object list. list<ref_string> input_ws_objects - the
+           workspace objects that were used as input to this action;
+           typically these will also be present as parts of the method_params
+           or the script_command_line arguments. A reference path into the
+           object graph may be supplied. list<obj_ref> resolved_ws_objects -
+           the workspace objects ids from input_ws_objects resolved to
+           permanent workspace object references by the workspace service.
+           list<string> intermediate_incoming - if the previous action
+           produced output that 1) was not stored in a referrable way, and 2)
+           is used as input for this action, provide it with an arbitrary and
+           unique ID here, in the order of the input arguments to this
+           action. These IDs can be used in the method_params argument.
+           list<string> intermediate_outgoing - if this action produced
+           output that 1) was not stored in a referrable way, and 2) is used
+           as input for the next action, provide it with an arbitrary and
+           unique ID here, in the order of the output values from this
+           action. These IDs can be used in the intermediate_incoming
+           argument in the next action. list<ExternalDataUnit> external_data
+           - data external to the workspace that was either imported to the
+           workspace or used to create a workspace object. list<SubAction>
+           subactions - the subactions taken as a part of this action.
+           mapping<string, string> custom - user definable custom provenance
+           fields and their values. string description - a free text
+           description of this action.) -> structure: parameter "time" of
+           type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where
+           Z is either the character Z (representing the UTC timezone) or the
+           difference in time to UTC in the format +/-HHMM, eg:
+           2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC
+           time) 2013-04-03T08:56:32Z (UTC time)), parameter "epoch" of type
+           "epoch" (A Unix epoch (the time since 00:00:00 1/1/1970 UTC) in
+           milliseconds.), parameter "caller" of String, parameter "service"
+           of String, parameter "service_ver" of String, parameter "method"
+           of String, parameter "method_params" of list of unspecified
+           object, parameter "script" of String, parameter "script_ver" of
+           String, parameter "script_command_line" of String, parameter
+           "input_ws_objects" of list of type "ref_string" (A chain of
+           objects with references to one another as a string. A single
+           string that is semantically identical to ref_chain above.
+           Represents a path from one workspace object to another through an
+           arbitrarily number of intermediate objects where each object has a
+           dependency or provenance reference to the next object. Each entry
+           is an obj_ref as defined earlier. Entries are separated by
+           semicolons. Whitespace is ignored. Examples: 3/5/6;
+           kbaseuser:myworkspace/myobject; 5/myobject/2 aworkspace/6),
+           parameter "resolved_ws_objects" of list of type "obj_ref" (A
+           string that uniquely identifies an object in the workspace
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
            third version of an object called MyFirstObject in the workspace
            called MyFirstWorkspace. 42/Panic/1 would identify the first
            version of the object name Panic in workspace with id 42.
            Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "resolved_ws_objects" of list of
-           type "obj_ref" (A string that uniquely identifies an object in the
-           workspace service. There are two ways to uniquely identify an
-           object in one string: "[ws_name or id]/[obj_name or id]/[obj_ver]"
-           - for example, "MyFirstWorkspace/MyFirstObject/3" would identify
-           the third version of an object called MyFirstObject in the
-           workspace called MyFirstWorkspace. 42/Panic/1 would identify the
-           first version of the object name Panic in workspace with id 42.
-           Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "intermediate_incoming" of list of
-           String, parameter "intermediate_outgoing" of list of String,
-           parameter "external_data" of list of type "ExternalDataUnit" (An
-           external data unit. A piece of data from a source outside the
-           Workspace. On input, only one of the resource_release_date or
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.), parameter
+           "intermediate_incoming" of list of String, parameter
+           "intermediate_outgoing" of list of String, parameter
+           "external_data" of list of type "ExternalDataUnit" (An external
+           data unit. A piece of data from a source outside the Workspace. On
+           input, only one of the resource_release_date or
            resource_release_epoch may be supplied. Both are supplied on
            output. string resource_name - the name of the resource, for
            example JGI. string resource_url - the url of the resource, for
@@ -1496,37 +1495,30 @@ class Workspace(object):
            time)), parameter "epoch" of type "epoch" (A Unix epoch (the time
            since 00:00:00 1/1/1970 UTC) in milliseconds.), parameter "refs"
            of list of type "obj_ref" (A string that uniquely identifies an
-           object in the workspace service. There are two ways to uniquely
-           identify an object in one string: "[ws_name or id]/[obj_name or
-           id]/[obj_ver]" - for example, "MyFirstWorkspace/MyFirstObject/3"
-           would identify the third version of an object called MyFirstObject
-           in the workspace called MyFirstWorkspace. 42/Panic/1 would
-           identify the first version of the object name Panic in workspace
-           with id 42. Towel/1/6 would identify the 6th version of the object
-           with id 1 in the Towel workspace.
-           "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]" - for example,
-           "kb|ws.23.obj.567.ver.2" would identify the second version of an
-           object with id 567 in a workspace with id 23. In all cases, if the
-           version number is omitted, the latest version of the object is
-           assumed.), parameter "copied" of type "obj_ref" (A string that
-           uniquely identifies an object in the workspace service. There are
-           two ways to uniquely identify an object in one string: "[ws_name
-           or id]/[obj_name or id]/[obj_ver]" - for example,
-           "MyFirstWorkspace/MyFirstObject/3" would identify the third
-           version of an object called MyFirstObject in the workspace called
+           object in the workspace service. The format is [ws_name or
+           id]/[obj_name or id]/[obj_ver]. For example,
+           MyFirstWorkspace/MyFirstObject/3 would identify the third version
+           of an object called MyFirstObject in the workspace called
            MyFirstWorkspace. 42/Panic/1 would identify the first version of
            the object name Panic in workspace with id 42. Towel/1/6 would
            identify the 6th version of the object with id 1 in the Towel
-           workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]" - for
-           example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "copy_source_inaccessible" of type
-           "boolean" (A boolean. 0 = false, other = true.), parameter
-           "extracted_ids" of mapping from type "id_type" (An id type (e.g.
-           from a typespec @id annotation: @id [idtype])) to list of type
-           "extracted_id" (An id extracted from an object.), parameter
-           "handle_error" of String, parameter "handle_stacktrace" of String
+           workspace.If the version number is omitted, the latest version of
+           the object is assumed.), parameter "copied" of type "obj_ref" (A
+           string that uniquely identifies an object in the workspace
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
+           third version of an object called MyFirstObject in the workspace
+           called MyFirstWorkspace. 42/Panic/1 would identify the first
+           version of the object name Panic in workspace with id 42.
+           Towel/1/6 would identify the 6th version of the object with id 1
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.), parameter
+           "copy_source_inaccessible" of type "boolean" (A boolean. 0 =
+           false, other = true.), parameter "extracted_ids" of mapping from
+           type "id_type" (An id type (e.g. from a typespec @id annotation:
+           @id [idtype])) to list of type "extracted_id" (An id extracted
+           from an object.), parameter "handle_error" of String, parameter
+           "handle_stacktrace" of String
         """
         return self._client.call_method(
             'Workspace.get_objects',
@@ -1546,38 +1538,63 @@ class Workspace(object):
            references, and object_info for this object without the object
            data. Default false.) -> structure: parameter "objects" of list of
            type "ObjectSpecification" (An Object Specification (OS). Inherits
-           from ObjectIdentity. Specifies which object, and which parts of
-           that object, to retrieve from the Workspace Service. The fields
-           wsid, workspace, objid, name, ver, and ref are identical to the
-           ObjectIdentity fields. REFERENCE FOLLOWING: Reference following
-           guarantees that a user that has access to an object can always see
-           a) objects that are referenced inside the object and b) objects
-           that are referenced in the object's provenance. This ensures that
-           the user has visibility into the entire provenance of the object
-           and the object's object dependencies (e.g. references). The user
-           must have at least read access to the object specified in this SO,
-           but need not have access to any further objects in the reference
-           chain, and those objects may be deleted. Optional reference
-           following fields: ref_chain obj_path - a path to the desired
-           object from the object specified in this OS. In other words, the
-           object specified in this OS is assumed to be accessible to the
-           user, and the objects in the object path represent a chain of
-           references to the desired object at the end of the object path. If
-           the references are all valid, the desired object will be returned.
-           - OR - list<obj_ref> obj_ref_path - shorthand for the obj_path.
-           Only one of obj_path or obj_ref_path may be specified. OBJECT
-           SUBSETS: When selecting a subset of an array in an object, the
-           returned array is compressed to the size of the subset, but the
-           ordering of the array is maintained. For example, if the array
-           stored at the 'feature' key of a Genome object has 4000 entries,
-           and the object paths provided are: /feature/7 /feature/3015
-           /feature/700 The returned feature array will be of length three
-           and the entries will consist, in order, of the 7th, 700th, and
-           3015th entries of the original array. Optional object subset
-           fields: list<object_path> included - the portions of the object to
-           include in the object subset. boolean strict_maps - if true, throw
-           an exception if the subset specification traverses a non-existant
-           map key (default false) boolean strict_arrays - if true, throw an
+           from ObjectIdentity (OI). Specifies which object, and which parts
+           of that object, to retrieve from the Workspace Service. The fields
+           wsid, workspace, objid, name, and ver are identical to the OI
+           fields. The ref field's behavior is extended from OI. It maintains
+           its previous behavior, but now also can act as a reference string.
+           See reference following below for more information. REFERENCE
+           FOLLOWING: Reference following guarantees that a user that has
+           access to an object can always see a) objects that are referenced
+           inside the object and b) objects that are referenced in the
+           object's provenance. This ensures that the user has visibility
+           into the entire provenance of the object and the object's object
+           dependencies (e.g. references). The user must have at least read
+           access to the object specified in this SO, but need not have
+           access to any further objects in the reference chain, and those
+           objects may be deleted. Optional reference following fields: Note
+           that only one of the following fields may be specified. ref_chain
+           obj_path - a path to the desired object from the object specified
+           in this OS. In other words, the object specified in this OS is
+           assumed to be accessible to the user, and the objects in the
+           object path represent a chain of references to the desired object
+           at the end of the object path. If the references are all valid,
+           the desired object will be returned. - OR - list<obj_ref>
+           obj_ref_path - shorthand for the obj_path. - OR - ref_chain
+           to_obj_path - identical to obj_path, except that the path is TO
+           the object specified in this OS, rather than from the object. In
+           other words the object specified by wsid/objid/ref etc. is the end
+           of the path, and to_obj_path is the rest of the path. The user
+           must have access to the first object in the to_obj_path. - OR -
+           list<obj_ref> to_obj_ref_path - shorthand for the to_obj_path. -
+           OR - ref_string ref - A string representing a reference path from
+           one object to another. Unlike the previous reference following
+           options, the ref_string represents the ENTIRE path from the source
+           object to the target object. As with the OI object, the ref field
+           may contain a single reference. - OR - boolean find_refence_path -
+           This is the last, slowest, and most expensive resort for getting a
+           referenced object - do not use this method unless the path to the
+           object is unavailable by any other means. Setting the
+           find_refence_path parameter to true means that the workspace
+           service will search through the object reference graph from the
+           object specified in this OS to find an object that 1) the user can
+           access, and 2) has an unbroken reference path to the target
+           object. If the search succeeds, the object will be returned as
+           normal. Note that the search will automatically fail after a
+           certain (but much larger than necessary for the vast majority of
+           cases) number of objects are traversed. OBJECT SUBSETS: When
+           selecting a subset of an array in an object, the returned array is
+           compressed to the size of the subset, but the ordering of the
+           array is maintained. For example, if the array stored at the
+           'feature' key of a Genome object has 4000 entries, and the object
+           paths provided are: /feature/7 /feature/3015 /feature/700 The
+           returned feature array will be of length three and the entries
+           will consist, in order, of the 7th, 700th, and 3015th entries of
+           the original array. Optional object subset fields:
+           list<object_path> included - the portions of the object to include
+           in the object subset. boolean strict_maps - if true, throw an
+           exception if the subset specification traverses a non-existent map
+           key (default false) boolean strict_arrays - if true, throw an
            exception if the subset specification exceeds the size of an array
            (default true)) -> structure: parameter "workspace" of type
            "ws_name" (A string used as a name for a workspace. Any string
@@ -1591,31 +1608,68 @@ class Workspace(object):
            |._- that is not an integer is acceptable.), parameter "objid" of
            type "obj_id" (The unique, permanent numerical ID of an object.),
            parameter "ver" of type "obj_ver" (An object version. The version
+           of the object, starting at 1.), parameter "ref" of type
+           "ref_string" (A chain of objects with references to one another as
+           a string. A single string that is semantically identical to
+           ref_chain above. Represents a path from one workspace object to
+           another through an arbitrarily number of intermediate objects
+           where each object has a dependency or provenance reference to the
+           next object. Each entry is an obj_ref as defined earlier. Entries
+           are separated by semicolons. Whitespace is ignored. Examples:
+           3/5/6; kbaseuser:myworkspace/myobject; 5/myobject/2 aworkspace/6),
+           parameter "obj_path" of type "ref_chain" (A chain of objects with
+           references to one another. An object reference chain consists of a
+           list of objects where the nth object possesses a reference, either
+           in the object itself or in the object provenance, to the n+1th
+           object.) -> list of type "ObjectIdentity" (An object identifier.
+           Select an object by either: One, and only one, of the numerical id
+           or name of the workspace. ws_id wsid - the numerical ID of the
+           workspace. ws_name workspace - the name of the workspace. AND One,
+           and only one, of the numerical id or name of the object. obj_id
+           objid- the numerical ID of the object. obj_name name - name of the
+           object. OPTIONALLY obj_ver ver - the version of the object. OR an
+           object reference string: obj_ref ref - an object reference
+           string.) -> structure: parameter "workspace" of type "ws_name" (A
+           string used as a name for a workspace. Any string consisting of
+           alphanumeric characters and "_", ".", or "-" that is not an
+           integer is acceptable. The name may optionally be prefixed with
+           the workspace owner's user name and a colon, e.g.
+           kbasetest:my_workspace.), parameter "wsid" of type "ws_id" (The
+           unique, permanent numerical ID of a workspace.), parameter "name"
+           of type "obj_name" (A string used as a name for an object. Any
+           string consisting of alphanumeric characters and the characters
+           |._- that is not an integer is acceptable.), parameter "objid" of
+           type "obj_id" (The unique, permanent numerical ID of an object.),
+           parameter "ver" of type "obj_ver" (An object version. The version
            of the object, starting at 1.), parameter "ref" of type "obj_ref"
            (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
            third version of an object called MyFirstObject in the workspace
            called MyFirstWorkspace. 42/Panic/1 would identify the first
            version of the object name Panic in workspace with id 42.
            Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "obj_path" of type "ref_chain" (A
-           chain of objects with references to one another. An object
-           reference chain consists of a list of objects where the nth object
-           possesses a reference, either in the object itself or in the
-           object provenance, to the n+1th object.) -> list of type
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.), parameter
+           "obj_ref_path" of list of type "obj_ref" (A string that uniquely
+           identifies an object in the workspace service. The format is
+           [ws_name or id]/[obj_name or id]/[obj_ver]. For example,
+           MyFirstWorkspace/MyFirstObject/3 would identify the third version
+           of an object called MyFirstObject in the workspace called
+           MyFirstWorkspace. 42/Panic/1 would identify the first version of
+           the object name Panic in workspace with id 42. Towel/1/6 would
+           identify the 6th version of the object with id 1 in the Towel
+           workspace.If the version number is omitted, the latest version of
+           the object is assumed.), parameter "to_obj_path" of type
+           "ref_chain" (A chain of objects with references to one another. An
+           object reference chain consists of a list of objects where the nth
+           object possesses a reference, either in the object itself or in
+           the object provenance, to the n+1th object.) -> list of type
            "ObjectIdentity" (An object identifier. Select an object by
            either: One, and only one, of the numerical id or name of the
-           workspace, where the name can also be a KBase ID including the
-           numerical id, e.g. kb|ws.35. ws_id wsid - the numerical ID of the
-           workspace. ws_name workspace - name of the workspace or the
-           workspace ID in KBase format, e.g. kb|ws.78. AND One, and only
-           one, of the numerical id or name of the object. obj_id objid- the
+           workspace. ws_id wsid - the numerical ID of the workspace. ws_name
+           workspace - the name of the workspace. AND One, and only one, of
+           the numerical id or name of the object. obj_id objid- the
            numerical ID of the object. obj_name name - name of the object.
            OPTIONALLY obj_ver ver - the version of the object. OR an object
            reference string: obj_ref ref - an object reference string.) ->
@@ -1632,62 +1686,58 @@ class Workspace(object):
            unique, permanent numerical ID of an object.), parameter "ver" of
            type "obj_ver" (An object version. The version of the object,
            starting at 1.), parameter "ref" of type "obj_ref" (A string that
-           uniquely identifies an object in the workspace service. There are
-           two ways to uniquely identify an object in one string: "[ws_name
-           or id]/[obj_name or id]/[obj_ver]" - for example,
-           "MyFirstWorkspace/MyFirstObject/3" would identify the third
-           version of an object called MyFirstObject in the workspace called
+           uniquely identifies an object in the workspace service. The format
+           is [ws_name or id]/[obj_name or id]/[obj_ver]. For example,
+           MyFirstWorkspace/MyFirstObject/3 would identify the third version
+           of an object called MyFirstObject in the workspace called
            MyFirstWorkspace. 42/Panic/1 would identify the first version of
            the object name Panic in workspace with id 42. Towel/1/6 would
            identify the 6th version of the object with id 1 in the Towel
-           workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]" - for
-           example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "obj_ref_path" of list of type
-           "obj_ref" (A string that uniquely identifies an object in the
-           workspace service. There are two ways to uniquely identify an
-           object in one string: "[ws_name or id]/[obj_name or id]/[obj_ver]"
-           - for example, "MyFirstWorkspace/MyFirstObject/3" would identify
-           the third version of an object called MyFirstObject in the
-           workspace called MyFirstWorkspace. 42/Panic/1 would identify the
-           first version of the object name Panic in workspace with id 42.
-           Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "included" of list of type
-           "object_path" (A path into an object. Identify a sub portion of an
-           object by providing the path, delimited by a slash (/), to that
-           portion of the object. Thus the path may not have slashes in the
-           structure or mapping keys. Examples: /foo/bar/3 - specifies the
-           bar key of the foo mapping and the 3rd entry of the array if bar
-           maps to an array or the value mapped to the string "3" if bar maps
-           to a map. /foo/bar/[*]/baz - specifies the baz field of all the
-           objects in the list mapped by the bar key in the map foo.
-           /foo/asterisk/baz - specifies the baz field of all the objects in
-           the values of the foo mapping. Swap 'asterisk' for * in the path.
-           In case you need to use '/' or '~' in path items use JSON Pointer
-           notation defined here: http://tools.ietf.org/html/rfc6901),
-           parameter "strict_maps" of type "boolean" (A boolean. 0 = false,
-           other = true.), parameter "strict_arrays" of type "boolean" (A
-           boolean. 0 = false, other = true.), parameter "ignoreErrors" of
-           type "boolean" (A boolean. 0 = false, other = true.), parameter
-           "no_data" of type "boolean" (A boolean. 0 = false, other = true.)
+           workspace.If the version number is omitted, the latest version of
+           the object is assumed.), parameter "to_obj_ref_path" of list of
+           type "obj_ref" (A string that uniquely identifies an object in the
+           workspace service. The format is [ws_name or id]/[obj_name or
+           id]/[obj_ver]. For example, MyFirstWorkspace/MyFirstObject/3 would
+           identify the third version of an object called MyFirstObject in
+           the workspace called MyFirstWorkspace. 42/Panic/1 would identify
+           the first version of the object name Panic in workspace with id
+           42. Towel/1/6 would identify the 6th version of the object with id
+           1 in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.), parameter
+           "find_reference_path" of type "boolean" (A boolean. 0 = false,
+           other = true.), parameter "included" of list of type "object_path"
+           (A path into an object. Identify a sub portion of an object by
+           providing the path, delimited by a slash (/), to that portion of
+           the object. Thus the path may not have slashes in the structure or
+           mapping keys. Examples: /foo/bar/3 - specifies the bar key of the
+           foo mapping and the 3rd entry of the array if bar maps to an array
+           or the value mapped to the string "3" if bar maps to a map.
+           /foo/bar/[*]/baz - specifies the baz field of all the objects in
+           the list mapped by the bar key in the map foo. /foo/asterisk/baz -
+           specifies the baz field of all the objects in the values of the
+           foo mapping. Swap 'asterisk' for * in the path. In case you need
+           to use '/' or '~' in path items use JSON Pointer notation defined
+           here: http://tools.ietf.org/html/rfc6901), parameter "strict_maps"
+           of type "boolean" (A boolean. 0 = false, other = true.), parameter
+           "strict_arrays" of type "boolean" (A boolean. 0 = false, other =
+           true.), parameter "ignoreErrors" of type "boolean" (A boolean. 0 =
+           false, other = true.), parameter "no_data" of type "boolean" (A
+           boolean. 0 = false, other = true.)
         :returns: instance of type "GetObjects2Results" (Results from the
            get_objects2 function. list<ObjectData> data - the returned
            objects.) -> structure: parameter "data" of list of type
            "ObjectData" (The data and supplemental info for an object.
            UnspecifiedObject data - the object's data or subset data.
-           object_info info - information about the object.
+           object_info info - information about the object. list<obj_ref>
+           path - the path to the object through the object reference graph.
+           All the references in the path are absolute.
            list<ProvenanceAction> provenance - the object's provenance.
            username creator - the user that first saved the object to the
            workspace. ws_id orig_wsid - the id of the workspace in which this
            object was originally saved. Missing for objects saved prior to
            version 0.4.1. timestamp created - the date the object was first
            saved to the workspace. epoch epoch - the date the object was
-           first saved to the workspace. list<obj_ref> - the references
+           first saved to the workspace. list<obj_ref> refs - the references
            contained within the object. obj_ref copied - the reference of the
            source object if this object is a copy and the copy source exists
            and is accessible. null otherwise. boolean
@@ -1741,97 +1791,101 @@ class Workspace(object):
            kbasetest:my_workspace.), parameter "chsum" of String, parameter
            "size" of Long, parameter "meta" of type "usermeta" (User provided
            metadata about an object. Arbitrary key-value pairs provided by
-           the user.) -> mapping from String to String, parameter
-           "provenance" of list of type "ProvenanceAction" (A provenance
-           action. A provenance action (PA) is an action taken while
-           transforming one data object to another. There may be several PAs
-           taken in series. A PA is typically running a script, running an
-           api command, etc. All of the following fields are optional, but
-           more information provided equates to better data provenance.
-           resolved_ws_objects should never be set by the user; it is set by
-           the workspace service when returning data. On input, only one of
-           the time or epoch may be supplied. Both are supplied on output.
-           The maximum size of the entire provenance object, including all
-           actions, is 1MB. timestamp time - the time the action was started
-           epoch epoch - the time the action was started. string caller - the
-           name or id of the invoker of this provenance action. In most
-           cases, this will be the same for all PAs. string service - the
-           name of the service that performed this action. string service_ver
-           - the version of the service that performed this action. string
-           method - the method of the service that performed this action.
-           list<UnspecifiedObject> method_params - the parameters of the
-           method that performed this action. If an object in the parameters
-           is a workspace object, also put the object reference in the
-           input_ws_object list. string script - the name of the script that
-           performed this action. string script_ver - the version of the
-           script that performed this action. string script_command_line -
-           the command line provided to the script that performed this
-           action. If workspace objects were provided in the command line,
-           also put the object reference in the input_ws_object list.
-           list<obj_ref> input_ws_objects - the workspace objects that were
-           used as input to this action; typically these will also be present
-           as parts of the method_params or the script_command_line
-           arguments. list<obj_ref> resolved_ws_objects - the workspace
-           objects ids from input_ws_objects resolved to permanent workspace
-           object references by the workspace service. list<string>
-           intermediate_incoming - if the previous action produced output
-           that 1) was not stored in a referrable way, and 2) is used as
-           input for this action, provide it with an arbitrary and unique ID
-           here, in the order of the input arguments to this action. These
-           IDs can be used in the method_params argument. list<string>
-           intermediate_outgoing - if this action produced output that 1) was
-           not stored in a referrable way, and 2) is used as input for the
-           next action, provide it with an arbitrary and unique ID here, in
-           the order of the output values from this action. These IDs can be
-           used in the intermediate_incoming argument in the next action.
-           list<ExternalDataUnit> external_data - data external to the
-           workspace that was either imported to the workspace or used to
-           create a workspace object. list<SubAction> subactions - the
-           subactions taken as a part of this action. mapping<string, string>
-           custom - user definable custom provenance fields and their values.
-           string description - a free text description of this action.) ->
-           structure: parameter "time" of type "timestamp" (A time in the
-           format YYYY-MM-DDThh:mm:ssZ, where Z is either the character Z
-           (representing the UTC timezone) or the difference in time to UTC
-           in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time)
-           2013-04-03T08:56:32+0000 (UTC time) 2013-04-03T08:56:32Z (UTC
-           time)), parameter "epoch" of type "epoch" (A Unix epoch (the time
-           since 00:00:00 1/1/1970 UTC) in milliseconds.), parameter "caller"
-           of String, parameter "service" of String, parameter "service_ver"
-           of String, parameter "method" of String, parameter "method_params"
-           of list of unspecified object, parameter "script" of String,
-           parameter "script_ver" of String, parameter "script_command_line"
-           of String, parameter "input_ws_objects" of list of type "obj_ref"
-           (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           the user.) -> mapping from String to String, parameter "path" of
+           list of type "obj_ref" (A string that uniquely identifies an
+           object in the workspace service. The format is [ws_name or
+           id]/[obj_name or id]/[obj_ver]. For example,
+           MyFirstWorkspace/MyFirstObject/3 would identify the third version
+           of an object called MyFirstObject in the workspace called
+           MyFirstWorkspace. 42/Panic/1 would identify the first version of
+           the object name Panic in workspace with id 42. Towel/1/6 would
+           identify the 6th version of the object with id 1 in the Towel
+           workspace.If the version number is omitted, the latest version of
+           the object is assumed.), parameter "provenance" of list of type
+           "ProvenanceAction" (A provenance action. A provenance action (PA)
+           is an action taken while transforming one data object to another.
+           There may be several PAs taken in series. A PA is typically
+           running a script, running an api command, etc. All of the
+           following fields are optional, but more information provided
+           equates to better data provenance. resolved_ws_objects should
+           never be set by the user; it is set by the workspace service when
+           returning data. On input, only one of the time or epoch may be
+           supplied. Both are supplied on output. The maximum size of the
+           entire provenance object, including all actions, is 1MB. timestamp
+           time - the time the action was started epoch epoch - the time the
+           action was started. string caller - the name or id of the invoker
+           of this provenance action. In most cases, this will be the same
+           for all PAs. string service - the name of the service that
+           performed this action. string service_ver - the version of the
+           service that performed this action. string method - the method of
+           the service that performed this action. list<UnspecifiedObject>
+           method_params - the parameters of the method that performed this
+           action. If an object in the parameters is a workspace object, also
+           put the object reference in the input_ws_object list. string
+           script - the name of the script that performed this action. string
+           script_ver - the version of the script that performed this action.
+           string script_command_line - the command line provided to the
+           script that performed this action. If workspace objects were
+           provided in the command line, also put the object reference in the
+           input_ws_object list. list<ref_string> input_ws_objects - the
+           workspace objects that were used as input to this action;
+           typically these will also be present as parts of the method_params
+           or the script_command_line arguments. A reference path into the
+           object graph may be supplied. list<obj_ref> resolved_ws_objects -
+           the workspace objects ids from input_ws_objects resolved to
+           permanent workspace object references by the workspace service.
+           list<string> intermediate_incoming - if the previous action
+           produced output that 1) was not stored in a referrable way, and 2)
+           is used as input for this action, provide it with an arbitrary and
+           unique ID here, in the order of the input arguments to this
+           action. These IDs can be used in the method_params argument.
+           list<string> intermediate_outgoing - if this action produced
+           output that 1) was not stored in a referrable way, and 2) is used
+           as input for the next action, provide it with an arbitrary and
+           unique ID here, in the order of the output values from this
+           action. These IDs can be used in the intermediate_incoming
+           argument in the next action. list<ExternalDataUnit> external_data
+           - data external to the workspace that was either imported to the
+           workspace or used to create a workspace object. list<SubAction>
+           subactions - the subactions taken as a part of this action.
+           mapping<string, string> custom - user definable custom provenance
+           fields and their values. string description - a free text
+           description of this action.) -> structure: parameter "time" of
+           type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where
+           Z is either the character Z (representing the UTC timezone) or the
+           difference in time to UTC in the format +/-HHMM, eg:
+           2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC
+           time) 2013-04-03T08:56:32Z (UTC time)), parameter "epoch" of type
+           "epoch" (A Unix epoch (the time since 00:00:00 1/1/1970 UTC) in
+           milliseconds.), parameter "caller" of String, parameter "service"
+           of String, parameter "service_ver" of String, parameter "method"
+           of String, parameter "method_params" of list of unspecified
+           object, parameter "script" of String, parameter "script_ver" of
+           String, parameter "script_command_line" of String, parameter
+           "input_ws_objects" of list of type "ref_string" (A chain of
+           objects with references to one another as a string. A single
+           string that is semantically identical to ref_chain above.
+           Represents a path from one workspace object to another through an
+           arbitrarily number of intermediate objects where each object has a
+           dependency or provenance reference to the next object. Each entry
+           is an obj_ref as defined earlier. Entries are separated by
+           semicolons. Whitespace is ignored. Examples: 3/5/6;
+           kbaseuser:myworkspace/myobject; 5/myobject/2 aworkspace/6),
+           parameter "resolved_ws_objects" of list of type "obj_ref" (A
+           string that uniquely identifies an object in the workspace
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
            third version of an object called MyFirstObject in the workspace
            called MyFirstWorkspace. 42/Panic/1 would identify the first
            version of the object name Panic in workspace with id 42.
            Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "resolved_ws_objects" of list of
-           type "obj_ref" (A string that uniquely identifies an object in the
-           workspace service. There are two ways to uniquely identify an
-           object in one string: "[ws_name or id]/[obj_name or id]/[obj_ver]"
-           - for example, "MyFirstWorkspace/MyFirstObject/3" would identify
-           the third version of an object called MyFirstObject in the
-           workspace called MyFirstWorkspace. 42/Panic/1 would identify the
-           first version of the object name Panic in workspace with id 42.
-           Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "intermediate_incoming" of list of
-           String, parameter "intermediate_outgoing" of list of String,
-           parameter "external_data" of list of type "ExternalDataUnit" (An
-           external data unit. A piece of data from a source outside the
-           Workspace. On input, only one of the resource_release_date or
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.), parameter
+           "intermediate_incoming" of list of String, parameter
+           "intermediate_outgoing" of list of String, parameter
+           "external_data" of list of type "ExternalDataUnit" (An external
+           data unit. A piece of data from a source outside the Workspace. On
+           input, only one of the resource_release_date or
            resource_release_epoch may be supplied. Both are supplied on
            output. string resource_name - the name of the resource, for
            example JGI. string resource_url - the url of the resource, for
@@ -1886,37 +1940,30 @@ class Workspace(object):
            time)), parameter "epoch" of type "epoch" (A Unix epoch (the time
            since 00:00:00 1/1/1970 UTC) in milliseconds.), parameter "refs"
            of list of type "obj_ref" (A string that uniquely identifies an
-           object in the workspace service. There are two ways to uniquely
-           identify an object in one string: "[ws_name or id]/[obj_name or
-           id]/[obj_ver]" - for example, "MyFirstWorkspace/MyFirstObject/3"
-           would identify the third version of an object called MyFirstObject
-           in the workspace called MyFirstWorkspace. 42/Panic/1 would
-           identify the first version of the object name Panic in workspace
-           with id 42. Towel/1/6 would identify the 6th version of the object
-           with id 1 in the Towel workspace.
-           "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]" - for example,
-           "kb|ws.23.obj.567.ver.2" would identify the second version of an
-           object with id 567 in a workspace with id 23. In all cases, if the
-           version number is omitted, the latest version of the object is
-           assumed.), parameter "copied" of type "obj_ref" (A string that
-           uniquely identifies an object in the workspace service. There are
-           two ways to uniquely identify an object in one string: "[ws_name
-           or id]/[obj_name or id]/[obj_ver]" - for example,
-           "MyFirstWorkspace/MyFirstObject/3" would identify the third
-           version of an object called MyFirstObject in the workspace called
+           object in the workspace service. The format is [ws_name or
+           id]/[obj_name or id]/[obj_ver]. For example,
+           MyFirstWorkspace/MyFirstObject/3 would identify the third version
+           of an object called MyFirstObject in the workspace called
            MyFirstWorkspace. 42/Panic/1 would identify the first version of
            the object name Panic in workspace with id 42. Towel/1/6 would
            identify the 6th version of the object with id 1 in the Towel
-           workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]" - for
-           example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "copy_source_inaccessible" of type
-           "boolean" (A boolean. 0 = false, other = true.), parameter
-           "extracted_ids" of mapping from type "id_type" (An id type (e.g.
-           from a typespec @id annotation: @id [idtype])) to list of type
-           "extracted_id" (An id extracted from an object.), parameter
-           "handle_error" of String, parameter "handle_stacktrace" of String
+           workspace.If the version number is omitted, the latest version of
+           the object is assumed.), parameter "copied" of type "obj_ref" (A
+           string that uniquely identifies an object in the workspace
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
+           third version of an object called MyFirstObject in the workspace
+           called MyFirstWorkspace. 42/Panic/1 would identify the first
+           version of the object name Panic in workspace with id 42.
+           Towel/1/6 would identify the 6th version of the object with id 1
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.), parameter
+           "copy_source_inaccessible" of type "boolean" (A boolean. 0 =
+           false, other = true.), parameter "extracted_ids" of mapping from
+           type "id_type" (An id type (e.g. from a typespec @id annotation:
+           @id [idtype])) to list of type "extracted_id" (An id extracted
+           from an object.), parameter "handle_error" of String, parameter
+           "handle_stacktrace" of String
         """
         return self._client.call_method(
             'Workspace.get_objects2',
@@ -1941,11 +1988,9 @@ class Workspace(object):
         :param sub_object_ids: instance of list of type "SubObjectIdentity"
            (DEPRECATED An object subset identifier. Select a subset of an
            object by: EITHER One, and only one, of the numerical id or name
-           of the workspace, where the name can also be a KBase ID including
-           the numerical id, e.g. kb|ws.35. ws_id wsid - the numerical ID of
-           the workspace. ws_name workspace - name of the workspace or the
-           workspace ID in KBase format, e.g. kb|ws.78. AND One, and only
-           one, of the numerical id or name of the object. obj_id objid- the
+           of the workspace. ws_id wsid - the numerical ID of the workspace.
+           ws_name workspace - name of the workspace. AND One, and only one,
+           of the numerical id or name of the object. obj_id objid- the
            numerical ID of the object. obj_name name - name of the object.
            OPTIONALLY obj_ver ver - the version of the object. OR an object
            reference string: obj_ref ref - an object reference string. AND a
@@ -1969,44 +2014,43 @@ class Workspace(object):
            parameter "ver" of type "obj_ver" (An object version. The version
            of the object, starting at 1.), parameter "ref" of type "obj_ref"
            (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
            third version of an object called MyFirstObject in the workspace
            called MyFirstWorkspace. 42/Panic/1 would identify the first
            version of the object name Panic in workspace with id 42.
            Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "included" of list of type
-           "object_path" (A path into an object. Identify a sub portion of an
-           object by providing the path, delimited by a slash (/), to that
-           portion of the object. Thus the path may not have slashes in the
-           structure or mapping keys. Examples: /foo/bar/3 - specifies the
-           bar key of the foo mapping and the 3rd entry of the array if bar
-           maps to an array or the value mapped to the string "3" if bar maps
-           to a map. /foo/bar/[*]/baz - specifies the baz field of all the
-           objects in the list mapped by the bar key in the map foo.
-           /foo/asterisk/baz - specifies the baz field of all the objects in
-           the values of the foo mapping. Swap 'asterisk' for * in the path.
-           In case you need to use '/' or '~' in path items use JSON Pointer
-           notation defined here: http://tools.ietf.org/html/rfc6901),
-           parameter "strict_maps" of type "boolean" (A boolean. 0 = false,
-           other = true.), parameter "strict_arrays" of type "boolean" (A
-           boolean. 0 = false, other = true.)
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.), parameter "included" of
+           list of type "object_path" (A path into an object. Identify a sub
+           portion of an object by providing the path, delimited by a slash
+           (/), to that portion of the object. Thus the path may not have
+           slashes in the structure or mapping keys. Examples: /foo/bar/3 -
+           specifies the bar key of the foo mapping and the 3rd entry of the
+           array if bar maps to an array or the value mapped to the string
+           "3" if bar maps to a map. /foo/bar/[*]/baz - specifies the baz
+           field of all the objects in the list mapped by the bar key in the
+           map foo. /foo/asterisk/baz - specifies the baz field of all the
+           objects in the values of the foo mapping. Swap 'asterisk' for * in
+           the path. In case you need to use '/' or '~' in path items use
+           JSON Pointer notation defined here:
+           http://tools.ietf.org/html/rfc6901), parameter "strict_maps" of
+           type "boolean" (A boolean. 0 = false, other = true.), parameter
+           "strict_arrays" of type "boolean" (A boolean. 0 = false, other =
+           true.)
         :returns: instance of list of type "ObjectData" (The data and
            supplemental info for an object. UnspecifiedObject data - the
            object's data or subset data. object_info info - information about
-           the object. list<ProvenanceAction> provenance - the object's
+           the object. list<obj_ref> path - the path to the object through
+           the object reference graph. All the references in the path are
+           absolute. list<ProvenanceAction> provenance - the object's
            provenance. username creator - the user that first saved the
            object to the workspace. ws_id orig_wsid - the id of the workspace
            in which this object was originally saved. Missing for objects
            saved prior to version 0.4.1. timestamp created - the date the
            object was first saved to the workspace. epoch epoch - the date
-           the object was first saved to the workspace. list<obj_ref> - the
-           references contained within the object. obj_ref copied - the
+           the object was first saved to the workspace. list<obj_ref> refs -
+           the references contained within the object. obj_ref copied - the
            reference of the source object if this object is a copy and the
            copy source exists and is accessible. null otherwise. boolean
            copy_source_inaccessible - true if the object was copied from
@@ -2059,97 +2103,101 @@ class Workspace(object):
            kbasetest:my_workspace.), parameter "chsum" of String, parameter
            "size" of Long, parameter "meta" of type "usermeta" (User provided
            metadata about an object. Arbitrary key-value pairs provided by
-           the user.) -> mapping from String to String, parameter
-           "provenance" of list of type "ProvenanceAction" (A provenance
-           action. A provenance action (PA) is an action taken while
-           transforming one data object to another. There may be several PAs
-           taken in series. A PA is typically running a script, running an
-           api command, etc. All of the following fields are optional, but
-           more information provided equates to better data provenance.
-           resolved_ws_objects should never be set by the user; it is set by
-           the workspace service when returning data. On input, only one of
-           the time or epoch may be supplied. Both are supplied on output.
-           The maximum size of the entire provenance object, including all
-           actions, is 1MB. timestamp time - the time the action was started
-           epoch epoch - the time the action was started. string caller - the
-           name or id of the invoker of this provenance action. In most
-           cases, this will be the same for all PAs. string service - the
-           name of the service that performed this action. string service_ver
-           - the version of the service that performed this action. string
-           method - the method of the service that performed this action.
-           list<UnspecifiedObject> method_params - the parameters of the
-           method that performed this action. If an object in the parameters
-           is a workspace object, also put the object reference in the
-           input_ws_object list. string script - the name of the script that
-           performed this action. string script_ver - the version of the
-           script that performed this action. string script_command_line -
-           the command line provided to the script that performed this
-           action. If workspace objects were provided in the command line,
-           also put the object reference in the input_ws_object list.
-           list<obj_ref> input_ws_objects - the workspace objects that were
-           used as input to this action; typically these will also be present
-           as parts of the method_params or the script_command_line
-           arguments. list<obj_ref> resolved_ws_objects - the workspace
-           objects ids from input_ws_objects resolved to permanent workspace
-           object references by the workspace service. list<string>
-           intermediate_incoming - if the previous action produced output
-           that 1) was not stored in a referrable way, and 2) is used as
-           input for this action, provide it with an arbitrary and unique ID
-           here, in the order of the input arguments to this action. These
-           IDs can be used in the method_params argument. list<string>
-           intermediate_outgoing - if this action produced output that 1) was
-           not stored in a referrable way, and 2) is used as input for the
-           next action, provide it with an arbitrary and unique ID here, in
-           the order of the output values from this action. These IDs can be
-           used in the intermediate_incoming argument in the next action.
-           list<ExternalDataUnit> external_data - data external to the
-           workspace that was either imported to the workspace or used to
-           create a workspace object. list<SubAction> subactions - the
-           subactions taken as a part of this action. mapping<string, string>
-           custom - user definable custom provenance fields and their values.
-           string description - a free text description of this action.) ->
-           structure: parameter "time" of type "timestamp" (A time in the
-           format YYYY-MM-DDThh:mm:ssZ, where Z is either the character Z
-           (representing the UTC timezone) or the difference in time to UTC
-           in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time)
-           2013-04-03T08:56:32+0000 (UTC time) 2013-04-03T08:56:32Z (UTC
-           time)), parameter "epoch" of type "epoch" (A Unix epoch (the time
-           since 00:00:00 1/1/1970 UTC) in milliseconds.), parameter "caller"
-           of String, parameter "service" of String, parameter "service_ver"
-           of String, parameter "method" of String, parameter "method_params"
-           of list of unspecified object, parameter "script" of String,
-           parameter "script_ver" of String, parameter "script_command_line"
-           of String, parameter "input_ws_objects" of list of type "obj_ref"
-           (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           the user.) -> mapping from String to String, parameter "path" of
+           list of type "obj_ref" (A string that uniquely identifies an
+           object in the workspace service. The format is [ws_name or
+           id]/[obj_name or id]/[obj_ver]. For example,
+           MyFirstWorkspace/MyFirstObject/3 would identify the third version
+           of an object called MyFirstObject in the workspace called
+           MyFirstWorkspace. 42/Panic/1 would identify the first version of
+           the object name Panic in workspace with id 42. Towel/1/6 would
+           identify the 6th version of the object with id 1 in the Towel
+           workspace.If the version number is omitted, the latest version of
+           the object is assumed.), parameter "provenance" of list of type
+           "ProvenanceAction" (A provenance action. A provenance action (PA)
+           is an action taken while transforming one data object to another.
+           There may be several PAs taken in series. A PA is typically
+           running a script, running an api command, etc. All of the
+           following fields are optional, but more information provided
+           equates to better data provenance. resolved_ws_objects should
+           never be set by the user; it is set by the workspace service when
+           returning data. On input, only one of the time or epoch may be
+           supplied. Both are supplied on output. The maximum size of the
+           entire provenance object, including all actions, is 1MB. timestamp
+           time - the time the action was started epoch epoch - the time the
+           action was started. string caller - the name or id of the invoker
+           of this provenance action. In most cases, this will be the same
+           for all PAs. string service - the name of the service that
+           performed this action. string service_ver - the version of the
+           service that performed this action. string method - the method of
+           the service that performed this action. list<UnspecifiedObject>
+           method_params - the parameters of the method that performed this
+           action. If an object in the parameters is a workspace object, also
+           put the object reference in the input_ws_object list. string
+           script - the name of the script that performed this action. string
+           script_ver - the version of the script that performed this action.
+           string script_command_line - the command line provided to the
+           script that performed this action. If workspace objects were
+           provided in the command line, also put the object reference in the
+           input_ws_object list. list<ref_string> input_ws_objects - the
+           workspace objects that were used as input to this action;
+           typically these will also be present as parts of the method_params
+           or the script_command_line arguments. A reference path into the
+           object graph may be supplied. list<obj_ref> resolved_ws_objects -
+           the workspace objects ids from input_ws_objects resolved to
+           permanent workspace object references by the workspace service.
+           list<string> intermediate_incoming - if the previous action
+           produced output that 1) was not stored in a referrable way, and 2)
+           is used as input for this action, provide it with an arbitrary and
+           unique ID here, in the order of the input arguments to this
+           action. These IDs can be used in the method_params argument.
+           list<string> intermediate_outgoing - if this action produced
+           output that 1) was not stored in a referrable way, and 2) is used
+           as input for the next action, provide it with an arbitrary and
+           unique ID here, in the order of the output values from this
+           action. These IDs can be used in the intermediate_incoming
+           argument in the next action. list<ExternalDataUnit> external_data
+           - data external to the workspace that was either imported to the
+           workspace or used to create a workspace object. list<SubAction>
+           subactions - the subactions taken as a part of this action.
+           mapping<string, string> custom - user definable custom provenance
+           fields and their values. string description - a free text
+           description of this action.) -> structure: parameter "time" of
+           type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where
+           Z is either the character Z (representing the UTC timezone) or the
+           difference in time to UTC in the format +/-HHMM, eg:
+           2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC
+           time) 2013-04-03T08:56:32Z (UTC time)), parameter "epoch" of type
+           "epoch" (A Unix epoch (the time since 00:00:00 1/1/1970 UTC) in
+           milliseconds.), parameter "caller" of String, parameter "service"
+           of String, parameter "service_ver" of String, parameter "method"
+           of String, parameter "method_params" of list of unspecified
+           object, parameter "script" of String, parameter "script_ver" of
+           String, parameter "script_command_line" of String, parameter
+           "input_ws_objects" of list of type "ref_string" (A chain of
+           objects with references to one another as a string. A single
+           string that is semantically identical to ref_chain above.
+           Represents a path from one workspace object to another through an
+           arbitrarily number of intermediate objects where each object has a
+           dependency or provenance reference to the next object. Each entry
+           is an obj_ref as defined earlier. Entries are separated by
+           semicolons. Whitespace is ignored. Examples: 3/5/6;
+           kbaseuser:myworkspace/myobject; 5/myobject/2 aworkspace/6),
+           parameter "resolved_ws_objects" of list of type "obj_ref" (A
+           string that uniquely identifies an object in the workspace
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
            third version of an object called MyFirstObject in the workspace
            called MyFirstWorkspace. 42/Panic/1 would identify the first
            version of the object name Panic in workspace with id 42.
            Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "resolved_ws_objects" of list of
-           type "obj_ref" (A string that uniquely identifies an object in the
-           workspace service. There are two ways to uniquely identify an
-           object in one string: "[ws_name or id]/[obj_name or id]/[obj_ver]"
-           - for example, "MyFirstWorkspace/MyFirstObject/3" would identify
-           the third version of an object called MyFirstObject in the
-           workspace called MyFirstWorkspace. 42/Panic/1 would identify the
-           first version of the object name Panic in workspace with id 42.
-           Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "intermediate_incoming" of list of
-           String, parameter "intermediate_outgoing" of list of String,
-           parameter "external_data" of list of type "ExternalDataUnit" (An
-           external data unit. A piece of data from a source outside the
-           Workspace. On input, only one of the resource_release_date or
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.), parameter
+           "intermediate_incoming" of list of String, parameter
+           "intermediate_outgoing" of list of String, parameter
+           "external_data" of list of type "ExternalDataUnit" (An external
+           data unit. A piece of data from a source outside the Workspace. On
+           input, only one of the resource_release_date or
            resource_release_epoch may be supplied. Both are supplied on
            output. string resource_name - the name of the resource, for
            example JGI. string resource_url - the url of the resource, for
@@ -2204,37 +2252,30 @@ class Workspace(object):
            time)), parameter "epoch" of type "epoch" (A Unix epoch (the time
            since 00:00:00 1/1/1970 UTC) in milliseconds.), parameter "refs"
            of list of type "obj_ref" (A string that uniquely identifies an
-           object in the workspace service. There are two ways to uniquely
-           identify an object in one string: "[ws_name or id]/[obj_name or
-           id]/[obj_ver]" - for example, "MyFirstWorkspace/MyFirstObject/3"
-           would identify the third version of an object called MyFirstObject
-           in the workspace called MyFirstWorkspace. 42/Panic/1 would
-           identify the first version of the object name Panic in workspace
-           with id 42. Towel/1/6 would identify the 6th version of the object
-           with id 1 in the Towel workspace.
-           "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]" - for example,
-           "kb|ws.23.obj.567.ver.2" would identify the second version of an
-           object with id 567 in a workspace with id 23. In all cases, if the
-           version number is omitted, the latest version of the object is
-           assumed.), parameter "copied" of type "obj_ref" (A string that
-           uniquely identifies an object in the workspace service. There are
-           two ways to uniquely identify an object in one string: "[ws_name
-           or id]/[obj_name or id]/[obj_ver]" - for example,
-           "MyFirstWorkspace/MyFirstObject/3" would identify the third
-           version of an object called MyFirstObject in the workspace called
+           object in the workspace service. The format is [ws_name or
+           id]/[obj_name or id]/[obj_ver]. For example,
+           MyFirstWorkspace/MyFirstObject/3 would identify the third version
+           of an object called MyFirstObject in the workspace called
            MyFirstWorkspace. 42/Panic/1 would identify the first version of
            the object name Panic in workspace with id 42. Towel/1/6 would
            identify the 6th version of the object with id 1 in the Towel
-           workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]" - for
-           example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "copy_source_inaccessible" of type
-           "boolean" (A boolean. 0 = false, other = true.), parameter
-           "extracted_ids" of mapping from type "id_type" (An id type (e.g.
-           from a typespec @id annotation: @id [idtype])) to list of type
-           "extracted_id" (An id extracted from an object.), parameter
-           "handle_error" of String, parameter "handle_stacktrace" of String
+           workspace.If the version number is omitted, the latest version of
+           the object is assumed.), parameter "copied" of type "obj_ref" (A
+           string that uniquely identifies an object in the workspace
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
+           third version of an object called MyFirstObject in the workspace
+           called MyFirstWorkspace. 42/Panic/1 would identify the first
+           version of the object name Panic in workspace with id 42.
+           Towel/1/6 would identify the 6th version of the object with id 1
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.), parameter
+           "copy_source_inaccessible" of type "boolean" (A boolean. 0 =
+           false, other = true.), parameter "extracted_ids" of mapping from
+           type "id_type" (An id type (e.g. from a typespec @id annotation:
+           @id [idtype])) to list of type "extracted_id" (An id extracted
+           from an object.), parameter "handle_error" of String, parameter
+           "handle_stacktrace" of String
         """
         return self._client.call_method(
             'Workspace.get_object_subset',
@@ -2246,19 +2287,17 @@ class Workspace(object):
         ignored.
         :param object: instance of type "ObjectIdentity" (An object
            identifier. Select an object by either: One, and only one, of the
-           numerical id or name of the workspace, where the name can also be
-           a KBase ID including the numerical id, e.g. kb|ws.35. ws_id wsid -
-           the numerical ID of the workspace. ws_name workspace - name of the
-           workspace or the workspace ID in KBase format, e.g. kb|ws.78. AND
-           One, and only one, of the numerical id or name of the object.
-           obj_id objid- the numerical ID of the object. obj_name name - name
-           of the object. OPTIONALLY obj_ver ver - the version of the object.
-           OR an object reference string: obj_ref ref - an object reference
-           string.) -> structure: parameter "workspace" of type "ws_name" (A
-           string used as a name for a workspace. Any string consisting of
-           alphanumeric characters and "_", ".", or "-" that is not an
-           integer is acceptable. The name may optionally be prefixed with
-           the workspace owner's user name and a colon, e.g.
+           numerical id or name of the workspace. ws_id wsid - the numerical
+           ID of the workspace. ws_name workspace - the name of the
+           workspace. AND One, and only one, of the numerical id or name of
+           the object. obj_id objid- the numerical ID of the object. obj_name
+           name - name of the object. OPTIONALLY obj_ver ver - the version of
+           the object. OR an object reference string: obj_ref ref - an object
+           reference string.) -> structure: parameter "workspace" of type
+           "ws_name" (A string used as a name for a workspace. Any string
+           consisting of alphanumeric characters and "_", ".", or "-" that is
+           not an integer is acceptable. The name may optionally be prefixed
+           with the workspace owner's user name and a colon, e.g.
            kbasetest:my_workspace.), parameter "wsid" of type "ws_id" (The
            unique, permanent numerical ID of a workspace.), parameter "name"
            of type "obj_name" (A string used as a name for an object. Any
@@ -2268,18 +2307,14 @@ class Workspace(object):
            parameter "ver" of type "obj_ver" (An object version. The version
            of the object, starting at 1.), parameter "ref" of type "obj_ref"
            (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
            third version of an object called MyFirstObject in the workspace
            called MyFirstWorkspace. 42/Panic/1 would identify the first
            version of the object name Panic in workspace with id 42.
            Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.)
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.)
         :returns: instance of list of type "object_info" (Information about
            an object, including user provided metadata. obj_id objid - the
            numerical id of the object. obj_name name - the name of the
@@ -2335,11 +2370,9 @@ class Workspace(object):
         in the deleted state are not returned.
         :param object_ids: instance of list of type "ObjectIdentity" (An
            object identifier. Select an object by either: One, and only one,
-           of the numerical id or name of the workspace, where the name can
-           also be a KBase ID including the numerical id, e.g. kb|ws.35.
-           ws_id wsid - the numerical ID of the workspace. ws_name workspace
-           - name of the workspace or the workspace ID in KBase format, e.g.
-           kb|ws.78. AND One, and only one, of the numerical id or name of
+           of the numerical id or name of the workspace. ws_id wsid - the
+           numerical ID of the workspace. ws_name workspace - the name of the
+           workspace. AND One, and only one, of the numerical id or name of
            the object. obj_id objid- the numerical ID of the object. obj_name
            name - name of the object. OPTIONALLY obj_ver ver - the version of
            the object. OR an object reference string: obj_ref ref - an object
@@ -2357,18 +2390,14 @@ class Workspace(object):
            parameter "ver" of type "obj_ver" (An object version. The version
            of the object, starting at 1.), parameter "ref" of type "obj_ref"
            (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
            third version of an object called MyFirstObject in the workspace
            called MyFirstWorkspace. 42/Panic/1 would identify the first
            version of the object name Panic in workspace with id 42.
            Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.)
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.)
         :returns: instance of list of list of type "object_info" (Information
            about an object, including user provided metadata. obj_id objid -
            the numerical id of the object. obj_name name - the name of the
@@ -2428,11 +2457,9 @@ class Workspace(object):
         @deprecated
         :param object_ids: instance of list of type "ObjectIdentity" (An
            object identifier. Select an object by either: One, and only one,
-           of the numerical id or name of the workspace, where the name can
-           also be a KBase ID including the numerical id, e.g. kb|ws.35.
-           ws_id wsid - the numerical ID of the workspace. ws_name workspace
-           - name of the workspace or the workspace ID in KBase format, e.g.
-           kb|ws.78. AND One, and only one, of the numerical id or name of
+           of the numerical id or name of the workspace. ws_id wsid - the
+           numerical ID of the workspace. ws_name workspace - the name of the
+           workspace. AND One, and only one, of the numerical id or name of
            the object. obj_id objid- the numerical ID of the object. obj_name
            name - name of the object. OPTIONALLY obj_ver ver - the version of
            the object. OR an object reference string: obj_ref ref - an object
@@ -2450,18 +2477,14 @@ class Workspace(object):
            parameter "ver" of type "obj_ver" (An object version. The version
            of the object, starting at 1.), parameter "ref" of type "obj_ref"
            (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
            third version of an object called MyFirstObject in the workspace
            called MyFirstWorkspace. 42/Panic/1 would identify the first
            version of the object name Panic in workspace with id 42.
            Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.)
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.)
         :returns: instance of list of Long
         """
         return self._client.call_method(
@@ -2473,18 +2496,18 @@ class Workspace(object):
         DEPRECATED
                 Get objects by references from other objects.
                 NOTE: In the vast majority of cases, this method is not necessary and
-                get_objects should be used instead. 
-                
+                get_objects should be used instead.
+
                 get_referenced_objects guarantees that a user that has access to an
                 object can always see a) objects that are referenced inside the object
                 and b) objects that are referenced in the object's provenance. This
                 ensures that the user has visibility into the entire provenance of the
                 object and the object's object dependencies (e.g. references).
-                
+
                 The user must have at least read access to the first object in each
                 reference chain, but need not have access to any further objects in
                 the chain, and those objects may be deleted.
-                
+
                 @deprecated Workspace.get_objects2
         :param ref_chains: instance of list of type "ref_chain" (A chain of
            objects with references to one another. An object reference chain
@@ -2492,19 +2515,17 @@ class Workspace(object):
            reference, either in the object itself or in the object
            provenance, to the n+1th object.) -> list of type "ObjectIdentity"
            (An object identifier. Select an object by either: One, and only
-           one, of the numerical id or name of the workspace, where the name
-           can also be a KBase ID including the numerical id, e.g. kb|ws.35.
-           ws_id wsid - the numerical ID of the workspace. ws_name workspace
-           - name of the workspace or the workspace ID in KBase format, e.g.
-           kb|ws.78. AND One, and only one, of the numerical id or name of
-           the object. obj_id objid- the numerical ID of the object. obj_name
-           name - name of the object. OPTIONALLY obj_ver ver - the version of
-           the object. OR an object reference string: obj_ref ref - an object
-           reference string.) -> structure: parameter "workspace" of type
-           "ws_name" (A string used as a name for a workspace. Any string
-           consisting of alphanumeric characters and "_", ".", or "-" that is
-           not an integer is acceptable. The name may optionally be prefixed
-           with the workspace owner's user name and a colon, e.g.
+           one, of the numerical id or name of the workspace. ws_id wsid -
+           the numerical ID of the workspace. ws_name workspace - the name of
+           the workspace. AND One, and only one, of the numerical id or name
+           of the object. obj_id objid- the numerical ID of the object.
+           obj_name name - name of the object. OPTIONALLY obj_ver ver - the
+           version of the object. OR an object reference string: obj_ref ref
+           - an object reference string.) -> structure: parameter "workspace"
+           of type "ws_name" (A string used as a name for a workspace. Any
+           string consisting of alphanumeric characters and "_", ".", or "-"
+           that is not an integer is acceptable. The name may optionally be
+           prefixed with the workspace owner's user name and a colon, e.g.
            kbasetest:my_workspace.), parameter "wsid" of type "ws_id" (The
            unique, permanent numerical ID of a workspace.), parameter "name"
            of type "obj_name" (A string used as a name for an object. Any
@@ -2514,29 +2535,27 @@ class Workspace(object):
            parameter "ver" of type "obj_ver" (An object version. The version
            of the object, starting at 1.), parameter "ref" of type "obj_ref"
            (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
            third version of an object called MyFirstObject in the workspace
            called MyFirstWorkspace. 42/Panic/1 would identify the first
            version of the object name Panic in workspace with id 42.
            Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.)
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.)
         :returns: instance of list of type "ObjectData" (The data and
            supplemental info for an object. UnspecifiedObject data - the
            object's data or subset data. object_info info - information about
-           the object. list<ProvenanceAction> provenance - the object's
+           the object. list<obj_ref> path - the path to the object through
+           the object reference graph. All the references in the path are
+           absolute. list<ProvenanceAction> provenance - the object's
            provenance. username creator - the user that first saved the
            object to the workspace. ws_id orig_wsid - the id of the workspace
            in which this object was originally saved. Missing for objects
            saved prior to version 0.4.1. timestamp created - the date the
            object was first saved to the workspace. epoch epoch - the date
-           the object was first saved to the workspace. list<obj_ref> - the
-           references contained within the object. obj_ref copied - the
+           the object was first saved to the workspace. list<obj_ref> refs -
+           the references contained within the object. obj_ref copied - the
            reference of the source object if this object is a copy and the
            copy source exists and is accessible. null otherwise. boolean
            copy_source_inaccessible - true if the object was copied from
@@ -2589,97 +2608,101 @@ class Workspace(object):
            kbasetest:my_workspace.), parameter "chsum" of String, parameter
            "size" of Long, parameter "meta" of type "usermeta" (User provided
            metadata about an object. Arbitrary key-value pairs provided by
-           the user.) -> mapping from String to String, parameter
-           "provenance" of list of type "ProvenanceAction" (A provenance
-           action. A provenance action (PA) is an action taken while
-           transforming one data object to another. There may be several PAs
-           taken in series. A PA is typically running a script, running an
-           api command, etc. All of the following fields are optional, but
-           more information provided equates to better data provenance.
-           resolved_ws_objects should never be set by the user; it is set by
-           the workspace service when returning data. On input, only one of
-           the time or epoch may be supplied. Both are supplied on output.
-           The maximum size of the entire provenance object, including all
-           actions, is 1MB. timestamp time - the time the action was started
-           epoch epoch - the time the action was started. string caller - the
-           name or id of the invoker of this provenance action. In most
-           cases, this will be the same for all PAs. string service - the
-           name of the service that performed this action. string service_ver
-           - the version of the service that performed this action. string
-           method - the method of the service that performed this action.
-           list<UnspecifiedObject> method_params - the parameters of the
-           method that performed this action. If an object in the parameters
-           is a workspace object, also put the object reference in the
-           input_ws_object list. string script - the name of the script that
-           performed this action. string script_ver - the version of the
-           script that performed this action. string script_command_line -
-           the command line provided to the script that performed this
-           action. If workspace objects were provided in the command line,
-           also put the object reference in the input_ws_object list.
-           list<obj_ref> input_ws_objects - the workspace objects that were
-           used as input to this action; typically these will also be present
-           as parts of the method_params or the script_command_line
-           arguments. list<obj_ref> resolved_ws_objects - the workspace
-           objects ids from input_ws_objects resolved to permanent workspace
-           object references by the workspace service. list<string>
-           intermediate_incoming - if the previous action produced output
-           that 1) was not stored in a referrable way, and 2) is used as
-           input for this action, provide it with an arbitrary and unique ID
-           here, in the order of the input arguments to this action. These
-           IDs can be used in the method_params argument. list<string>
-           intermediate_outgoing - if this action produced output that 1) was
-           not stored in a referrable way, and 2) is used as input for the
-           next action, provide it with an arbitrary and unique ID here, in
-           the order of the output values from this action. These IDs can be
-           used in the intermediate_incoming argument in the next action.
-           list<ExternalDataUnit> external_data - data external to the
-           workspace that was either imported to the workspace or used to
-           create a workspace object. list<SubAction> subactions - the
-           subactions taken as a part of this action. mapping<string, string>
-           custom - user definable custom provenance fields and their values.
-           string description - a free text description of this action.) ->
-           structure: parameter "time" of type "timestamp" (A time in the
-           format YYYY-MM-DDThh:mm:ssZ, where Z is either the character Z
-           (representing the UTC timezone) or the difference in time to UTC
-           in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time)
-           2013-04-03T08:56:32+0000 (UTC time) 2013-04-03T08:56:32Z (UTC
-           time)), parameter "epoch" of type "epoch" (A Unix epoch (the time
-           since 00:00:00 1/1/1970 UTC) in milliseconds.), parameter "caller"
-           of String, parameter "service" of String, parameter "service_ver"
-           of String, parameter "method" of String, parameter "method_params"
-           of list of unspecified object, parameter "script" of String,
-           parameter "script_ver" of String, parameter "script_command_line"
-           of String, parameter "input_ws_objects" of list of type "obj_ref"
-           (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           the user.) -> mapping from String to String, parameter "path" of
+           list of type "obj_ref" (A string that uniquely identifies an
+           object in the workspace service. The format is [ws_name or
+           id]/[obj_name or id]/[obj_ver]. For example,
+           MyFirstWorkspace/MyFirstObject/3 would identify the third version
+           of an object called MyFirstObject in the workspace called
+           MyFirstWorkspace. 42/Panic/1 would identify the first version of
+           the object name Panic in workspace with id 42. Towel/1/6 would
+           identify the 6th version of the object with id 1 in the Towel
+           workspace.If the version number is omitted, the latest version of
+           the object is assumed.), parameter "provenance" of list of type
+           "ProvenanceAction" (A provenance action. A provenance action (PA)
+           is an action taken while transforming one data object to another.
+           There may be several PAs taken in series. A PA is typically
+           running a script, running an api command, etc. All of the
+           following fields are optional, but more information provided
+           equates to better data provenance. resolved_ws_objects should
+           never be set by the user; it is set by the workspace service when
+           returning data. On input, only one of the time or epoch may be
+           supplied. Both are supplied on output. The maximum size of the
+           entire provenance object, including all actions, is 1MB. timestamp
+           time - the time the action was started epoch epoch - the time the
+           action was started. string caller - the name or id of the invoker
+           of this provenance action. In most cases, this will be the same
+           for all PAs. string service - the name of the service that
+           performed this action. string service_ver - the version of the
+           service that performed this action. string method - the method of
+           the service that performed this action. list<UnspecifiedObject>
+           method_params - the parameters of the method that performed this
+           action. If an object in the parameters is a workspace object, also
+           put the object reference in the input_ws_object list. string
+           script - the name of the script that performed this action. string
+           script_ver - the version of the script that performed this action.
+           string script_command_line - the command line provided to the
+           script that performed this action. If workspace objects were
+           provided in the command line, also put the object reference in the
+           input_ws_object list. list<ref_string> input_ws_objects - the
+           workspace objects that were used as input to this action;
+           typically these will also be present as parts of the method_params
+           or the script_command_line arguments. A reference path into the
+           object graph may be supplied. list<obj_ref> resolved_ws_objects -
+           the workspace objects ids from input_ws_objects resolved to
+           permanent workspace object references by the workspace service.
+           list<string> intermediate_incoming - if the previous action
+           produced output that 1) was not stored in a referrable way, and 2)
+           is used as input for this action, provide it with an arbitrary and
+           unique ID here, in the order of the input arguments to this
+           action. These IDs can be used in the method_params argument.
+           list<string> intermediate_outgoing - if this action produced
+           output that 1) was not stored in a referrable way, and 2) is used
+           as input for the next action, provide it with an arbitrary and
+           unique ID here, in the order of the output values from this
+           action. These IDs can be used in the intermediate_incoming
+           argument in the next action. list<ExternalDataUnit> external_data
+           - data external to the workspace that was either imported to the
+           workspace or used to create a workspace object. list<SubAction>
+           subactions - the subactions taken as a part of this action.
+           mapping<string, string> custom - user definable custom provenance
+           fields and their values. string description - a free text
+           description of this action.) -> structure: parameter "time" of
+           type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where
+           Z is either the character Z (representing the UTC timezone) or the
+           difference in time to UTC in the format +/-HHMM, eg:
+           2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC
+           time) 2013-04-03T08:56:32Z (UTC time)), parameter "epoch" of type
+           "epoch" (A Unix epoch (the time since 00:00:00 1/1/1970 UTC) in
+           milliseconds.), parameter "caller" of String, parameter "service"
+           of String, parameter "service_ver" of String, parameter "method"
+           of String, parameter "method_params" of list of unspecified
+           object, parameter "script" of String, parameter "script_ver" of
+           String, parameter "script_command_line" of String, parameter
+           "input_ws_objects" of list of type "ref_string" (A chain of
+           objects with references to one another as a string. A single
+           string that is semantically identical to ref_chain above.
+           Represents a path from one workspace object to another through an
+           arbitrarily number of intermediate objects where each object has a
+           dependency or provenance reference to the next object. Each entry
+           is an obj_ref as defined earlier. Entries are separated by
+           semicolons. Whitespace is ignored. Examples: 3/5/6;
+           kbaseuser:myworkspace/myobject; 5/myobject/2 aworkspace/6),
+           parameter "resolved_ws_objects" of list of type "obj_ref" (A
+           string that uniquely identifies an object in the workspace
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
            third version of an object called MyFirstObject in the workspace
            called MyFirstWorkspace. 42/Panic/1 would identify the first
            version of the object name Panic in workspace with id 42.
            Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "resolved_ws_objects" of list of
-           type "obj_ref" (A string that uniquely identifies an object in the
-           workspace service. There are two ways to uniquely identify an
-           object in one string: "[ws_name or id]/[obj_name or id]/[obj_ver]"
-           - for example, "MyFirstWorkspace/MyFirstObject/3" would identify
-           the third version of an object called MyFirstObject in the
-           workspace called MyFirstWorkspace. 42/Panic/1 would identify the
-           first version of the object name Panic in workspace with id 42.
-           Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "intermediate_incoming" of list of
-           String, parameter "intermediate_outgoing" of list of String,
-           parameter "external_data" of list of type "ExternalDataUnit" (An
-           external data unit. A piece of data from a source outside the
-           Workspace. On input, only one of the resource_release_date or
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.), parameter
+           "intermediate_incoming" of list of String, parameter
+           "intermediate_outgoing" of list of String, parameter
+           "external_data" of list of type "ExternalDataUnit" (An external
+           data unit. A piece of data from a source outside the Workspace. On
+           input, only one of the resource_release_date or
            resource_release_epoch may be supplied. Both are supplied on
            output. string resource_name - the name of the resource, for
            example JGI. string resource_url - the url of the resource, for
@@ -2734,37 +2757,30 @@ class Workspace(object):
            time)), parameter "epoch" of type "epoch" (A Unix epoch (the time
            since 00:00:00 1/1/1970 UTC) in milliseconds.), parameter "refs"
            of list of type "obj_ref" (A string that uniquely identifies an
-           object in the workspace service. There are two ways to uniquely
-           identify an object in one string: "[ws_name or id]/[obj_name or
-           id]/[obj_ver]" - for example, "MyFirstWorkspace/MyFirstObject/3"
-           would identify the third version of an object called MyFirstObject
-           in the workspace called MyFirstWorkspace. 42/Panic/1 would
-           identify the first version of the object name Panic in workspace
-           with id 42. Towel/1/6 would identify the 6th version of the object
-           with id 1 in the Towel workspace.
-           "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]" - for example,
-           "kb|ws.23.obj.567.ver.2" would identify the second version of an
-           object with id 567 in a workspace with id 23. In all cases, if the
-           version number is omitted, the latest version of the object is
-           assumed.), parameter "copied" of type "obj_ref" (A string that
-           uniquely identifies an object in the workspace service. There are
-           two ways to uniquely identify an object in one string: "[ws_name
-           or id]/[obj_name or id]/[obj_ver]" - for example,
-           "MyFirstWorkspace/MyFirstObject/3" would identify the third
-           version of an object called MyFirstObject in the workspace called
+           object in the workspace service. The format is [ws_name or
+           id]/[obj_name or id]/[obj_ver]. For example,
+           MyFirstWorkspace/MyFirstObject/3 would identify the third version
+           of an object called MyFirstObject in the workspace called
            MyFirstWorkspace. 42/Panic/1 would identify the first version of
            the object name Panic in workspace with id 42. Towel/1/6 would
            identify the 6th version of the object with id 1 in the Towel
-           workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]" - for
-           example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "copy_source_inaccessible" of type
-           "boolean" (A boolean. 0 = false, other = true.), parameter
-           "extracted_ids" of mapping from type "id_type" (An id type (e.g.
-           from a typespec @id annotation: @id [idtype])) to list of type
-           "extracted_id" (An id extracted from an object.), parameter
-           "handle_error" of String, parameter "handle_stacktrace" of String
+           workspace.If the version number is omitted, the latest version of
+           the object is assumed.), parameter "copied" of type "obj_ref" (A
+           string that uniquely identifies an object in the workspace
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
+           third version of an object called MyFirstObject in the workspace
+           called MyFirstWorkspace. 42/Panic/1 would identify the first
+           version of the object name Panic in workspace with id 42.
+           Towel/1/6 would identify the 6th version of the object with id 1
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.), parameter
+           "copy_source_inaccessible" of type "boolean" (A boolean. 0 =
+           false, other = true.), parameter "extracted_ids" of mapping from
+           type "id_type" (An id type (e.g. from a typespec @id annotation:
+           @id [idtype])) to list of type "extracted_id" (An id extracted
+           from an object.), parameter "handle_error" of String, parameter
+           "handle_stacktrace" of String
         """
         return self._client.call_method(
             'Workspace.get_referenced_objects',
@@ -2872,26 +2888,28 @@ class Workspace(object):
            about a workspace. ws_id id - the numerical ID of the workspace.
            ws_name workspace - name of the workspace. username owner - name
            of the user who owns (e.g. created) this workspace. timestamp
-           moddate - date when the workspace was last modified. int objects -
-           the number of objects created in this workspace, including objects
-           that have been deleted. permission user_permission - permissions
-           for the authenticated user of this workspace. permission
-           globalread - whether this workspace is globally readable.
-           lock_status lockstat - the status of the workspace lock. usermeta
-           metadata - arbitrary user-supplied metadata about the workspace.)
-           -> tuple of size 9: parameter "id" of type "ws_id" (The unique,
-           permanent numerical ID of a workspace.), parameter "workspace" of
-           type "ws_name" (A string used as a name for a workspace. Any
-           string consisting of alphanumeric characters and "_", ".", or "-"
-           that is not an integer is acceptable. The name may optionally be
-           prefixed with the workspace owner's user name and a colon, e.g.
+           moddate - date when the workspace was last modified. int max_objid
+           - the maximum object ID appearing in this workspace. Since cloning
+           a workspace preserves object IDs, this number may be greater than
+           the number of objects in a newly cloned workspace. permission
+           user_permission - permissions for the authenticated user of this
+           workspace. permission globalread - whether this workspace is
+           globally readable. lock_status lockstat - the status of the
+           workspace lock. usermeta metadata - arbitrary user-supplied
+           metadata about the workspace.) -> tuple of size 9: parameter "id"
+           of type "ws_id" (The unique, permanent numerical ID of a
+           workspace.), parameter "workspace" of type "ws_name" (A string
+           used as a name for a workspace. Any string consisting of
+           alphanumeric characters and "_", ".", or "-" that is not an
+           integer is acceptable. The name may optionally be prefixed with
+           the workspace owner's user name and a colon, e.g.
            kbasetest:my_workspace.), parameter "owner" of type "username"
            (Login name of a KBase user account.), parameter "moddate" of type
            "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is
            either the character Z (representing the UTC timezone) or the
            difference in time to UTC in the format +/-HHMM, eg:
            2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC
-           time) 2013-04-03T08:56:32Z (UTC time)), parameter "object" of
+           time) 2013-04-03T08:56:32Z (UTC time)), parameter "max_objid" of
            Long, parameter "user_permission" of type "permission" (Represents
            the permissions a user or users have to a workspace: 'a' -
            administrator. All operations allowed. 'w' - read/write. 'r' -
@@ -2959,29 +2977,30 @@ class Workspace(object):
            Always returns the empty string. string chsum - the md5 checksum
            of the object. usermeta metadata - arbitrary user-supplied
            metadata about the object. obj_id objid - the numerical id of the
-           object.) -> tuple of size 12: parameter "id" of type "obj_name" (A
-           string used as a name for an object. Any string consisting of
-           alphanumeric characters and the characters |._- that is not an
-           integer is acceptable.), parameter "type" of type "type_string" (A
-           type string. Specifies the type and its version in a single string
-           in the format [module].[typename]-[major].[minor]: module - a
-           string. The module name of the typespec containing the type.
-           typename - a string. The name of the type as assigned by the
-           typedef statement. major - an integer. The major version of the
-           type. A change in the major version implies the type has changed
-           in a non-backwards compatible way. minor - an integer. The minor
-           version of the type. A change in the minor version implies that
-           the type has changed in a way that is backwards compatible with
-           previous type definitions. In many cases, the major and minor
-           versions are optional, and if not provided the most recent version
-           will be used. Example: MyModule.MyType-3.1), parameter "moddate"
-           of type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ,
-           where Z is either the character Z (representing the UTC timezone)
-           or the difference in time to UTC in the format +/-HHMM, eg:
-           2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC
-           time) 2013-04-03T08:56:32Z (UTC time)), parameter "instance" of
-           Long, parameter "command" of String, parameter "lastmodifier" of
-           type "username" (Login name of a KBase user account.), parameter
+           object. @deprecated object_info) -> tuple of size 12: parameter
+           "id" of type "obj_name" (A string used as a name for an object.
+           Any string consisting of alphanumeric characters and the
+           characters |._- that is not an integer is acceptable.), parameter
+           "type" of type "type_string" (A type string. Specifies the type
+           and its version in a single string in the format
+           [module].[typename]-[major].[minor]: module - a string. The module
+           name of the typespec containing the type. typename - a string. The
+           name of the type as assigned by the typedef statement. major - an
+           integer. The major version of the type. A change in the major
+           version implies the type has changed in a non-backwards compatible
+           way. minor - an integer. The minor version of the type. A change
+           in the minor version implies that the type has changed in a way
+           that is backwards compatible with previous type definitions. In
+           many cases, the major and minor versions are optional, and if not
+           provided the most recent version will be used. Example:
+           MyModule.MyType-3.1), parameter "moddate" of type "timestamp" (A
+           time in the format YYYY-MM-DDThh:mm:ssZ, where Z is either the
+           character Z (representing the UTC timezone) or the difference in
+           time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500
+           (EST time) 2013-04-03T08:56:32+0000 (UTC time)
+           2013-04-03T08:56:32Z (UTC time)), parameter "instance" of Long,
+           parameter "command" of String, parameter "lastmodifier" of type
+           "username" (Login name of a KBase user account.), parameter
            "owner" of type "username" (Login name of a KBase user account.),
            parameter "workspace" of type "ws_name" (A string used as a name
            for a workspace. Any string consisting of alphanumeric characters
@@ -3006,49 +3025,47 @@ class Workspace(object):
            must be provided. It is strongly recommended that the list is
            restricted to the workspaces of interest, or the results may be
            very large: list<ws_id> ids - the numerical IDs of the workspaces
-           of interest. list<ws_name> workspaces - names of the workspaces of
-           interest or the workspace IDs in KBase format, e.g. kb|ws.78.
-           type_string type - type of the objects to be listed.  Here,
-           omitting version information will find any objects that match the
-           provided type - e.g. Foo.Bar-0 will match Foo.Bar-0.X where X is
-           any existing version. Only one of each timestamp/epoch pair may be
-           supplied. Optional arguments: permission perm - filter objects by
-           minimum permission level. 'None' and 'readable' are ignored.
-           list<username> savedby - filter objects by the user that saved or
-           copied the object. usermeta meta - filter objects by the user
-           supplied metadata. NOTE: only one key/value pair is supported at
-           this time. A full map is provided as input for the possibility for
-           expansion in the future. timestamp after - only return objects
-           that were created after this date. timestamp before - only return
-           objects that were created before this date. epoch after_epoch -
-           only return objects that were created after this date. epoch
-           before_epoch - only return objects that were created before this
-           date. obj_id minObjectID - only return objects with an object id
-           greater or equal to this value. obj_id maxObjectID - only return
-           objects with an object id less than or equal to this value.
-           boolean showDeleted - show deleted objects in workspaces to which
-           the user has write access. boolean showOnlyDeleted - only show
+           of interest. list<ws_name> workspaces - the names of the
+           workspaces of interest. type_string type - type of the objects to
+           be listed.  Here, omitting version information will find any
+           objects that match the provided type - e.g. Foo.Bar-0 will match
+           Foo.Bar-0.X where X is any existing version. Only one of each
+           timestamp/epoch pair may be supplied. Optional arguments:
+           permission perm - filter objects by minimum permission level.
+           'None' and 'readable' are ignored. list<username> savedby - filter
+           objects by the user that saved or copied the object. usermeta meta
+           - filter objects by the user supplied metadata. NOTE: only one
+           key/value pair is supported at this time. A full map is provided
+           as input for the possibility for expansion in the future.
+           timestamp after - only return objects that were created after this
+           date. timestamp before - only return objects that were created
+           before this date. epoch after_epoch - only return objects that
+           were created after this date. epoch before_epoch - only return
+           objects that were created before this date. obj_id minObjectID -
+           only return objects with an object id greater or equal to this
+           value. obj_id maxObjectID - only return objects with an object id
+           less than or equal to this value. boolean showDeleted - show
            deleted objects in workspaces to which the user has write access.
-           boolean showHidden - show hidden objects. boolean showAllVersions
-           - show all versions of each object that match the filters rather
-           than only the most recent version. boolean includeMetadata -
-           include the user provided metadata in the returned object_info. If
-           false (0 or null), the default, the metadata will be null. boolean
+           boolean showOnlyDeleted - only show deleted objects in workspaces
+           to which the user has write access. boolean showHidden - show
+           hidden objects. boolean showAllVersions - show all versions of
+           each object that match the filters rather than only the most
+           recent version. boolean includeMetadata - include the user
+           provided metadata in the returned object_info. If false (0 or
+           null), the default, the metadata will be null. boolean
            excludeGlobal - exclude objects in global workspaces. This
            parameter only has an effect when filtering by types alone. int
-           skip - DEPRECATED. Skip the first X objects. Maximum value is
-           2^31, skip values < 0 are treated as 0, the default. int limit -
-           limit the output to X objects. Default and maximum value is 10000.
-           Limit values < 1 are treated as 10000, the default.) -> structure:
-           parameter "workspaces" of list of type "ws_name" (A string used as
-           a name for a workspace. Any string consisting of alphanumeric
-           characters and "_", ".", or "-" that is not an integer is
-           acceptable. The name may optionally be prefixed with the workspace
-           owner's user name and a colon, e.g. kbasetest:my_workspace.),
-           parameter "ids" of list of type "ws_id" (The unique, permanent
-           numerical ID of a workspace.), parameter "type" of type
-           "type_string" (A type string. Specifies the type and its version
-           in a single string in the format
+           limit - limit the output to X objects. Default and maximum value
+           is 10000. Limit values < 1 are treated as 10000, the default.) ->
+           structure: parameter "workspaces" of list of type "ws_name" (A
+           string used as a name for a workspace. Any string consisting of
+           alphanumeric characters and "_", ".", or "-" that is not an
+           integer is acceptable. The name may optionally be prefixed with
+           the workspace owner's user name and a colon, e.g.
+           kbasetest:my_workspace.), parameter "ids" of list of type "ws_id"
+           (The unique, permanent numerical ID of a workspace.), parameter
+           "type" of type "type_string" (A type string. Specifies the type
+           and its version in a single string in the format
            [module].[typename]-[major].[minor]: module - a string. The module
            name of the typespec containing the type. typename - a string. The
            name of the type as assigned by the typedef statement. major - an
@@ -3090,8 +3107,7 @@ class Workspace(object):
            "boolean" (A boolean. 0 = false, other = true.), parameter
            "includeMetadata" of type "boolean" (A boolean. 0 = false, other =
            true.), parameter "excludeGlobal" of type "boolean" (A boolean. 0
-           = false, other = true.), parameter "skip" of Long, parameter
-           "limit" of Long
+           = false, other = true.), parameter "limit" of Long
         :returns: instance of list of type "object_info" (Information about
            an object, including user provided metadata. obj_id objid - the
            numerical id of the object. obj_name name - the name of the
@@ -3146,7 +3162,7 @@ class Workspace(object):
         Retrieves the metadata for a specified object from the specified
         workspace. Provides access to metadata for all versions of the object
         via the instance parameter. Provided for backwards compatibility.
-        @deprecated Workspace.get_object_info
+        @deprecated Workspace.get_object_info3
         :param params: instance of type "get_objectmeta_params" (Input
            parameters for the "get_objectmeta" function. Required arguments:
            ws_name workspace - name of the workspace containing the object
@@ -3179,22 +3195,23 @@ class Workspace(object):
            the object is stored string ref - Deprecated. Always returns the
            empty string. string chsum - the md5 checksum of the object.
            usermeta metadata - arbitrary user-supplied metadata about the
-           object. obj_id objid - the numerical id of the object.) -> tuple
-           of size 12: parameter "id" of type "obj_name" (A string used as a
-           name for an object. Any string consisting of alphanumeric
-           characters and the characters |._- that is not an integer is
-           acceptable.), parameter "type" of type "type_string" (A type
-           string. Specifies the type and its version in a single string in
-           the format [module].[typename]-[major].[minor]: module - a string.
-           The module name of the typespec containing the type. typename - a
-           string. The name of the type as assigned by the typedef statement.
-           major - an integer. The major version of the type. A change in the
-           major version implies the type has changed in a non-backwards
-           compatible way. minor - an integer. The minor version of the type.
-           A change in the minor version implies that the type has changed in
-           a way that is backwards compatible with previous type definitions.
-           In many cases, the major and minor versions are optional, and if
-           not provided the most recent version will be used. Example:
+           object. obj_id objid - the numerical id of the object. @deprecated
+           object_info) -> tuple of size 12: parameter "id" of type
+           "obj_name" (A string used as a name for an object. Any string
+           consisting of alphanumeric characters and the characters |._- that
+           is not an integer is acceptable.), parameter "type" of type
+           "type_string" (A type string. Specifies the type and its version
+           in a single string in the format
+           [module].[typename]-[major].[minor]: module - a string. The module
+           name of the typespec containing the type. typename - a string. The
+           name of the type as assigned by the typedef statement. major - an
+           integer. The major version of the type. A change in the major
+           version implies the type has changed in a non-backwards compatible
+           way. minor - an integer. The minor version of the type. A change
+           in the minor version implies that the type has changed in a way
+           that is backwards compatible with previous type definitions. In
+           many cases, the major and minor versions are optional, and if not
+           provided the most recent version will be used. Example:
            MyModule.MyType-3.1), parameter "moddate" of type "timestamp" (A
            time in the format YYYY-MM-DDThh:mm:ssZ, where Z is either the
            character Z (representing the UTC timezone) or the difference in
@@ -3226,14 +3243,12 @@ class Workspace(object):
         Otherwise the metadata in the object_info will be null.
         This method will be replaced by the behavior of get_object_info_new
         in the future.
-        @deprecated Workspace.get_object_info_new
+        @deprecated Workspace.get_object_info3
         :param object_ids: instance of list of type "ObjectIdentity" (An
            object identifier. Select an object by either: One, and only one,
-           of the numerical id or name of the workspace, where the name can
-           also be a KBase ID including the numerical id, e.g. kb|ws.35.
-           ws_id wsid - the numerical ID of the workspace. ws_name workspace
-           - name of the workspace or the workspace ID in KBase format, e.g.
-           kb|ws.78. AND One, and only one, of the numerical id or name of
+           of the numerical id or name of the workspace. ws_id wsid - the
+           numerical ID of the workspace. ws_name workspace - the name of the
+           workspace. AND One, and only one, of the numerical id or name of
            the object. obj_id objid- the numerical ID of the object. obj_name
            name - name of the object. OPTIONALLY obj_ver ver - the version of
            the object. OR an object reference string: obj_ref ref - an object
@@ -3251,18 +3266,14 @@ class Workspace(object):
            parameter "ver" of type "obj_ver" (An object version. The version
            of the object, starting at 1.), parameter "ref" of type "obj_ref"
            (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
            third version of an object called MyFirstObject in the workspace
            called MyFirstWorkspace. 42/Panic/1 would identify the first
            version of the object name Panic in workspace with id 42.
            Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.)
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.)
         :param includeMetadata: instance of type "boolean" (A boolean. 0 =
            false, other = true.)
         :returns: instance of list of type "object_info" (Information about
@@ -3317,6 +3328,7 @@ class Workspace(object):
     def get_object_info_new(self, params, context=None):
         """
         Get information about objects from the workspace.
+        @deprecated Workspace.get_object_info3
         :param params: instance of type "GetObjectInfoNewParams" (Input
            parameters for the "get_object_info_new" function. Required
            arguments: list<ObjectSpecification> objects - the objects for
@@ -3325,79 +3337,141 @@ class Workspace(object):
            includeMetadata - include the object metadata in the returned
            information. Default false. boolean ignoreErrors - Don't throw an
            exception if an object cannot be accessed; return null for that
-           object's information instead. Default false.) -> structure:
-           parameter "objects" of list of type "ObjectSpecification" (An
-           Object Specification (OS). Inherits from ObjectIdentity. Specifies
-           which object, and which parts of that object, to retrieve from the
-           Workspace Service. The fields wsid, workspace, objid, name, ver,
-           and ref are identical to the ObjectIdentity fields. REFERENCE
-           FOLLOWING: Reference following guarantees that a user that has
-           access to an object can always see a) objects that are referenced
-           inside the object and b) objects that are referenced in the
-           object's provenance. This ensures that the user has visibility
-           into the entire provenance of the object and the object's object
-           dependencies (e.g. references). The user must have at least read
-           access to the object specified in this SO, but need not have
-           access to any further objects in the reference chain, and those
-           objects may be deleted. Optional reference following fields:
+           object's information instead. Default false. @deprecated
+           Workspace.GetObjectInfo3Params) -> structure: parameter "objects"
+           of list of type "ObjectSpecification" (An Object Specification
+           (OS). Inherits from ObjectIdentity (OI). Specifies which object,
+           and which parts of that object, to retrieve from the Workspace
+           Service. The fields wsid, workspace, objid, name, and ver are
+           identical to the OI fields. The ref field's behavior is extended
+           from OI. It maintains its previous behavior, but now also can act
+           as a reference string. See reference following below for more
+           information. REFERENCE FOLLOWING: Reference following guarantees
+           that a user that has access to an object can always see a) objects
+           that are referenced inside the object and b) objects that are
+           referenced in the object's provenance. This ensures that the user
+           has visibility into the entire provenance of the object and the
+           object's object dependencies (e.g. references). The user must have
+           at least read access to the object specified in this SO, but need
+           not have access to any further objects in the reference chain, and
+           those objects may be deleted. Optional reference following fields:
+           Note that only one of the following fields may be specified.
            ref_chain obj_path - a path to the desired object from the object
            specified in this OS. In other words, the object specified in this
            OS is assumed to be accessible to the user, and the objects in the
            object path represent a chain of references to the desired object
            at the end of the object path. If the references are all valid,
            the desired object will be returned. - OR - list<obj_ref>
-           obj_ref_path - shorthand for the obj_path. Only one of obj_path or
-           obj_ref_path may be specified. OBJECT SUBSETS: When selecting a
-           subset of an array in an object, the returned array is compressed
-           to the size of the subset, but the ordering of the array is
-           maintained. For example, if the array stored at the 'feature' key
-           of a Genome object has 4000 entries, and the object paths provided
-           are: /feature/7 /feature/3015 /feature/700 The returned feature
-           array will be of length three and the entries will consist, in
-           order, of the 7th, 700th, and 3015th entries of the original
-           array. Optional object subset fields: list<object_path> included -
-           the portions of the object to include in the object subset.
-           boolean strict_maps - if true, throw an exception if the subset
-           specification traverses a non-existant map key (default false)
-           boolean strict_arrays - if true, throw an exception if the subset
-           specification exceeds the size of an array (default true)) ->
-           structure: parameter "workspace" of type "ws_name" (A string used
-           as a name for a workspace. Any string consisting of alphanumeric
-           characters and "_", ".", or "-" that is not an integer is
-           acceptable. The name may optionally be prefixed with the workspace
-           owner's user name and a colon, e.g. kbasetest:my_workspace.),
-           parameter "wsid" of type "ws_id" (The unique, permanent numerical
-           ID of a workspace.), parameter "name" of type "obj_name" (A string
-           used as a name for an object. Any string consisting of
-           alphanumeric characters and the characters |._- that is not an
-           integer is acceptable.), parameter "objid" of type "obj_id" (The
-           unique, permanent numerical ID of an object.), parameter "ver" of
-           type "obj_ver" (An object version. The version of the object,
-           starting at 1.), parameter "ref" of type "obj_ref" (A string that
-           uniquely identifies an object in the workspace service. There are
-           two ways to uniquely identify an object in one string: "[ws_name
-           or id]/[obj_name or id]/[obj_ver]" - for example,
-           "MyFirstWorkspace/MyFirstObject/3" would identify the third
-           version of an object called MyFirstObject in the workspace called
+           obj_ref_path - shorthand for the obj_path. - OR - ref_chain
+           to_obj_path - identical to obj_path, except that the path is TO
+           the object specified in this OS, rather than from the object. In
+           other words the object specified by wsid/objid/ref etc. is the end
+           of the path, and to_obj_path is the rest of the path. The user
+           must have access to the first object in the to_obj_path. - OR -
+           list<obj_ref> to_obj_ref_path - shorthand for the to_obj_path. -
+           OR - ref_string ref - A string representing a reference path from
+           one object to another. Unlike the previous reference following
+           options, the ref_string represents the ENTIRE path from the source
+           object to the target object. As with the OI object, the ref field
+           may contain a single reference. - OR - boolean find_refence_path -
+           This is the last, slowest, and most expensive resort for getting a
+           referenced object - do not use this method unless the path to the
+           object is unavailable by any other means. Setting the
+           find_refence_path parameter to true means that the workspace
+           service will search through the object reference graph from the
+           object specified in this OS to find an object that 1) the user can
+           access, and 2) has an unbroken reference path to the target
+           object. If the search succeeds, the object will be returned as
+           normal. Note that the search will automatically fail after a
+           certain (but much larger than necessary for the vast majority of
+           cases) number of objects are traversed. OBJECT SUBSETS: When
+           selecting a subset of an array in an object, the returned array is
+           compressed to the size of the subset, but the ordering of the
+           array is maintained. For example, if the array stored at the
+           'feature' key of a Genome object has 4000 entries, and the object
+           paths provided are: /feature/7 /feature/3015 /feature/700 The
+           returned feature array will be of length three and the entries
+           will consist, in order, of the 7th, 700th, and 3015th entries of
+           the original array. Optional object subset fields:
+           list<object_path> included - the portions of the object to include
+           in the object subset. boolean strict_maps - if true, throw an
+           exception if the subset specification traverses a non-existent map
+           key (default false) boolean strict_arrays - if true, throw an
+           exception if the subset specification exceeds the size of an array
+           (default true)) -> structure: parameter "workspace" of type
+           "ws_name" (A string used as a name for a workspace. Any string
+           consisting of alphanumeric characters and "_", ".", or "-" that is
+           not an integer is acceptable. The name may optionally be prefixed
+           with the workspace owner's user name and a colon, e.g.
+           kbasetest:my_workspace.), parameter "wsid" of type "ws_id" (The
+           unique, permanent numerical ID of a workspace.), parameter "name"
+           of type "obj_name" (A string used as a name for an object. Any
+           string consisting of alphanumeric characters and the characters
+           |._- that is not an integer is acceptable.), parameter "objid" of
+           type "obj_id" (The unique, permanent numerical ID of an object.),
+           parameter "ver" of type "obj_ver" (An object version. The version
+           of the object, starting at 1.), parameter "ref" of type
+           "ref_string" (A chain of objects with references to one another as
+           a string. A single string that is semantically identical to
+           ref_chain above. Represents a path from one workspace object to
+           another through an arbitrarily number of intermediate objects
+           where each object has a dependency or provenance reference to the
+           next object. Each entry is an obj_ref as defined earlier. Entries
+           are separated by semicolons. Whitespace is ignored. Examples:
+           3/5/6; kbaseuser:myworkspace/myobject; 5/myobject/2 aworkspace/6),
+           parameter "obj_path" of type "ref_chain" (A chain of objects with
+           references to one another. An object reference chain consists of a
+           list of objects where the nth object possesses a reference, either
+           in the object itself or in the object provenance, to the n+1th
+           object.) -> list of type "ObjectIdentity" (An object identifier.
+           Select an object by either: One, and only one, of the numerical id
+           or name of the workspace. ws_id wsid - the numerical ID of the
+           workspace. ws_name workspace - the name of the workspace. AND One,
+           and only one, of the numerical id or name of the object. obj_id
+           objid- the numerical ID of the object. obj_name name - name of the
+           object. OPTIONALLY obj_ver ver - the version of the object. OR an
+           object reference string: obj_ref ref - an object reference
+           string.) -> structure: parameter "workspace" of type "ws_name" (A
+           string used as a name for a workspace. Any string consisting of
+           alphanumeric characters and "_", ".", or "-" that is not an
+           integer is acceptable. The name may optionally be prefixed with
+           the workspace owner's user name and a colon, e.g.
+           kbasetest:my_workspace.), parameter "wsid" of type "ws_id" (The
+           unique, permanent numerical ID of a workspace.), parameter "name"
+           of type "obj_name" (A string used as a name for an object. Any
+           string consisting of alphanumeric characters and the characters
+           |._- that is not an integer is acceptable.), parameter "objid" of
+           type "obj_id" (The unique, permanent numerical ID of an object.),
+           parameter "ver" of type "obj_ver" (An object version. The version
+           of the object, starting at 1.), parameter "ref" of type "obj_ref"
+           (A string that uniquely identifies an object in the workspace
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
+           third version of an object called MyFirstObject in the workspace
+           called MyFirstWorkspace. 42/Panic/1 would identify the first
+           version of the object name Panic in workspace with id 42.
+           Towel/1/6 would identify the 6th version of the object with id 1
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.), parameter
+           "obj_ref_path" of list of type "obj_ref" (A string that uniquely
+           identifies an object in the workspace service. The format is
+           [ws_name or id]/[obj_name or id]/[obj_ver]. For example,
+           MyFirstWorkspace/MyFirstObject/3 would identify the third version
+           of an object called MyFirstObject in the workspace called
            MyFirstWorkspace. 42/Panic/1 would identify the first version of
            the object name Panic in workspace with id 42. Towel/1/6 would
            identify the 6th version of the object with id 1 in the Towel
-           workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]" - for
-           example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "obj_path" of type "ref_chain" (A
-           chain of objects with references to one another. An object
-           reference chain consists of a list of objects where the nth object
-           possesses a reference, either in the object itself or in the
-           object provenance, to the n+1th object.) -> list of type
+           workspace.If the version number is omitted, the latest version of
+           the object is assumed.), parameter "to_obj_path" of type
+           "ref_chain" (A chain of objects with references to one another. An
+           object reference chain consists of a list of objects where the nth
+           object possesses a reference, either in the object itself or in
+           the object provenance, to the n+1th object.) -> list of type
            "ObjectIdentity" (An object identifier. Select an object by
            either: One, and only one, of the numerical id or name of the
-           workspace, where the name can also be a KBase ID including the
-           numerical id, e.g. kb|ws.35. ws_id wsid - the numerical ID of the
-           workspace. ws_name workspace - name of the workspace or the
-           workspace ID in KBase format, e.g. kb|ws.78. AND One, and only
-           one, of the numerical id or name of the object. obj_id objid- the
+           workspace. ws_id wsid - the numerical ID of the workspace. ws_name
+           workspace - the name of the workspace. AND One, and only one, of
+           the numerical id or name of the object. obj_id objid- the
            numerical ID of the object. obj_name name - name of the object.
            OPTIONALLY obj_ver ver - the version of the object. OR an object
            reference string: obj_ref ref - an object reference string.) ->
@@ -3414,50 +3488,43 @@ class Workspace(object):
            unique, permanent numerical ID of an object.), parameter "ver" of
            type "obj_ver" (An object version. The version of the object,
            starting at 1.), parameter "ref" of type "obj_ref" (A string that
-           uniquely identifies an object in the workspace service. There are
-           two ways to uniquely identify an object in one string: "[ws_name
-           or id]/[obj_name or id]/[obj_ver]" - for example,
-           "MyFirstWorkspace/MyFirstObject/3" would identify the third
-           version of an object called MyFirstObject in the workspace called
+           uniquely identifies an object in the workspace service. The format
+           is [ws_name or id]/[obj_name or id]/[obj_ver]. For example,
+           MyFirstWorkspace/MyFirstObject/3 would identify the third version
+           of an object called MyFirstObject in the workspace called
            MyFirstWorkspace. 42/Panic/1 would identify the first version of
            the object name Panic in workspace with id 42. Towel/1/6 would
            identify the 6th version of the object with id 1 in the Towel
-           workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]" - for
-           example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "obj_ref_path" of list of type
-           "obj_ref" (A string that uniquely identifies an object in the
-           workspace service. There are two ways to uniquely identify an
-           object in one string: "[ws_name or id]/[obj_name or id]/[obj_ver]"
-           - for example, "MyFirstWorkspace/MyFirstObject/3" would identify
-           the third version of an object called MyFirstObject in the
-           workspace called MyFirstWorkspace. 42/Panic/1 would identify the
-           first version of the object name Panic in workspace with id 42.
-           Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "included" of list of type
-           "object_path" (A path into an object. Identify a sub portion of an
-           object by providing the path, delimited by a slash (/), to that
-           portion of the object. Thus the path may not have slashes in the
-           structure or mapping keys. Examples: /foo/bar/3 - specifies the
-           bar key of the foo mapping and the 3rd entry of the array if bar
-           maps to an array or the value mapped to the string "3" if bar maps
-           to a map. /foo/bar/[*]/baz - specifies the baz field of all the
-           objects in the list mapped by the bar key in the map foo.
-           /foo/asterisk/baz - specifies the baz field of all the objects in
-           the values of the foo mapping. Swap 'asterisk' for * in the path.
-           In case you need to use '/' or '~' in path items use JSON Pointer
-           notation defined here: http://tools.ietf.org/html/rfc6901),
-           parameter "strict_maps" of type "boolean" (A boolean. 0 = false,
-           other = true.), parameter "strict_arrays" of type "boolean" (A
-           boolean. 0 = false, other = true.), parameter "includeMetadata" of
-           type "boolean" (A boolean. 0 = false, other = true.), parameter
-           "ignoreErrors" of type "boolean" (A boolean. 0 = false, other =
-           true.)
+           workspace.If the version number is omitted, the latest version of
+           the object is assumed.), parameter "to_obj_ref_path" of list of
+           type "obj_ref" (A string that uniquely identifies an object in the
+           workspace service. The format is [ws_name or id]/[obj_name or
+           id]/[obj_ver]. For example, MyFirstWorkspace/MyFirstObject/3 would
+           identify the third version of an object called MyFirstObject in
+           the workspace called MyFirstWorkspace. 42/Panic/1 would identify
+           the first version of the object name Panic in workspace with id
+           42. Towel/1/6 would identify the 6th version of the object with id
+           1 in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.), parameter
+           "find_reference_path" of type "boolean" (A boolean. 0 = false,
+           other = true.), parameter "included" of list of type "object_path"
+           (A path into an object. Identify a sub portion of an object by
+           providing the path, delimited by a slash (/), to that portion of
+           the object. Thus the path may not have slashes in the structure or
+           mapping keys. Examples: /foo/bar/3 - specifies the bar key of the
+           foo mapping and the 3rd entry of the array if bar maps to an array
+           or the value mapped to the string "3" if bar maps to a map.
+           /foo/bar/[*]/baz - specifies the baz field of all the objects in
+           the list mapped by the bar key in the map foo. /foo/asterisk/baz -
+           specifies the baz field of all the objects in the values of the
+           foo mapping. Swap 'asterisk' for * in the path. In case you need
+           to use '/' or '~' in path items use JSON Pointer notation defined
+           here: http://tools.ietf.org/html/rfc6901), parameter "strict_maps"
+           of type "boolean" (A boolean. 0 = false, other = true.), parameter
+           "strict_arrays" of type "boolean" (A boolean. 0 = false, other =
+           true.), parameter "includeMetadata" of type "boolean" (A boolean.
+           0 = false, other = true.), parameter "ignoreErrors" of type
+           "boolean" (A boolean. 0 = false, other = true.)
         :returns: instance of list of type "object_info" (Information about
            an object, including user provided metadata. obj_id objid - the
            numerical id of the object. obj_name name - the name of the
@@ -3507,6 +3574,268 @@ class Workspace(object):
             'Workspace.get_object_info_new',
             [params], self._service_ver, context)
 
+    def get_object_info3(self, params, context=None):
+        """
+        :param params: instance of type "GetObjectInfo3Params" (Input
+           parameters for the "get_object_info3" function. Required
+           arguments: list<ObjectSpecification> objects - the objects for
+           which the information should be fetched. Subsetting related
+           parameters are ignored. Optional arguments: boolean
+           includeMetadata - include the object metadata in the returned
+           information. Default false. boolean ignoreErrors - Don't throw an
+           exception if an object cannot be accessed; return null for that
+           object's information and path instead. Default false.) ->
+           structure: parameter "objects" of list of type
+           "ObjectSpecification" (An Object Specification (OS). Inherits from
+           ObjectIdentity (OI). Specifies which object, and which parts of
+           that object, to retrieve from the Workspace Service. The fields
+           wsid, workspace, objid, name, and ver are identical to the OI
+           fields. The ref field's behavior is extended from OI. It maintains
+           its previous behavior, but now also can act as a reference string.
+           See reference following below for more information. REFERENCE
+           FOLLOWING: Reference following guarantees that a user that has
+           access to an object can always see a) objects that are referenced
+           inside the object and b) objects that are referenced in the
+           object's provenance. This ensures that the user has visibility
+           into the entire provenance of the object and the object's object
+           dependencies (e.g. references). The user must have at least read
+           access to the object specified in this SO, but need not have
+           access to any further objects in the reference chain, and those
+           objects may be deleted. Optional reference following fields: Note
+           that only one of the following fields may be specified. ref_chain
+           obj_path - a path to the desired object from the object specified
+           in this OS. In other words, the object specified in this OS is
+           assumed to be accessible to the user, and the objects in the
+           object path represent a chain of references to the desired object
+           at the end of the object path. If the references are all valid,
+           the desired object will be returned. - OR - list<obj_ref>
+           obj_ref_path - shorthand for the obj_path. - OR - ref_chain
+           to_obj_path - identical to obj_path, except that the path is TO
+           the object specified in this OS, rather than from the object. In
+           other words the object specified by wsid/objid/ref etc. is the end
+           of the path, and to_obj_path is the rest of the path. The user
+           must have access to the first object in the to_obj_path. - OR -
+           list<obj_ref> to_obj_ref_path - shorthand for the to_obj_path. -
+           OR - ref_string ref - A string representing a reference path from
+           one object to another. Unlike the previous reference following
+           options, the ref_string represents the ENTIRE path from the source
+           object to the target object. As with the OI object, the ref field
+           may contain a single reference. - OR - boolean find_refence_path -
+           This is the last, slowest, and most expensive resort for getting a
+           referenced object - do not use this method unless the path to the
+           object is unavailable by any other means. Setting the
+           find_refence_path parameter to true means that the workspace
+           service will search through the object reference graph from the
+           object specified in this OS to find an object that 1) the user can
+           access, and 2) has an unbroken reference path to the target
+           object. If the search succeeds, the object will be returned as
+           normal. Note that the search will automatically fail after a
+           certain (but much larger than necessary for the vast majority of
+           cases) number of objects are traversed. OBJECT SUBSETS: When
+           selecting a subset of an array in an object, the returned array is
+           compressed to the size of the subset, but the ordering of the
+           array is maintained. For example, if the array stored at the
+           'feature' key of a Genome object has 4000 entries, and the object
+           paths provided are: /feature/7 /feature/3015 /feature/700 The
+           returned feature array will be of length three and the entries
+           will consist, in order, of the 7th, 700th, and 3015th entries of
+           the original array. Optional object subset fields:
+           list<object_path> included - the portions of the object to include
+           in the object subset. boolean strict_maps - if true, throw an
+           exception if the subset specification traverses a non-existent map
+           key (default false) boolean strict_arrays - if true, throw an
+           exception if the subset specification exceeds the size of an array
+           (default true)) -> structure: parameter "workspace" of type
+           "ws_name" (A string used as a name for a workspace. Any string
+           consisting of alphanumeric characters and "_", ".", or "-" that is
+           not an integer is acceptable. The name may optionally be prefixed
+           with the workspace owner's user name and a colon, e.g.
+           kbasetest:my_workspace.), parameter "wsid" of type "ws_id" (The
+           unique, permanent numerical ID of a workspace.), parameter "name"
+           of type "obj_name" (A string used as a name for an object. Any
+           string consisting of alphanumeric characters and the characters
+           |._- that is not an integer is acceptable.), parameter "objid" of
+           type "obj_id" (The unique, permanent numerical ID of an object.),
+           parameter "ver" of type "obj_ver" (An object version. The version
+           of the object, starting at 1.), parameter "ref" of type
+           "ref_string" (A chain of objects with references to one another as
+           a string. A single string that is semantically identical to
+           ref_chain above. Represents a path from one workspace object to
+           another through an arbitrarily number of intermediate objects
+           where each object has a dependency or provenance reference to the
+           next object. Each entry is an obj_ref as defined earlier. Entries
+           are separated by semicolons. Whitespace is ignored. Examples:
+           3/5/6; kbaseuser:myworkspace/myobject; 5/myobject/2 aworkspace/6),
+           parameter "obj_path" of type "ref_chain" (A chain of objects with
+           references to one another. An object reference chain consists of a
+           list of objects where the nth object possesses a reference, either
+           in the object itself or in the object provenance, to the n+1th
+           object.) -> list of type "ObjectIdentity" (An object identifier.
+           Select an object by either: One, and only one, of the numerical id
+           or name of the workspace. ws_id wsid - the numerical ID of the
+           workspace. ws_name workspace - the name of the workspace. AND One,
+           and only one, of the numerical id or name of the object. obj_id
+           objid- the numerical ID of the object. obj_name name - name of the
+           object. OPTIONALLY obj_ver ver - the version of the object. OR an
+           object reference string: obj_ref ref - an object reference
+           string.) -> structure: parameter "workspace" of type "ws_name" (A
+           string used as a name for a workspace. Any string consisting of
+           alphanumeric characters and "_", ".", or "-" that is not an
+           integer is acceptable. The name may optionally be prefixed with
+           the workspace owner's user name and a colon, e.g.
+           kbasetest:my_workspace.), parameter "wsid" of type "ws_id" (The
+           unique, permanent numerical ID of a workspace.), parameter "name"
+           of type "obj_name" (A string used as a name for an object. Any
+           string consisting of alphanumeric characters and the characters
+           |._- that is not an integer is acceptable.), parameter "objid" of
+           type "obj_id" (The unique, permanent numerical ID of an object.),
+           parameter "ver" of type "obj_ver" (An object version. The version
+           of the object, starting at 1.), parameter "ref" of type "obj_ref"
+           (A string that uniquely identifies an object in the workspace
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
+           third version of an object called MyFirstObject in the workspace
+           called MyFirstWorkspace. 42/Panic/1 would identify the first
+           version of the object name Panic in workspace with id 42.
+           Towel/1/6 would identify the 6th version of the object with id 1
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.), parameter
+           "obj_ref_path" of list of type "obj_ref" (A string that uniquely
+           identifies an object in the workspace service. The format is
+           [ws_name or id]/[obj_name or id]/[obj_ver]. For example,
+           MyFirstWorkspace/MyFirstObject/3 would identify the third version
+           of an object called MyFirstObject in the workspace called
+           MyFirstWorkspace. 42/Panic/1 would identify the first version of
+           the object name Panic in workspace with id 42. Towel/1/6 would
+           identify the 6th version of the object with id 1 in the Towel
+           workspace.If the version number is omitted, the latest version of
+           the object is assumed.), parameter "to_obj_path" of type
+           "ref_chain" (A chain of objects with references to one another. An
+           object reference chain consists of a list of objects where the nth
+           object possesses a reference, either in the object itself or in
+           the object provenance, to the n+1th object.) -> list of type
+           "ObjectIdentity" (An object identifier. Select an object by
+           either: One, and only one, of the numerical id or name of the
+           workspace. ws_id wsid - the numerical ID of the workspace. ws_name
+           workspace - the name of the workspace. AND One, and only one, of
+           the numerical id or name of the object. obj_id objid- the
+           numerical ID of the object. obj_name name - name of the object.
+           OPTIONALLY obj_ver ver - the version of the object. OR an object
+           reference string: obj_ref ref - an object reference string.) ->
+           structure: parameter "workspace" of type "ws_name" (A string used
+           as a name for a workspace. Any string consisting of alphanumeric
+           characters and "_", ".", or "-" that is not an integer is
+           acceptable. The name may optionally be prefixed with the workspace
+           owner's user name and a colon, e.g. kbasetest:my_workspace.),
+           parameter "wsid" of type "ws_id" (The unique, permanent numerical
+           ID of a workspace.), parameter "name" of type "obj_name" (A string
+           used as a name for an object. Any string consisting of
+           alphanumeric characters and the characters |._- that is not an
+           integer is acceptable.), parameter "objid" of type "obj_id" (The
+           unique, permanent numerical ID of an object.), parameter "ver" of
+           type "obj_ver" (An object version. The version of the object,
+           starting at 1.), parameter "ref" of type "obj_ref" (A string that
+           uniquely identifies an object in the workspace service. The format
+           is [ws_name or id]/[obj_name or id]/[obj_ver]. For example,
+           MyFirstWorkspace/MyFirstObject/3 would identify the third version
+           of an object called MyFirstObject in the workspace called
+           MyFirstWorkspace. 42/Panic/1 would identify the first version of
+           the object name Panic in workspace with id 42. Towel/1/6 would
+           identify the 6th version of the object with id 1 in the Towel
+           workspace.If the version number is omitted, the latest version of
+           the object is assumed.), parameter "to_obj_ref_path" of list of
+           type "obj_ref" (A string that uniquely identifies an object in the
+           workspace service. The format is [ws_name or id]/[obj_name or
+           id]/[obj_ver]. For example, MyFirstWorkspace/MyFirstObject/3 would
+           identify the third version of an object called MyFirstObject in
+           the workspace called MyFirstWorkspace. 42/Panic/1 would identify
+           the first version of the object name Panic in workspace with id
+           42. Towel/1/6 would identify the 6th version of the object with id
+           1 in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.), parameter
+           "find_reference_path" of type "boolean" (A boolean. 0 = false,
+           other = true.), parameter "included" of list of type "object_path"
+           (A path into an object. Identify a sub portion of an object by
+           providing the path, delimited by a slash (/), to that portion of
+           the object. Thus the path may not have slashes in the structure or
+           mapping keys. Examples: /foo/bar/3 - specifies the bar key of the
+           foo mapping and the 3rd entry of the array if bar maps to an array
+           or the value mapped to the string "3" if bar maps to a map.
+           /foo/bar/[*]/baz - specifies the baz field of all the objects in
+           the list mapped by the bar key in the map foo. /foo/asterisk/baz -
+           specifies the baz field of all the objects in the values of the
+           foo mapping. Swap 'asterisk' for * in the path. In case you need
+           to use '/' or '~' in path items use JSON Pointer notation defined
+           here: http://tools.ietf.org/html/rfc6901), parameter "strict_maps"
+           of type "boolean" (A boolean. 0 = false, other = true.), parameter
+           "strict_arrays" of type "boolean" (A boolean. 0 = false, other =
+           true.), parameter "includeMetadata" of type "boolean" (A boolean.
+           0 = false, other = true.), parameter "ignoreErrors" of type
+           "boolean" (A boolean. 0 = false, other = true.)
+        :returns: instance of type "GetObjectInfo3Results" (Output from the
+           get_object_info3 function. list<object_info> infos - the
+           object_info data for each object. list<list<obj_ref> paths - the
+           path to the object through the object reference graph for each
+           object. All the references in the path are absolute.) ->
+           structure: parameter "infos" of list of type "object_info"
+           (Information about an object, including user provided metadata.
+           obj_id objid - the numerical id of the object. obj_name name - the
+           name of the object. type_string type - the type of the object.
+           timestamp save_date - the save date of the object. obj_ver ver -
+           the version of the object. username saved_by - the user that saved
+           or copied the object. ws_id wsid - the workspace containing the
+           object. ws_name workspace - the workspace containing the object.
+           string chsum - the md5 checksum of the object. int size - the size
+           of the object in bytes. usermeta meta - arbitrary user-supplied
+           metadata about the object.) -> tuple of size 11: parameter "objid"
+           of type "obj_id" (The unique, permanent numerical ID of an
+           object.), parameter "name" of type "obj_name" (A string used as a
+           name for an object. Any string consisting of alphanumeric
+           characters and the characters |._- that is not an integer is
+           acceptable.), parameter "type" of type "type_string" (A type
+           string. Specifies the type and its version in a single string in
+           the format [module].[typename]-[major].[minor]: module - a string.
+           The module name of the typespec containing the type. typename - a
+           string. The name of the type as assigned by the typedef statement.
+           major - an integer. The major version of the type. A change in the
+           major version implies the type has changed in a non-backwards
+           compatible way. minor - an integer. The minor version of the type.
+           A change in the minor version implies that the type has changed in
+           a way that is backwards compatible with previous type definitions.
+           In many cases, the major and minor versions are optional, and if
+           not provided the most recent version will be used. Example:
+           MyModule.MyType-3.1), parameter "save_date" of type "timestamp" (A
+           time in the format YYYY-MM-DDThh:mm:ssZ, where Z is either the
+           character Z (representing the UTC timezone) or the difference in
+           time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500
+           (EST time) 2013-04-03T08:56:32+0000 (UTC time)
+           2013-04-03T08:56:32Z (UTC time)), parameter "version" of Long,
+           parameter "saved_by" of type "username" (Login name of a KBase
+           user account.), parameter "wsid" of type "ws_id" (The unique,
+           permanent numerical ID of a workspace.), parameter "workspace" of
+           type "ws_name" (A string used as a name for a workspace. Any
+           string consisting of alphanumeric characters and "_", ".", or "-"
+           that is not an integer is acceptable. The name may optionally be
+           prefixed with the workspace owner's user name and a colon, e.g.
+           kbasetest:my_workspace.), parameter "chsum" of String, parameter
+           "size" of Long, parameter "meta" of type "usermeta" (User provided
+           metadata about an object. Arbitrary key-value pairs provided by
+           the user.) -> mapping from String to String, parameter "paths" of
+           list of list of type "obj_ref" (A string that uniquely identifies
+           an object in the workspace service. The format is [ws_name or
+           id]/[obj_name or id]/[obj_ver]. For example,
+           MyFirstWorkspace/MyFirstObject/3 would identify the third version
+           of an object called MyFirstObject in the workspace called
+           MyFirstWorkspace. 42/Panic/1 would identify the first version of
+           the object name Panic in workspace with id 42. Towel/1/6 would
+           identify the 6th version of the object with id 1 in the Towel
+           workspace.If the version number is omitted, the latest version of
+           the object is assumed.)
+        """
+        return self._client.call_method(
+            'Workspace.get_object_info3',
+            [params], self._service_ver, context)
+
     def rename_workspace(self, params, context=None):
         """
         Rename a workspace.
@@ -3516,10 +3845,8 @@ class Workspace(object):
            ws_name new_name - the new name for the workspace.) -> structure:
            parameter "wsi" of type "WorkspaceIdentity" (A workspace
            identifier. Select a workspace by one, and only one, of the
-           numerical id or name, where the name can also be a KBase ID
-           including the numerical id, e.g. kb|ws.35. ws_id id - the
-           numerical ID of the workspace. ws_name workspace - name of the
-           workspace or the workspace ID in KBase format, e.g. kb|ws.78.) ->
+           numerical id or name. ws_id id - the numerical ID of the
+           workspace. ws_name workspace - the name of the workspace.) ->
            structure: parameter "workspace" of type "ws_name" (A string used
            as a name for a workspace. Any string consisting of alphanumeric
            characters and "_", ".", or "-" that is not an integer is
@@ -3536,26 +3863,28 @@ class Workspace(object):
            workspace. ws_id id - the numerical ID of the workspace. ws_name
            workspace - name of the workspace. username owner - name of the
            user who owns (e.g. created) this workspace. timestamp moddate -
-           date when the workspace was last modified. int objects - the
-           number of objects created in this workspace, including objects
-           that have been deleted. permission user_permission - permissions
-           for the authenticated user of this workspace. permission
-           globalread - whether this workspace is globally readable.
-           lock_status lockstat - the status of the workspace lock. usermeta
-           metadata - arbitrary user-supplied metadata about the workspace.)
-           -> tuple of size 9: parameter "id" of type "ws_id" (The unique,
-           permanent numerical ID of a workspace.), parameter "workspace" of
-           type "ws_name" (A string used as a name for a workspace. Any
-           string consisting of alphanumeric characters and "_", ".", or "-"
-           that is not an integer is acceptable. The name may optionally be
-           prefixed with the workspace owner's user name and a colon, e.g.
+           date when the workspace was last modified. int max_objid - the
+           maximum object ID appearing in this workspace. Since cloning a
+           workspace preserves object IDs, this number may be greater than
+           the number of objects in a newly cloned workspace. permission
+           user_permission - permissions for the authenticated user of this
+           workspace. permission globalread - whether this workspace is
+           globally readable. lock_status lockstat - the status of the
+           workspace lock. usermeta metadata - arbitrary user-supplied
+           metadata about the workspace.) -> tuple of size 9: parameter "id"
+           of type "ws_id" (The unique, permanent numerical ID of a
+           workspace.), parameter "workspace" of type "ws_name" (A string
+           used as a name for a workspace. Any string consisting of
+           alphanumeric characters and "_", ".", or "-" that is not an
+           integer is acceptable. The name may optionally be prefixed with
+           the workspace owner's user name and a colon, e.g.
            kbasetest:my_workspace.), parameter "owner" of type "username"
            (Login name of a KBase user account.), parameter "moddate" of type
            "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is
            either the character Z (representing the UTC timezone) or the
            difference in time to UTC in the format +/-HHMM, eg:
            2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC
-           time) 2013-04-03T08:56:32Z (UTC time)), parameter "object" of
+           time) 2013-04-03T08:56:32Z (UTC time)), parameter "max_objid" of
            Long, parameter "user_permission" of type "permission" (Represents
            the permissions a user or users have to a workspace: 'a' -
            administrator. All operations allowed. 'w' - read/write. 'r' -
@@ -3582,11 +3911,9 @@ class Workspace(object):
            new name for the object.) -> structure: parameter "obj" of type
            "ObjectIdentity" (An object identifier. Select an object by
            either: One, and only one, of the numerical id or name of the
-           workspace, where the name can also be a KBase ID including the
-           numerical id, e.g. kb|ws.35. ws_id wsid - the numerical ID of the
-           workspace. ws_name workspace - name of the workspace or the
-           workspace ID in KBase format, e.g. kb|ws.78. AND One, and only
-           one, of the numerical id or name of the object. obj_id objid- the
+           workspace. ws_id wsid - the numerical ID of the workspace. ws_name
+           workspace - the name of the workspace. AND One, and only one, of
+           the numerical id or name of the object. obj_id objid- the
            numerical ID of the object. obj_name name - name of the object.
            OPTIONALLY obj_ver ver - the version of the object. OR an object
            reference string: obj_ref ref - an object reference string.) ->
@@ -3603,20 +3930,16 @@ class Workspace(object):
            unique, permanent numerical ID of an object.), parameter "ver" of
            type "obj_ver" (An object version. The version of the object,
            starting at 1.), parameter "ref" of type "obj_ref" (A string that
-           uniquely identifies an object in the workspace service. There are
-           two ways to uniquely identify an object in one string: "[ws_name
-           or id]/[obj_name or id]/[obj_ver]" - for example,
-           "MyFirstWorkspace/MyFirstObject/3" would identify the third
-           version of an object called MyFirstObject in the workspace called
+           uniquely identifies an object in the workspace service. The format
+           is [ws_name or id]/[obj_name or id]/[obj_ver]. For example,
+           MyFirstWorkspace/MyFirstObject/3 would identify the third version
+           of an object called MyFirstObject in the workspace called
            MyFirstWorkspace. 42/Panic/1 would identify the first version of
            the object name Panic in workspace with id 42. Towel/1/6 would
            identify the 6th version of the object with id 1 in the Towel
-           workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]" - for
-           example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "new_name" of type "obj_name" (A
-           string used as a name for an object. Any string consisting of
+           workspace.If the version number is omitted, the latest version of
+           the object is assumed.), parameter "new_name" of type "obj_name"
+           (A string used as a name for an object. Any string consisting of
            alphanumeric characters and the characters |._- that is not an
            integer is acceptable.)
         :returns: instance of type "object_info" (Information about an
@@ -3681,46 +4004,9 @@ class Workspace(object):
            object to copy. ObjectIdentity to - where to copy the object.) ->
            structure: parameter "from" of type "ObjectIdentity" (An object
            identifier. Select an object by either: One, and only one, of the
-           numerical id or name of the workspace, where the name can also be
-           a KBase ID including the numerical id, e.g. kb|ws.35. ws_id wsid -
-           the numerical ID of the workspace. ws_name workspace - name of the
-           workspace or the workspace ID in KBase format, e.g. kb|ws.78. AND
-           One, and only one, of the numerical id or name of the object.
-           obj_id objid- the numerical ID of the object. obj_name name - name
-           of the object. OPTIONALLY obj_ver ver - the version of the object.
-           OR an object reference string: obj_ref ref - an object reference
-           string.) -> structure: parameter "workspace" of type "ws_name" (A
-           string used as a name for a workspace. Any string consisting of
-           alphanumeric characters and "_", ".", or "-" that is not an
-           integer is acceptable. The name may optionally be prefixed with
-           the workspace owner's user name and a colon, e.g.
-           kbasetest:my_workspace.), parameter "wsid" of type "ws_id" (The
-           unique, permanent numerical ID of a workspace.), parameter "name"
-           of type "obj_name" (A string used as a name for an object. Any
-           string consisting of alphanumeric characters and the characters
-           |._- that is not an integer is acceptable.), parameter "objid" of
-           type "obj_id" (The unique, permanent numerical ID of an object.),
-           parameter "ver" of type "obj_ver" (An object version. The version
-           of the object, starting at 1.), parameter "ref" of type "obj_ref"
-           (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
-           third version of an object called MyFirstObject in the workspace
-           called MyFirstWorkspace. 42/Panic/1 would identify the first
-           version of the object name Panic in workspace with id 42.
-           Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.), parameter "to" of type "ObjectIdentity" (An
-           object identifier. Select an object by either: One, and only one,
-           of the numerical id or name of the workspace, where the name can
-           also be a KBase ID including the numerical id, e.g. kb|ws.35.
-           ws_id wsid - the numerical ID of the workspace. ws_name workspace
-           - name of the workspace or the workspace ID in KBase format, e.g.
-           kb|ws.78. AND One, and only one, of the numerical id or name of
+           numerical id or name of the workspace. ws_id wsid - the numerical
+           ID of the workspace. ws_name workspace - the name of the
+           workspace. AND One, and only one, of the numerical id or name of
            the object. obj_id objid- the numerical ID of the object. obj_name
            name - name of the object. OPTIONALLY obj_ver ver - the version of
            the object. OR an object reference string: obj_ref ref - an object
@@ -3738,18 +4024,44 @@ class Workspace(object):
            parameter "ver" of type "obj_ver" (An object version. The version
            of the object, starting at 1.), parameter "ref" of type "obj_ref"
            (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
            third version of an object called MyFirstObject in the workspace
            called MyFirstWorkspace. 42/Panic/1 would identify the first
            version of the object name Panic in workspace with id 42.
            Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.)
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.), parameter "to" of type
+           "ObjectIdentity" (An object identifier. Select an object by
+           either: One, and only one, of the numerical id or name of the
+           workspace. ws_id wsid - the numerical ID of the workspace. ws_name
+           workspace - the name of the workspace. AND One, and only one, of
+           the numerical id or name of the object. obj_id objid- the
+           numerical ID of the object. obj_name name - name of the object.
+           OPTIONALLY obj_ver ver - the version of the object. OR an object
+           reference string: obj_ref ref - an object reference string.) ->
+           structure: parameter "workspace" of type "ws_name" (A string used
+           as a name for a workspace. Any string consisting of alphanumeric
+           characters and "_", ".", or "-" that is not an integer is
+           acceptable. The name may optionally be prefixed with the workspace
+           owner's user name and a colon, e.g. kbasetest:my_workspace.),
+           parameter "wsid" of type "ws_id" (The unique, permanent numerical
+           ID of a workspace.), parameter "name" of type "obj_name" (A string
+           used as a name for an object. Any string consisting of
+           alphanumeric characters and the characters |._- that is not an
+           integer is acceptable.), parameter "objid" of type "obj_id" (The
+           unique, permanent numerical ID of an object.), parameter "ver" of
+           type "obj_ver" (An object version. The version of the object,
+           starting at 1.), parameter "ref" of type "obj_ref" (A string that
+           uniquely identifies an object in the workspace service. The format
+           is [ws_name or id]/[obj_name or id]/[obj_ver]. For example,
+           MyFirstWorkspace/MyFirstObject/3 would identify the third version
+           of an object called MyFirstObject in the workspace called
+           MyFirstWorkspace. 42/Panic/1 would identify the first version of
+           the object name Panic in workspace with id 42. Towel/1/6 would
+           identify the 6th version of the object with id 1 in the Towel
+           workspace.If the version number is omitted, the latest version of
+           the object is assumed.)
         :returns: instance of type "object_info" (Information about an
            object, including user provided metadata. obj_id objid - the
            numerical id of the object. obj_name name - the name of the
@@ -3806,19 +4118,17 @@ class Workspace(object):
                 specified in the ObjectIdentity.
         :param object: instance of type "ObjectIdentity" (An object
            identifier. Select an object by either: One, and only one, of the
-           numerical id or name of the workspace, where the name can also be
-           a KBase ID including the numerical id, e.g. kb|ws.35. ws_id wsid -
-           the numerical ID of the workspace. ws_name workspace - name of the
-           workspace or the workspace ID in KBase format, e.g. kb|ws.78. AND
-           One, and only one, of the numerical id or name of the object.
-           obj_id objid- the numerical ID of the object. obj_name name - name
-           of the object. OPTIONALLY obj_ver ver - the version of the object.
-           OR an object reference string: obj_ref ref - an object reference
-           string.) -> structure: parameter "workspace" of type "ws_name" (A
-           string used as a name for a workspace. Any string consisting of
-           alphanumeric characters and "_", ".", or "-" that is not an
-           integer is acceptable. The name may optionally be prefixed with
-           the workspace owner's user name and a colon, e.g.
+           numerical id or name of the workspace. ws_id wsid - the numerical
+           ID of the workspace. ws_name workspace - the name of the
+           workspace. AND One, and only one, of the numerical id or name of
+           the object. obj_id objid- the numerical ID of the object. obj_name
+           name - name of the object. OPTIONALLY obj_ver ver - the version of
+           the object. OR an object reference string: obj_ref ref - an object
+           reference string.) -> structure: parameter "workspace" of type
+           "ws_name" (A string used as a name for a workspace. Any string
+           consisting of alphanumeric characters and "_", ".", or "-" that is
+           not an integer is acceptable. The name may optionally be prefixed
+           with the workspace owner's user name and a colon, e.g.
            kbasetest:my_workspace.), parameter "wsid" of type "ws_id" (The
            unique, permanent numerical ID of a workspace.), parameter "name"
            of type "obj_name" (A string used as a name for an object. Any
@@ -3828,18 +4138,14 @@ class Workspace(object):
            parameter "ver" of type "obj_ver" (An object version. The version
            of the object, starting at 1.), parameter "ref" of type "obj_ref"
            (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
            third version of an object called MyFirstObject in the workspace
            called MyFirstWorkspace. 42/Panic/1 would identify the first
            version of the object name Panic in workspace with id 42.
            Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.)
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.)
         :returns: instance of type "object_info" (Information about an
            object, including user provided metadata. obj_id objid - the
            numerical id of the object. obj_name name - the name of the
@@ -3903,10 +4209,8 @@ class Workspace(object):
            hidden objects in the results. Default false.) -> structure:
            parameter "workspaces" of list of type "WorkspaceIdentity" (A
            workspace identifier. Select a workspace by one, and only one, of
-           the numerical id or name, where the name can also be a KBase ID
-           including the numerical id, e.g. kb|ws.35. ws_id id - the
-           numerical ID of the workspace. ws_name workspace - name of the
-           workspace or the workspace ID in KBase format, e.g. kb|ws.78.) ->
+           the numerical id or name. ws_id id - the numerical ID of the
+           workspace. ws_name workspace - the name of the workspace.) ->
            structure: parameter "workspace" of type "ws_name" (A string used
            as a name for a workspace. Any string consisting of alphanumeric
            characters and "_", ".", or "-" that is not an integer is
@@ -3935,11 +4239,9 @@ class Workspace(object):
         appear in the list_objects method.
         :param object_ids: instance of list of type "ObjectIdentity" (An
            object identifier. Select an object by either: One, and only one,
-           of the numerical id or name of the workspace, where the name can
-           also be a KBase ID including the numerical id, e.g. kb|ws.35.
-           ws_id wsid - the numerical ID of the workspace. ws_name workspace
-           - name of the workspace or the workspace ID in KBase format, e.g.
-           kb|ws.78. AND One, and only one, of the numerical id or name of
+           of the numerical id or name of the workspace. ws_id wsid - the
+           numerical ID of the workspace. ws_name workspace - the name of the
+           workspace. AND One, and only one, of the numerical id or name of
            the object. obj_id objid- the numerical ID of the object. obj_name
            name - name of the object. OPTIONALLY obj_ver ver - the version of
            the object. OR an object reference string: obj_ref ref - an object
@@ -3957,18 +4259,14 @@ class Workspace(object):
            parameter "ver" of type "obj_ver" (An object version. The version
            of the object, starting at 1.), parameter "ref" of type "obj_ref"
            (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
            third version of an object called MyFirstObject in the workspace
            called MyFirstWorkspace. 42/Panic/1 would identify the first
            version of the object name Panic in workspace with id 42.
            Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.)
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.)
         """
         return self._client.call_method(
             'Workspace.hide_objects',
@@ -3980,11 +4278,9 @@ class Workspace(object):
         of the version specified in the ObjectIdentity.
         :param object_ids: instance of list of type "ObjectIdentity" (An
            object identifier. Select an object by either: One, and only one,
-           of the numerical id or name of the workspace, where the name can
-           also be a KBase ID including the numerical id, e.g. kb|ws.35.
-           ws_id wsid - the numerical ID of the workspace. ws_name workspace
-           - name of the workspace or the workspace ID in KBase format, e.g.
-           kb|ws.78. AND One, and only one, of the numerical id or name of
+           of the numerical id or name of the workspace. ws_id wsid - the
+           numerical ID of the workspace. ws_name workspace - the name of the
+           workspace. AND One, and only one, of the numerical id or name of
            the object. obj_id objid- the numerical ID of the object. obj_name
            name - name of the object. OPTIONALLY obj_ver ver - the version of
            the object. OR an object reference string: obj_ref ref - an object
@@ -4002,18 +4298,14 @@ class Workspace(object):
            parameter "ver" of type "obj_ver" (An object version. The version
            of the object, starting at 1.), parameter "ref" of type "obj_ref"
            (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
            third version of an object called MyFirstObject in the workspace
            called MyFirstWorkspace. 42/Panic/1 would identify the first
            version of the object name Panic in workspace with id 42.
            Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.)
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.)
         """
         return self._client.call_method(
             'Workspace.unhide_objects',
@@ -4025,11 +4317,9 @@ class Workspace(object):
         the version specified in the ObjectIdentity.
         :param object_ids: instance of list of type "ObjectIdentity" (An
            object identifier. Select an object by either: One, and only one,
-           of the numerical id or name of the workspace, where the name can
-           also be a KBase ID including the numerical id, e.g. kb|ws.35.
-           ws_id wsid - the numerical ID of the workspace. ws_name workspace
-           - name of the workspace or the workspace ID in KBase format, e.g.
-           kb|ws.78. AND One, and only one, of the numerical id or name of
+           of the numerical id or name of the workspace. ws_id wsid - the
+           numerical ID of the workspace. ws_name workspace - the name of the
+           workspace. AND One, and only one, of the numerical id or name of
            the object. obj_id objid- the numerical ID of the object. obj_name
            name - name of the object. OPTIONALLY obj_ver ver - the version of
            the object. OR an object reference string: obj_ref ref - an object
@@ -4047,18 +4337,14 @@ class Workspace(object):
            parameter "ver" of type "obj_ver" (An object version. The version
            of the object, starting at 1.), parameter "ref" of type "obj_ref"
            (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
            third version of an object called MyFirstObject in the workspace
            called MyFirstWorkspace. 42/Panic/1 would identify the first
            version of the object name Panic in workspace with id 42.
            Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.)
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.)
         """
         return self._client.call_method(
             'Workspace.delete_objects',
@@ -4071,11 +4357,9 @@ class Workspace(object):
         deleted, no error is thrown.
         :param object_ids: instance of list of type "ObjectIdentity" (An
            object identifier. Select an object by either: One, and only one,
-           of the numerical id or name of the workspace, where the name can
-           also be a KBase ID including the numerical id, e.g. kb|ws.35.
-           ws_id wsid - the numerical ID of the workspace. ws_name workspace
-           - name of the workspace or the workspace ID in KBase format, e.g.
-           kb|ws.78. AND One, and only one, of the numerical id or name of
+           of the numerical id or name of the workspace. ws_id wsid - the
+           numerical ID of the workspace. ws_name workspace - the name of the
+           workspace. AND One, and only one, of the numerical id or name of
            the object. obj_id objid- the numerical ID of the object. obj_name
            name - name of the object. OPTIONALLY obj_ver ver - the version of
            the object. OR an object reference string: obj_ref ref - an object
@@ -4093,18 +4377,14 @@ class Workspace(object):
            parameter "ver" of type "obj_ver" (An object version. The version
            of the object, starting at 1.), parameter "ref" of type "obj_ref"
            (A string that uniquely identifies an object in the workspace
-           service. There are two ways to uniquely identify an object in one
-           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
-           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           service. The format is [ws_name or id]/[obj_name or id]/[obj_ver].
+           For example, MyFirstWorkspace/MyFirstObject/3 would identify the
            third version of an object called MyFirstObject in the workspace
            called MyFirstWorkspace. 42/Panic/1 would identify the first
            version of the object name Panic in workspace with id 42.
            Towel/1/6 would identify the 6th version of the object with id 1
-           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
-           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
-           version of an object with id 567 in a workspace with id 23. In all
-           cases, if the version number is omitted, the latest version of the
-           object is assumed.)
+           in the Towel workspace.If the version number is omitted, the
+           latest version of the object is assumed.)
         """
         return self._client.call_method(
             'Workspace.undelete_objects',
@@ -4115,10 +4395,8 @@ class Workspace(object):
         Delete a workspace. All objects contained in the workspace are deleted.
         :param wsi: instance of type "WorkspaceIdentity" (A workspace
            identifier. Select a workspace by one, and only one, of the
-           numerical id or name, where the name can also be a KBase ID
-           including the numerical id, e.g. kb|ws.35. ws_id id - the
-           numerical ID of the workspace. ws_name workspace - name of the
-           workspace or the workspace ID in KBase format, e.g. kb|ws.78.) ->
+           numerical id or name. ws_id id - the numerical ID of the
+           workspace. ws_name workspace - the name of the workspace.) ->
            structure: parameter "workspace" of type "ws_name" (A string used
            as a name for a workspace. Any string consisting of alphanumeric
            characters and "_", ".", or "-" that is not an integer is
@@ -4138,10 +4416,8 @@ class Workspace(object):
         deleted.
         :param wsi: instance of type "WorkspaceIdentity" (A workspace
            identifier. Select a workspace by one, and only one, of the
-           numerical id or name, where the name can also be a KBase ID
-           including the numerical id, e.g. kb|ws.35. ws_id id - the
-           numerical ID of the workspace. ws_name workspace - name of the
-           workspace or the workspace ID in KBase format, e.g. kb|ws.78.) ->
+           numerical id or name. ws_id id - the numerical ID of the
+           workspace. ws_name workspace - the name of the workspace.) ->
            structure: parameter "workspace" of type "ws_name" (A string used
            as a name for a workspace. Any string consisting of alphanumeric
            characters and "_", ".", or "-" that is not an integer is
@@ -4232,7 +4508,7 @@ class Workspace(object):
         Also see the release_types function.
         :param params: instance of type "RegisterTypespecCopyParams"
            (Parameters for the register_typespec_copy function. Required
-           arguments: string external_workspace_url - the URL of the 
+           arguments: string external_workspace_url - the URL of the
            workspace server from which to copy a typespec. modulename mod -
            the name of the module in the workspace server Optional arguments:
            spec_version version - the version of the module in the workspace
@@ -4257,7 +4533,7 @@ class Workspace(object):
                 backwards incompatible changes from minor version to minor version.
                 Once a type is released, backwards incompatible changes always
                 cause a major version increment.
-        2) This version of the type becomes the default version, and if a 
+        2) This version of the type becomes the default version, and if a
                 specific version is not supplied in a function call, this version
                 will be used. This means that newer, unreleased versions of the
                 type may be skipped.

--- a/lib/javascript/Client.js
+++ b/lib/javascript/Client.js
@@ -19,6 +19,32 @@ function SetAPI(url, auth, auth_cb, timeout, async_job_check_time_ms, service_ve
     var _auth = auth ? auth : { 'token' : '', 'user_id' : ''};
     var _auth_cb = auth_cb;
 
+     this.get_reads_alignment_set_v1 = function (params, _callback, _errorCallback) {
+        if (typeof params === 'function')
+            throw 'Argument params can not be a function';
+        if (_callback && typeof _callback !== 'function')
+            throw 'Argument _callback must be a function if defined';
+        if (_errorCallback && typeof _errorCallback !== 'function')
+            throw 'Argument _errorCallback must be a function if defined';
+        if (typeof arguments === 'function' && arguments.length > 1+2)
+            throw 'Too many arguments ('+arguments.length+' instead of '+(1+2)+')';
+        return json_call_ajax(_url, "SetAPI.get_reads_alignment_set_v1",
+            [params], 1, _callback, _errorCallback);
+    };
+ 
+     this.save_reads_alignment_set_v1 = function (params, _callback, _errorCallback) {
+        if (typeof params === 'function')
+            throw 'Argument params can not be a function';
+        if (_callback && typeof _callback !== 'function')
+            throw 'Argument _callback must be a function if defined';
+        if (_errorCallback && typeof _errorCallback !== 'function')
+            throw 'Argument _errorCallback must be a function if defined';
+        if (typeof arguments === 'function' && arguments.length > 1+2)
+            throw 'Too many arguments ('+arguments.length+' instead of '+(1+2)+')';
+        return json_call_ajax(_url, "SetAPI.save_reads_alignment_set_v1",
+            [params], 1, _callback, _errorCallback);
+    };
+ 
      this.get_reads_set_v1 = function (params, _callback, _errorCallback) {
         if (typeof params === 'function')
             throw 'Argument params can not be a function';

--- a/lib/javascript/Client.js
+++ b/lib/javascript/Client.js
@@ -19,6 +19,32 @@ function SetAPI(url, auth, auth_cb, timeout, async_job_check_time_ms, service_ve
     var _auth = auth ? auth : { 'token' : '', 'user_id' : ''};
     var _auth_cb = auth_cb;
 
+     this.get_expression_set_v1 = function (params, _callback, _errorCallback) {
+        if (typeof params === 'function')
+            throw 'Argument params can not be a function';
+        if (_callback && typeof _callback !== 'function')
+            throw 'Argument _callback must be a function if defined';
+        if (_errorCallback && typeof _errorCallback !== 'function')
+            throw 'Argument _errorCallback must be a function if defined';
+        if (typeof arguments === 'function' && arguments.length > 1+2)
+            throw 'Too many arguments ('+arguments.length+' instead of '+(1+2)+')';
+        return json_call_ajax(_url, "SetAPI.get_expression_set_v1",
+            [params], 1, _callback, _errorCallback);
+    };
+ 
+     this.save_expression_set_v1 = function (params, _callback, _errorCallback) {
+        if (typeof params === 'function')
+            throw 'Argument params can not be a function';
+        if (_callback && typeof _callback !== 'function')
+            throw 'Argument _callback must be a function if defined';
+        if (_errorCallback && typeof _errorCallback !== 'function')
+            throw 'Argument _errorCallback must be a function if defined';
+        if (typeof arguments === 'function' && arguments.length > 1+2)
+            throw 'Too many arguments ('+arguments.length+' instead of '+(1+2)+')';
+        return json_call_ajax(_url, "SetAPI.save_expression_set_v1",
+            [params], 1, _callback, _errorCallback);
+    };
+ 
      this.get_reads_alignment_set_v1 = function (params, _callback, _errorCallback) {
         if (typeof params === 'function')
             throw 'Argument params can not be a function';

--- a/lib/src/us/kbase/setapi/ExpressionSet.java
+++ b/lib/src/us/kbase/setapi/ExpressionSet.java
@@ -13,11 +13,11 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 
 /**
- * <p>Original spec-file type: ReadsAlignmentSet</p>
+ * <p>Original spec-file type: ExpressionSet</p>
  * <pre>
- * When building a ReadsAlignmentSet, all ReadsAlignments must be aligned against the same
+ * When building a ExpressionSet, all Expression objects must be aligned against the same
  * genome. This is not part of the object type, but enforced during a call to
- * save_reads_alignment_set_v1.
+ * save_expression_set_v1.
  * @meta ws description as description
  * @meta ws length(items) as item_count
  * </pre>
@@ -29,12 +29,12 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
     "description",
     "items"
 })
-public class ReadsAlignmentSet {
+public class ExpressionSet {
 
     @JsonProperty("description")
     private String description;
     @JsonProperty("items")
-    private List<ReadsAlignmentSetItem> items;
+    private List<ExpressionSetItem> items;
     private Map<String, Object> additionalProperties = new HashMap<String, Object>();
 
     @JsonProperty("description")
@@ -47,22 +47,22 @@ public class ReadsAlignmentSet {
         this.description = description;
     }
 
-    public ReadsAlignmentSet withDescription(String description) {
+    public ExpressionSet withDescription(String description) {
         this.description = description;
         return this;
     }
 
     @JsonProperty("items")
-    public List<ReadsAlignmentSetItem> getItems() {
+    public List<ExpressionSetItem> getItems() {
         return items;
     }
 
     @JsonProperty("items")
-    public void setItems(List<ReadsAlignmentSetItem> items) {
+    public void setItems(List<ExpressionSetItem> items) {
         this.items = items;
     }
 
-    public ReadsAlignmentSet withItems(List<ReadsAlignmentSetItem> items) {
+    public ExpressionSet withItems(List<ExpressionSetItem> items) {
         this.items = items;
         return this;
     }
@@ -79,7 +79,7 @@ public class ReadsAlignmentSet {
 
     @Override
     public String toString() {
-        return ((((((("ReadsAlignmentSet"+" [description=")+ description)+", items=")+ items)+", additionalProperties=")+ additionalProperties)+"]");
+        return ((((((("ExpressionSet"+" [description=")+ description)+", items=")+ items)+", additionalProperties=")+ additionalProperties)+"]");
     }
 
 }

--- a/lib/src/us/kbase/setapi/ExpressionSetItem.java
+++ b/lib/src/us/kbase/setapi/ExpressionSetItem.java
@@ -14,11 +14,11 @@ import us.kbase.common.service.Tuple11;
 
 
 /**
- * <p>Original spec-file type: ReadsAlignmentSetItem</p>
+ * <p>Original spec-file type: ExpressionSetItem</p>
  * <pre>
- * When saving a ReadsAlignmentSet, only 'ref' is required.
+ * When saving a ExpressionSet, only 'ref' is required.
  * You should never set 'info'.  'info' is provided optionally when fetching
- * the ReadsAlignmentSet.
+ * the ExpressionSet.
  * </pre>
  * 
  */
@@ -27,19 +27,19 @@ import us.kbase.common.service.Tuple11;
 @JsonPropertyOrder({
     "ref",
     "label",
-    "info",
-    "data_attachments"
+    "data_attachments",
+    "info"
 })
-public class ReadsAlignmentSetItem {
+public class ExpressionSetItem {
 
     @JsonProperty("ref")
     private java.lang.String ref;
     @JsonProperty("label")
     private java.lang.String label;
-    @JsonProperty("info")
-    private Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>> info;
     @JsonProperty("data_attachments")
     private List<DataAttachment> dataAttachments;
+    @JsonProperty("info")
+    private Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>> info;
     private Map<java.lang.String, Object> additionalProperties = new HashMap<java.lang.String, Object>();
 
     @JsonProperty("ref")
@@ -52,7 +52,7 @@ public class ReadsAlignmentSetItem {
         this.ref = ref;
     }
 
-    public ReadsAlignmentSetItem withRef(java.lang.String ref) {
+    public ExpressionSetItem withRef(java.lang.String ref) {
         this.ref = ref;
         return this;
     }
@@ -67,23 +67,8 @@ public class ReadsAlignmentSetItem {
         this.label = label;
     }
 
-    public ReadsAlignmentSetItem withLabel(java.lang.String label) {
+    public ExpressionSetItem withLabel(java.lang.String label) {
         this.label = label;
-        return this;
-    }
-
-    @JsonProperty("info")
-    public Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>> getInfo() {
-        return info;
-    }
-
-    @JsonProperty("info")
-    public void setInfo(Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>> info) {
-        this.info = info;
-    }
-
-    public ReadsAlignmentSetItem withInfo(Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>> info) {
-        this.info = info;
         return this;
     }
 
@@ -97,8 +82,23 @@ public class ReadsAlignmentSetItem {
         this.dataAttachments = dataAttachments;
     }
 
-    public ReadsAlignmentSetItem withDataAttachments(List<DataAttachment> dataAttachments) {
+    public ExpressionSetItem withDataAttachments(List<DataAttachment> dataAttachments) {
         this.dataAttachments = dataAttachments;
+        return this;
+    }
+
+    @JsonProperty("info")
+    public Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>> getInfo() {
+        return info;
+    }
+
+    @JsonProperty("info")
+    public void setInfo(Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>> info) {
+        this.info = info;
+    }
+
+    public ExpressionSetItem withInfo(Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>> info) {
+        this.info = info;
         return this;
     }
 
@@ -114,7 +114,7 @@ public class ReadsAlignmentSetItem {
 
     @Override
     public java.lang.String toString() {
-        return ((((((((((("ReadsAlignmentSetItem"+" [ref=")+ ref)+", label=")+ label)+", info=")+ info)+", dataAttachments=")+ dataAttachments)+", additionalProperties=")+ additionalProperties)+"]");
+        return ((((((((((("ExpressionSetItem"+" [ref=")+ ref)+", label=")+ label)+", dataAttachments=")+ dataAttachments)+", info=")+ info)+", additionalProperties=")+ additionalProperties)+"]");
     }
 
 }

--- a/lib/src/us/kbase/setapi/GetExpressionSetV1Params.java
+++ b/lib/src/us/kbase/setapi/GetExpressionSetV1Params.java
@@ -1,0 +1,101 @@
+
+package us.kbase.setapi;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: GetExpressionSetV1Params</p>
+ * <pre>
+ * ref - workspace reference to ExpressionSet object.
+ * include_item_info - 1 or 0, if 1 additionally provides workspace info (with
+ *                     metadata) for each Expression object in the Set
+ * </pre>
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "ref",
+    "include_item_info",
+    "ref_path_to_set"
+})
+public class GetExpressionSetV1Params {
+
+    @JsonProperty("ref")
+    private java.lang.String ref;
+    @JsonProperty("include_item_info")
+    private Long includeItemInfo;
+    @JsonProperty("ref_path_to_set")
+    private List<String> refPathToSet;
+    private Map<java.lang.String, Object> additionalProperties = new HashMap<java.lang.String, Object>();
+
+    @JsonProperty("ref")
+    public java.lang.String getRef() {
+        return ref;
+    }
+
+    @JsonProperty("ref")
+    public void setRef(java.lang.String ref) {
+        this.ref = ref;
+    }
+
+    public GetExpressionSetV1Params withRef(java.lang.String ref) {
+        this.ref = ref;
+        return this;
+    }
+
+    @JsonProperty("include_item_info")
+    public Long getIncludeItemInfo() {
+        return includeItemInfo;
+    }
+
+    @JsonProperty("include_item_info")
+    public void setIncludeItemInfo(Long includeItemInfo) {
+        this.includeItemInfo = includeItemInfo;
+    }
+
+    public GetExpressionSetV1Params withIncludeItemInfo(Long includeItemInfo) {
+        this.includeItemInfo = includeItemInfo;
+        return this;
+    }
+
+    @JsonProperty("ref_path_to_set")
+    public List<String> getRefPathToSet() {
+        return refPathToSet;
+    }
+
+    @JsonProperty("ref_path_to_set")
+    public void setRefPathToSet(List<String> refPathToSet) {
+        this.refPathToSet = refPathToSet;
+    }
+
+    public GetExpressionSetV1Params withRefPathToSet(List<String> refPathToSet) {
+        this.refPathToSet = refPathToSet;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<java.lang.String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(java.lang.String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public java.lang.String toString() {
+        return ((((((((("GetExpressionSetV1Params"+" [ref=")+ ref)+", includeItemInfo=")+ includeItemInfo)+", refPathToSet=")+ refPathToSet)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/src/us/kbase/setapi/GetExpressionSetV1Result.java
+++ b/lib/src/us/kbase/setapi/GetExpressionSetV1Result.java
@@ -13,7 +13,7 @@ import us.kbase.common.service.Tuple11;
 
 
 /**
- * <p>Original spec-file type: GetReadsAlignmentSetV1Result</p>
+ * <p>Original spec-file type: GetExpressionSetV1Result</p>
  * 
  * 
  */
@@ -23,58 +23,58 @@ import us.kbase.common.service.Tuple11;
     "data",
     "info"
 })
-public class GetReadsAlignmentSetV1Result {
+public class GetExpressionSetV1Result {
 
     /**
-     * <p>Original spec-file type: ReadsAlignmentSet</p>
+     * <p>Original spec-file type: ExpressionSet</p>
      * <pre>
-     * When building a ReadsAlignmentSet, all ReadsAlignments must be aligned against the same
+     * When building a ExpressionSet, all Expression objects must be aligned against the same
      * genome. This is not part of the object type, but enforced during a call to
-     * save_reads_alignment_set_v1.
+     * save_expression_set_v1.
      * @meta ws description as description
      * @meta ws length(items) as item_count
      * </pre>
      * 
      */
     @JsonProperty("data")
-    private ReadsAlignmentSet data;
+    private ExpressionSet data;
     @JsonProperty("info")
     private Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>> info;
     private Map<java.lang.String, Object> additionalProperties = new HashMap<java.lang.String, Object>();
 
     /**
-     * <p>Original spec-file type: ReadsAlignmentSet</p>
+     * <p>Original spec-file type: ExpressionSet</p>
      * <pre>
-     * When building a ReadsAlignmentSet, all ReadsAlignments must be aligned against the same
+     * When building a ExpressionSet, all Expression objects must be aligned against the same
      * genome. This is not part of the object type, but enforced during a call to
-     * save_reads_alignment_set_v1.
+     * save_expression_set_v1.
      * @meta ws description as description
      * @meta ws length(items) as item_count
      * </pre>
      * 
      */
     @JsonProperty("data")
-    public ReadsAlignmentSet getData() {
+    public ExpressionSet getData() {
         return data;
     }
 
     /**
-     * <p>Original spec-file type: ReadsAlignmentSet</p>
+     * <p>Original spec-file type: ExpressionSet</p>
      * <pre>
-     * When building a ReadsAlignmentSet, all ReadsAlignments must be aligned against the same
+     * When building a ExpressionSet, all Expression objects must be aligned against the same
      * genome. This is not part of the object type, but enforced during a call to
-     * save_reads_alignment_set_v1.
+     * save_expression_set_v1.
      * @meta ws description as description
      * @meta ws length(items) as item_count
      * </pre>
      * 
      */
     @JsonProperty("data")
-    public void setData(ReadsAlignmentSet data) {
+    public void setData(ExpressionSet data) {
         this.data = data;
     }
 
-    public GetReadsAlignmentSetV1Result withData(ReadsAlignmentSet data) {
+    public GetExpressionSetV1Result withData(ExpressionSet data) {
         this.data = data;
         return this;
     }
@@ -89,7 +89,7 @@ public class GetReadsAlignmentSetV1Result {
         this.info = info;
     }
 
-    public GetReadsAlignmentSetV1Result withInfo(Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>> info) {
+    public GetExpressionSetV1Result withInfo(Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>> info) {
         this.info = info;
         return this;
     }
@@ -106,7 +106,7 @@ public class GetReadsAlignmentSetV1Result {
 
     @Override
     public java.lang.String toString() {
-        return ((((((("GetReadsAlignmentSetV1Result"+" [data=")+ data)+", info=")+ info)+", additionalProperties=")+ additionalProperties)+"]");
+        return ((((((("GetExpressionSetV1Result"+" [data=")+ data)+", info=")+ info)+", additionalProperties=")+ additionalProperties)+"]");
     }
 
 }

--- a/lib/src/us/kbase/setapi/GetReadsAlignmentSetV1Params.java
+++ b/lib/src/us/kbase/setapi/GetReadsAlignmentSetV1Params.java
@@ -1,0 +1,101 @@
+
+package us.kbase.setapi;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: GetReadsAlignmentSetV1Params</p>
+ * <pre>
+ * ref - workspace reference to ReadsAlignmentSet object.
+ * include_item_info - 1 or 0, if 1 additionally provides workspace info (with
+ *                     metadata) for each ReadsAlignment object in the Set
+ * </pre>
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "ref",
+    "include_item_info",
+    "ref_path_to_set"
+})
+public class GetReadsAlignmentSetV1Params {
+
+    @JsonProperty("ref")
+    private java.lang.String ref;
+    @JsonProperty("include_item_info")
+    private Long includeItemInfo;
+    @JsonProperty("ref_path_to_set")
+    private List<String> refPathToSet;
+    private Map<java.lang.String, Object> additionalProperties = new HashMap<java.lang.String, Object>();
+
+    @JsonProperty("ref")
+    public java.lang.String getRef() {
+        return ref;
+    }
+
+    @JsonProperty("ref")
+    public void setRef(java.lang.String ref) {
+        this.ref = ref;
+    }
+
+    public GetReadsAlignmentSetV1Params withRef(java.lang.String ref) {
+        this.ref = ref;
+        return this;
+    }
+
+    @JsonProperty("include_item_info")
+    public Long getIncludeItemInfo() {
+        return includeItemInfo;
+    }
+
+    @JsonProperty("include_item_info")
+    public void setIncludeItemInfo(Long includeItemInfo) {
+        this.includeItemInfo = includeItemInfo;
+    }
+
+    public GetReadsAlignmentSetV1Params withIncludeItemInfo(Long includeItemInfo) {
+        this.includeItemInfo = includeItemInfo;
+        return this;
+    }
+
+    @JsonProperty("ref_path_to_set")
+    public List<String> getRefPathToSet() {
+        return refPathToSet;
+    }
+
+    @JsonProperty("ref_path_to_set")
+    public void setRefPathToSet(List<String> refPathToSet) {
+        this.refPathToSet = refPathToSet;
+    }
+
+    public GetReadsAlignmentSetV1Params withRefPathToSet(List<String> refPathToSet) {
+        this.refPathToSet = refPathToSet;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<java.lang.String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(java.lang.String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public java.lang.String toString() {
+        return ((((((((("GetReadsAlignmentSetV1Params"+" [ref=")+ ref)+", includeItemInfo=")+ includeItemInfo)+", refPathToSet=")+ refPathToSet)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/src/us/kbase/setapi/GetReadsAlignmentSetV1Result.java
+++ b/lib/src/us/kbase/setapi/GetReadsAlignmentSetV1Result.java
@@ -1,0 +1,112 @@
+
+package us.kbase.setapi;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import us.kbase.common.service.Tuple11;
+
+
+/**
+ * <p>Original spec-file type: GetReadsAlignmentSetV1Result</p>
+ * 
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "data",
+    "info"
+})
+public class GetReadsAlignmentSetV1Result {
+
+    /**
+     * <p>Original spec-file type: ReadsAlignmentSet</p>
+     * <pre>
+     * When building a ReadsAlignmentSet, all ReadsAlignments must be aligned against the same
+     * genome. This is not part of the object type, but enforced during a call to
+     * save_reads_alignment_v1.
+     * @meta ws description as description
+     * @meta ws length(items) as item_count
+     * </pre>
+     * 
+     */
+    @JsonProperty("data")
+    private ReadsAlignmentSet data;
+    @JsonProperty("info")
+    private Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>> info;
+    private Map<java.lang.String, Object> additionalProperties = new HashMap<java.lang.String, Object>();
+
+    /**
+     * <p>Original spec-file type: ReadsAlignmentSet</p>
+     * <pre>
+     * When building a ReadsAlignmentSet, all ReadsAlignments must be aligned against the same
+     * genome. This is not part of the object type, but enforced during a call to
+     * save_reads_alignment_v1.
+     * @meta ws description as description
+     * @meta ws length(items) as item_count
+     * </pre>
+     * 
+     */
+    @JsonProperty("data")
+    public ReadsAlignmentSet getData() {
+        return data;
+    }
+
+    /**
+     * <p>Original spec-file type: ReadsAlignmentSet</p>
+     * <pre>
+     * When building a ReadsAlignmentSet, all ReadsAlignments must be aligned against the same
+     * genome. This is not part of the object type, but enforced during a call to
+     * save_reads_alignment_v1.
+     * @meta ws description as description
+     * @meta ws length(items) as item_count
+     * </pre>
+     * 
+     */
+    @JsonProperty("data")
+    public void setData(ReadsAlignmentSet data) {
+        this.data = data;
+    }
+
+    public GetReadsAlignmentSetV1Result withData(ReadsAlignmentSet data) {
+        this.data = data;
+        return this;
+    }
+
+    @JsonProperty("info")
+    public Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>> getInfo() {
+        return info;
+    }
+
+    @JsonProperty("info")
+    public void setInfo(Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>> info) {
+        this.info = info;
+    }
+
+    public GetReadsAlignmentSetV1Result withInfo(Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>> info) {
+        this.info = info;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<java.lang.String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(java.lang.String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public java.lang.String toString() {
+        return ((((((("GetReadsAlignmentSetV1Result"+" [data=")+ data)+", info=")+ info)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/src/us/kbase/setapi/ListSetParams.java
+++ b/lib/src/us/kbase/setapi/ListSetParams.java
@@ -18,9 +18,9 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  *     workspaces parameter),
  * workspaces - list of workspace name ot ID (alternative to
  *     workspace parameter),
- * include_metadata - flag for including metadata into Set object info 
+ * include_metadata - flag for including metadata into Set object info
  *     and into object info of items (it affects DP raw data as well),
- * include_raw_data_palettes - advanced option designed for 
+ * include_raw_data_palettes - advanced option designed for
  *     optimization of listing methods in NarrativeService.
  * </pre>
  * 

--- a/lib/src/us/kbase/setapi/ReadsAlignmentSet.java
+++ b/lib/src/us/kbase/setapi/ReadsAlignmentSet.java
@@ -1,0 +1,85 @@
+
+package us.kbase.setapi;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: ReadsAlignmentSet</p>
+ * <pre>
+ * When building a ReadsAlignmentSet, all ReadsAlignments must be aligned against the same
+ * genome. This is not part of the object type, but enforced during a call to
+ * save_reads_alignment_v1.
+ * @meta ws description as description
+ * @meta ws length(items) as item_count
+ * </pre>
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "description",
+    "items"
+})
+public class ReadsAlignmentSet {
+
+    @JsonProperty("description")
+    private String description;
+    @JsonProperty("items")
+    private List<ReadsAlignmentSetItem> items;
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonProperty("description")
+    public String getDescription() {
+        return description;
+    }
+
+    @JsonProperty("description")
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public ReadsAlignmentSet withDescription(String description) {
+        this.description = description;
+        return this;
+    }
+
+    @JsonProperty("items")
+    public List<ReadsAlignmentSetItem> getItems() {
+        return items;
+    }
+
+    @JsonProperty("items")
+    public void setItems(List<ReadsAlignmentSetItem> items) {
+        this.items = items;
+    }
+
+    public ReadsAlignmentSet withItems(List<ReadsAlignmentSetItem> items) {
+        this.items = items;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return ((((((("ReadsAlignmentSet"+" [description=")+ description)+", items=")+ items)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/src/us/kbase/setapi/ReadsAlignmentSetItem.java
+++ b/lib/src/us/kbase/setapi/ReadsAlignmentSetItem.java
@@ -1,0 +1,101 @@
+
+package us.kbase.setapi;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import us.kbase.common.service.Tuple11;
+
+
+/**
+ * <p>Original spec-file type: ReadsAlignmentSetItem</p>
+ * <pre>
+ * When saving a ReadsAlignmentSet, only 'ref' is required.
+ * You should never set 'info'.  'info' is provided optionally when fetching
+ * the ReadsAlignmentSet.
+ * </pre>
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "ref",
+    "label",
+    "info"
+})
+public class ReadsAlignmentSetItem {
+
+    @JsonProperty("ref")
+    private java.lang.String ref;
+    @JsonProperty("label")
+    private java.lang.String label;
+    @JsonProperty("info")
+    private Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>> info;
+    private Map<java.lang.String, Object> additionalProperties = new HashMap<java.lang.String, Object>();
+
+    @JsonProperty("ref")
+    public java.lang.String getRef() {
+        return ref;
+    }
+
+    @JsonProperty("ref")
+    public void setRef(java.lang.String ref) {
+        this.ref = ref;
+    }
+
+    public ReadsAlignmentSetItem withRef(java.lang.String ref) {
+        this.ref = ref;
+        return this;
+    }
+
+    @JsonProperty("label")
+    public java.lang.String getLabel() {
+        return label;
+    }
+
+    @JsonProperty("label")
+    public void setLabel(java.lang.String label) {
+        this.label = label;
+    }
+
+    public ReadsAlignmentSetItem withLabel(java.lang.String label) {
+        this.label = label;
+        return this;
+    }
+
+    @JsonProperty("info")
+    public Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>> getInfo() {
+        return info;
+    }
+
+    @JsonProperty("info")
+    public void setInfo(Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>> info) {
+        this.info = info;
+    }
+
+    public ReadsAlignmentSetItem withInfo(Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>> info) {
+        this.info = info;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<java.lang.String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(java.lang.String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public java.lang.String toString() {
+        return ((((((((("ReadsAlignmentSetItem"+" [ref=")+ ref)+", label=")+ label)+", info=")+ info)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/src/us/kbase/setapi/SaveAssemblySetV1Params.java
+++ b/lib/src/us/kbase/setapi/SaveAssemblySetV1Params.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 /**
  * <p>Original spec-file type: SaveAssemblySetV1Params</p>
  * <pre>
- * workspace_name or workspace_id - alternative options defining 
+ * workspace_name or workspace_id - alternative options defining
  *     target workspace,
  * output_object_name - workspace object name (this parameter is
  *     used together with one of workspace params from above)

--- a/lib/src/us/kbase/setapi/SaveExpressionSetV1Params.java
+++ b/lib/src/us/kbase/setapi/SaveExpressionSetV1Params.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 
 /**
- * <p>Original spec-file type: SaveReadsAlignmentSetV1Params</p>
+ * <p>Original spec-file type: SaveExpressionSetV1Params</p>
  * <pre>
  * workspace_name or workspace_id - alternative options defining
  *     target workspace,
@@ -28,25 +28,25 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
     "output_object_name",
     "data"
 })
-public class SaveReadsAlignmentSetV1Params {
+public class SaveExpressionSetV1Params {
 
     @JsonProperty("workspace")
     private String workspace;
     @JsonProperty("output_object_name")
     private String outputObjectName;
     /**
-     * <p>Original spec-file type: ReadsAlignmentSet</p>
+     * <p>Original spec-file type: ExpressionSet</p>
      * <pre>
-     * When building a ReadsAlignmentSet, all ReadsAlignments must be aligned against the same
+     * When building a ExpressionSet, all Expression objects must be aligned against the same
      * genome. This is not part of the object type, but enforced during a call to
-     * save_reads_alignment_set_v1.
+     * save_expression_set_v1.
      * @meta ws description as description
      * @meta ws length(items) as item_count
      * </pre>
      * 
      */
     @JsonProperty("data")
-    private ReadsAlignmentSet data;
+    private ExpressionSet data;
     private Map<String, Object> additionalProperties = new HashMap<String, Object>();
 
     @JsonProperty("workspace")
@@ -59,7 +59,7 @@ public class SaveReadsAlignmentSetV1Params {
         this.workspace = workspace;
     }
 
-    public SaveReadsAlignmentSetV1Params withWorkspace(String workspace) {
+    public SaveExpressionSetV1Params withWorkspace(String workspace) {
         this.workspace = workspace;
         return this;
     }
@@ -74,44 +74,44 @@ public class SaveReadsAlignmentSetV1Params {
         this.outputObjectName = outputObjectName;
     }
 
-    public SaveReadsAlignmentSetV1Params withOutputObjectName(String outputObjectName) {
+    public SaveExpressionSetV1Params withOutputObjectName(String outputObjectName) {
         this.outputObjectName = outputObjectName;
         return this;
     }
 
     /**
-     * <p>Original spec-file type: ReadsAlignmentSet</p>
+     * <p>Original spec-file type: ExpressionSet</p>
      * <pre>
-     * When building a ReadsAlignmentSet, all ReadsAlignments must be aligned against the same
+     * When building a ExpressionSet, all Expression objects must be aligned against the same
      * genome. This is not part of the object type, but enforced during a call to
-     * save_reads_alignment_set_v1.
+     * save_expression_set_v1.
      * @meta ws description as description
      * @meta ws length(items) as item_count
      * </pre>
      * 
      */
     @JsonProperty("data")
-    public ReadsAlignmentSet getData() {
+    public ExpressionSet getData() {
         return data;
     }
 
     /**
-     * <p>Original spec-file type: ReadsAlignmentSet</p>
+     * <p>Original spec-file type: ExpressionSet</p>
      * <pre>
-     * When building a ReadsAlignmentSet, all ReadsAlignments must be aligned against the same
+     * When building a ExpressionSet, all Expression objects must be aligned against the same
      * genome. This is not part of the object type, but enforced during a call to
-     * save_reads_alignment_set_v1.
+     * save_expression_set_v1.
      * @meta ws description as description
      * @meta ws length(items) as item_count
      * </pre>
      * 
      */
     @JsonProperty("data")
-    public void setData(ReadsAlignmentSet data) {
+    public void setData(ExpressionSet data) {
         this.data = data;
     }
 
-    public SaveReadsAlignmentSetV1Params withData(ReadsAlignmentSet data) {
+    public SaveExpressionSetV1Params withData(ExpressionSet data) {
         this.data = data;
         return this;
     }
@@ -128,7 +128,7 @@ public class SaveReadsAlignmentSetV1Params {
 
     @Override
     public String toString() {
-        return ((((((((("SaveReadsAlignmentSetV1Params"+" [workspace=")+ workspace)+", outputObjectName=")+ outputObjectName)+", data=")+ data)+", additionalProperties=")+ additionalProperties)+"]");
+        return ((((((((("SaveExpressionSetV1Params"+" [workspace=")+ workspace)+", outputObjectName=")+ outputObjectName)+", data=")+ data)+", additionalProperties=")+ additionalProperties)+"]");
     }
 
 }

--- a/lib/src/us/kbase/setapi/SaveExpressionSetV1Result.java
+++ b/lib/src/us/kbase/setapi/SaveExpressionSetV1Result.java
@@ -1,0 +1,79 @@
+
+package us.kbase.setapi;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import us.kbase.common.service.Tuple11;
+
+
+/**
+ * <p>Original spec-file type: SaveExpressionSetV1Result</p>
+ * 
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "set_ref",
+    "set_info"
+})
+public class SaveExpressionSetV1Result {
+
+    @JsonProperty("set_ref")
+    private java.lang.String setRef;
+    @JsonProperty("set_info")
+    private Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>> setInfo;
+    private Map<java.lang.String, Object> additionalProperties = new HashMap<java.lang.String, Object>();
+
+    @JsonProperty("set_ref")
+    public java.lang.String getSetRef() {
+        return setRef;
+    }
+
+    @JsonProperty("set_ref")
+    public void setSetRef(java.lang.String setRef) {
+        this.setRef = setRef;
+    }
+
+    public SaveExpressionSetV1Result withSetRef(java.lang.String setRef) {
+        this.setRef = setRef;
+        return this;
+    }
+
+    @JsonProperty("set_info")
+    public Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>> getSetInfo() {
+        return setInfo;
+    }
+
+    @JsonProperty("set_info")
+    public void setSetInfo(Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>> setInfo) {
+        this.setInfo = setInfo;
+    }
+
+    public SaveExpressionSetV1Result withSetInfo(Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>> setInfo) {
+        this.setInfo = setInfo;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<java.lang.String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(java.lang.String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public java.lang.String toString() {
+        return ((((((("SaveExpressionSetV1Result"+" [setRef=")+ setRef)+", setInfo=")+ setInfo)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/src/us/kbase/setapi/SaveGenomeSetV1Params.java
+++ b/lib/src/us/kbase/setapi/SaveGenomeSetV1Params.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 /**
  * <p>Original spec-file type: SaveGenomeSetV1Params</p>
  * <pre>
- * workspace_name or workspace_id - alternative options defining 
+ * workspace_name or workspace_id - alternative options defining
  *     target workspace,
  * output_object_name - workspace object name (this parameter is
  *     used together with one of workspace params from above)

--- a/lib/src/us/kbase/setapi/SaveReadsAlignmentSetV1Params.java
+++ b/lib/src/us/kbase/setapi/SaveReadsAlignmentSetV1Params.java
@@ -1,0 +1,134 @@
+
+package us.kbase.setapi;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: SaveReadsAlignmentSetV1Params</p>
+ * <pre>
+ * workspace_name or workspace_id - alternative options defining
+ *     target workspace,
+ * output_object_name - workspace object name (this parameter is
+ *     used together with one of workspace params from above)
+ * </pre>
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "workspace",
+    "output_object_name",
+    "data"
+})
+public class SaveReadsAlignmentSetV1Params {
+
+    @JsonProperty("workspace")
+    private String workspace;
+    @JsonProperty("output_object_name")
+    private String outputObjectName;
+    /**
+     * <p>Original spec-file type: ReadsAlignmentSet</p>
+     * <pre>
+     * When building a ReadsAlignmentSet, all ReadsAlignments must be aligned against the same
+     * genome. This is not part of the object type, but enforced during a call to
+     * save_reads_alignment_v1.
+     * @meta ws description as description
+     * @meta ws length(items) as item_count
+     * </pre>
+     * 
+     */
+    @JsonProperty("data")
+    private ReadsAlignmentSet data;
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonProperty("workspace")
+    public String getWorkspace() {
+        return workspace;
+    }
+
+    @JsonProperty("workspace")
+    public void setWorkspace(String workspace) {
+        this.workspace = workspace;
+    }
+
+    public SaveReadsAlignmentSetV1Params withWorkspace(String workspace) {
+        this.workspace = workspace;
+        return this;
+    }
+
+    @JsonProperty("output_object_name")
+    public String getOutputObjectName() {
+        return outputObjectName;
+    }
+
+    @JsonProperty("output_object_name")
+    public void setOutputObjectName(String outputObjectName) {
+        this.outputObjectName = outputObjectName;
+    }
+
+    public SaveReadsAlignmentSetV1Params withOutputObjectName(String outputObjectName) {
+        this.outputObjectName = outputObjectName;
+        return this;
+    }
+
+    /**
+     * <p>Original spec-file type: ReadsAlignmentSet</p>
+     * <pre>
+     * When building a ReadsAlignmentSet, all ReadsAlignments must be aligned against the same
+     * genome. This is not part of the object type, but enforced during a call to
+     * save_reads_alignment_v1.
+     * @meta ws description as description
+     * @meta ws length(items) as item_count
+     * </pre>
+     * 
+     */
+    @JsonProperty("data")
+    public ReadsAlignmentSet getData() {
+        return data;
+    }
+
+    /**
+     * <p>Original spec-file type: ReadsAlignmentSet</p>
+     * <pre>
+     * When building a ReadsAlignmentSet, all ReadsAlignments must be aligned against the same
+     * genome. This is not part of the object type, but enforced during a call to
+     * save_reads_alignment_v1.
+     * @meta ws description as description
+     * @meta ws length(items) as item_count
+     * </pre>
+     * 
+     */
+    @JsonProperty("data")
+    public void setData(ReadsAlignmentSet data) {
+        this.data = data;
+    }
+
+    public SaveReadsAlignmentSetV1Params withData(ReadsAlignmentSet data) {
+        this.data = data;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return ((((((((("SaveReadsAlignmentSetV1Params"+" [workspace=")+ workspace)+", outputObjectName=")+ outputObjectName)+", data=")+ data)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/src/us/kbase/setapi/SaveReadsAlignmentSetV1Result.java
+++ b/lib/src/us/kbase/setapi/SaveReadsAlignmentSetV1Result.java
@@ -1,0 +1,79 @@
+
+package us.kbase.setapi;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import us.kbase.common.service.Tuple11;
+
+
+/**
+ * <p>Original spec-file type: SaveReadsAlignmentSetV1Result</p>
+ * 
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "set_ref",
+    "set_info"
+})
+public class SaveReadsAlignmentSetV1Result {
+
+    @JsonProperty("set_ref")
+    private java.lang.String setRef;
+    @JsonProperty("set_info")
+    private Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>> setInfo;
+    private Map<java.lang.String, Object> additionalProperties = new HashMap<java.lang.String, Object>();
+
+    @JsonProperty("set_ref")
+    public java.lang.String getSetRef() {
+        return setRef;
+    }
+
+    @JsonProperty("set_ref")
+    public void setSetRef(java.lang.String setRef) {
+        this.setRef = setRef;
+    }
+
+    public SaveReadsAlignmentSetV1Result withSetRef(java.lang.String setRef) {
+        this.setRef = setRef;
+        return this;
+    }
+
+    @JsonProperty("set_info")
+    public Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>> getSetInfo() {
+        return setInfo;
+    }
+
+    @JsonProperty("set_info")
+    public void setSetInfo(Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>> setInfo) {
+        this.setInfo = setInfo;
+    }
+
+    public SaveReadsAlignmentSetV1Result withSetInfo(Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>> setInfo) {
+        this.setInfo = setInfo;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<java.lang.String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(java.lang.String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public java.lang.String toString() {
+        return ((((((("SaveReadsAlignmentSetV1Result"+" [setRef=")+ setRef)+", setInfo=")+ setInfo)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/src/us/kbase/setapi/SaveReadsSetV1Params.java
+++ b/lib/src/us/kbase/setapi/SaveReadsSetV1Params.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 /**
  * <p>Original spec-file type: SaveReadsSetV1Params</p>
  * <pre>
- * workspace_name or workspace_id - alternative options defining 
+ * workspace_name or workspace_id - alternative options defining
  *     target workspace,
  * output_object_name - workspace object name (this parameter is
  *     used together with one of workspace params from above)

--- a/lib/src/us/kbase/setapi/SetAPIClient.java
+++ b/lib/src/us/kbase/setapi/SetAPIClient.java
@@ -162,6 +162,40 @@ public class SetAPIClient {
     }
 
     /**
+     * <p>Original spec-file function name: get_reads_alignment_set_v1</p>
+     * <pre>
+     * </pre>
+     * @param   params   instance of type {@link us.kbase.setapi.GetReadsAlignmentSetV1Params GetReadsAlignmentSetV1Params}
+     * @return   instance of type {@link us.kbase.setapi.GetReadsAlignmentSetV1Result GetReadsAlignmentSetV1Result}
+     * @throws IOException if an IO exception occurs
+     * @throws JsonClientException if a JSON RPC exception occurs
+     */
+    public GetReadsAlignmentSetV1Result getReadsAlignmentSetV1(GetReadsAlignmentSetV1Params params, RpcContext... jsonRpcContext) throws IOException, JsonClientException {
+        List<Object> args = new ArrayList<Object>();
+        args.add(params);
+        TypeReference<List<GetReadsAlignmentSetV1Result>> retType = new TypeReference<List<GetReadsAlignmentSetV1Result>>() {};
+        List<GetReadsAlignmentSetV1Result> res = caller.jsonrpcCall("SetAPI.get_reads_alignment_set_v1", args, retType, true, false, jsonRpcContext, this.serviceVersion);
+        return res.get(0);
+    }
+
+    /**
+     * <p>Original spec-file function name: save_reads_alignment_set_v1</p>
+     * <pre>
+     * </pre>
+     * @param   params   instance of type {@link us.kbase.setapi.SaveReadsAlignmentSetV1Params SaveReadsAlignmentSetV1Params}
+     * @return   parameter "result" of type {@link us.kbase.setapi.SaveReadsAlignmentSetV1Result SaveReadsAlignmentSetV1Result}
+     * @throws IOException if an IO exception occurs
+     * @throws JsonClientException if a JSON RPC exception occurs
+     */
+    public SaveReadsAlignmentSetV1Result saveReadsAlignmentSetV1(SaveReadsAlignmentSetV1Params params, RpcContext... jsonRpcContext) throws IOException, JsonClientException {
+        List<Object> args = new ArrayList<Object>();
+        args.add(params);
+        TypeReference<List<SaveReadsAlignmentSetV1Result>> retType = new TypeReference<List<SaveReadsAlignmentSetV1Result>>() {};
+        List<SaveReadsAlignmentSetV1Result> res = caller.jsonrpcCall("SetAPI.save_reads_alignment_set_v1", args, retType, true, true, jsonRpcContext, this.serviceVersion);
+        return res.get(0);
+    }
+
+    /**
      * <p>Original spec-file function name: get_reads_set_v1</p>
      * <pre>
      * </pre>
@@ -267,7 +301,7 @@ public class SetAPIClient {
      * <p>Original spec-file function name: list_sets</p>
      * <pre>
      * Use to get the top-level sets in a WS. Optionally can include
-     * one level down members of those sets. 
+     * one level down members of those sets.
      * NOTE: DOES NOT PRESERVE ORDERING OF ITEM LIST IN DATA
      * </pre>
      * @param   params   instance of type {@link us.kbase.setapi.ListSetParams ListSetParams}

--- a/lib/src/us/kbase/setapi/SetAPIClient.java
+++ b/lib/src/us/kbase/setapi/SetAPIClient.java
@@ -162,6 +162,40 @@ public class SetAPIClient {
     }
 
     /**
+     * <p>Original spec-file function name: get_expression_set_v1</p>
+     * <pre>
+     * </pre>
+     * @param   params   instance of type {@link us.kbase.setapi.GetExpressionSetV1Params GetExpressionSetV1Params}
+     * @return   instance of type {@link us.kbase.setapi.GetExpressionSetV1Result GetExpressionSetV1Result}
+     * @throws IOException if an IO exception occurs
+     * @throws JsonClientException if a JSON RPC exception occurs
+     */
+    public GetExpressionSetV1Result getExpressionSetV1(GetExpressionSetV1Params params, RpcContext... jsonRpcContext) throws IOException, JsonClientException {
+        List<Object> args = new ArrayList<Object>();
+        args.add(params);
+        TypeReference<List<GetExpressionSetV1Result>> retType = new TypeReference<List<GetExpressionSetV1Result>>() {};
+        List<GetExpressionSetV1Result> res = caller.jsonrpcCall("SetAPI.get_expression_set_v1", args, retType, true, false, jsonRpcContext, this.serviceVersion);
+        return res.get(0);
+    }
+
+    /**
+     * <p>Original spec-file function name: save_expression_set_v1</p>
+     * <pre>
+     * </pre>
+     * @param   params   instance of type {@link us.kbase.setapi.SaveExpressionSetV1Params SaveExpressionSetV1Params}
+     * @return   parameter "result" of type {@link us.kbase.setapi.SaveExpressionSetV1Result SaveExpressionSetV1Result}
+     * @throws IOException if an IO exception occurs
+     * @throws JsonClientException if a JSON RPC exception occurs
+     */
+    public SaveExpressionSetV1Result saveExpressionSetV1(SaveExpressionSetV1Params params, RpcContext... jsonRpcContext) throws IOException, JsonClientException {
+        List<Object> args = new ArrayList<Object>();
+        args.add(params);
+        TypeReference<List<SaveExpressionSetV1Result>> retType = new TypeReference<List<SaveExpressionSetV1Result>>() {};
+        List<SaveExpressionSetV1Result> res = caller.jsonrpcCall("SetAPI.save_expression_set_v1", args, retType, true, true, jsonRpcContext, this.serviceVersion);
+        return res.get(0);
+    }
+
+    /**
      * <p>Original spec-file function name: get_reads_alignment_set_v1</p>
      * <pre>
      * </pre>

--- a/test/ExpressionSet_basic_test.py
+++ b/test/ExpressionSet_basic_test.py
@@ -144,112 +144,117 @@ class ExpressionSetAPITest(unittest.TestCase):
         self.assertEqual(result["set_info"][1], expression_set_name)
         self.assertIn("KBaseSets.ExpressionSet", result["set_info"][2])
 
-    # def test_save_expression_set_mismatched_genomes(self):
-    #     alignment_set_name = "alignment_set_bad_genomes"
-    #     alignment_set = {
-    #         "description": "this_better_fail",
-    #         "items": [{
-    #             "ref": self.make_fake_alignment(
-    #                 "odd_alignment", self.reads_refs[0], self.genome_refs[1]
-    #             ),
-    #             "label": "odd_alignment"
-    #         }, {
-    #             "ref": self.alignment_refs[1],
-    #             "label": "wt"
-    #         }]
-    #     }
-    #     with self.assertRaises(ValueError) as err:
-    #         self.getImpl().save_reads_alignment_set_v1(self.getContext(), {
-    #             "workspace": self.getWsName(),
-    #             "output_object_name": alignment_set_name,
-    #             "data": alignment_set
-    #         })
-    #         self.assertIn("All ReadsAlignments in the set must be aligned against "
-    #                       "the same genome reference", str(err.exception))
-    #
-    # def test_save_alignment_set_no_data(self):
-    #     with self.assertRaises(ValueError) as err:
-    #         self.getImpl().save_reads_alignment_set_v1(self.getContext(), {
-    #             "workspace": self.getWsName(),
-    #             "output_object_name": "foo",
-    #             "data": None
-    #         })
-    #     self.assertIn('"data" parameter field required to save a ReadsAlignmentSet',
-    #                   str(err.exception))
-    #
-    # def test_save_alignment_set_no_alignments(self):
-    #     with self.assertRaises(ValueError) as err:
-    #         self.getImpl().save_reads_alignment_set_v1(self.getContext(), {
-    #             "workspace": self.getWsName(),
-    #             "output_object_name": "foo",
-    #             "data": {
-    #                 "items": []
-    #             }
-    #         })
-    #     self.assertIn("A ReadsAlignmentSet must contain at "
-    #                   "least one ReadsAlignment reference.", str(err.exception))
-    #
-    # def test_get_alignment_set(self):
-    #     alignment_set_name = "test_alignment_set"
-    #     alignment_items = list()
-    #     for ref in self.alignment_refs:
-    #         alignment_items.append({
-    #             "label": "wt",
-    #             "ref": ref
-    #         })
-    #     alignment_set = {
-    #         "description": "test_alignments",
-    #         "items": alignment_items
-    #     }
-    #     alignment_set_ref = self.getImpl().save_reads_alignment_set_v1(self.getContext(), {
-    #         "workspace": self.getWsName(),
-    #         "output_object_name": alignment_set_name,
-    #         "data": alignment_set
-    #     })[0]["set_ref"]
-    #
-    #     fetched_set = self.getImpl().get_reads_alignment_set_v1(self.getContext(), {
-    #         "ref": alignment_set_ref,
-    #         "include_item_info": 0
-    #     })[0]
-    #     self.assertIsNotNone(fetched_set)
-    #     self.assertIn("data", fetched_set)
-    #     self.assertIn("info", fetched_set)
-    #     self.assertEquals(len(fetched_set["data"]["items"]), 3)
-    #     self.assertEquals(alignment_set_ref, info_to_ref(fetched_set["info"]))
-    #     for item in fetched_set["data"]["items"]:
-    #         self.assertNotIn("info", item)
-    #         self.assertIn("ref", item)
-    #         self.assertIn("label", item)
-    #
-    #     fetched_set_with_info = self.getImpl().get_reads_alignment_set_v1(self.getContext(), {
-    #         "ref": alignment_set_ref,
-    #         "include_item_info": 1
-    #     })[0]
-    #     self.assertIsNotNone(fetched_set_with_info)
-    #     self.assertIn("data", fetched_set_with_info)
-    #     for item in fetched_set_with_info["data"]["items"]:
-    #         self.assertIn("info", item)
-    #         self.assertIn("ref", item)
-    #         self.assertIn("label", item)
-    #
-    # def test_get_alignment_set_bad_ref(self):
-    #     with self.assertRaises(ValueError) as err:
-    #         self.getImpl().get_reads_alignment_set_v1(self.getContext(), {
-    #             "ref": "not_a_ref"
-    #         })
-    #     self.assertIn('"ref" parameter must be a valid workspace reference', str(err.exception))
-    #
-    # def test_get_alignment_set_bad_path(self):
-    #     with self.assertRaises(Exception):
-    #         self.getImpl().get_reads_alignment_set_v1(self.getContext(), {
-    #             "ref": "1/2/3",
-    #             "path_to_set": ["foo", "bar"]
-    #         })
-    #
-    # def test_get_alignment_set_no_ref(self):
-    #     with self.assertRaises(ValueError) as err:
-    #         self.getImpl().get_reads_alignment_set_v1(self.getContext(), {
-    #             "ref": None
-    #         })
-    #     self.assertIn('"ref" parameter field specifiying the reads set is required',
-    #                   str(err.exception))
+    def test_save_expression_set_mismatched_genomes(self):
+        expression_set_name = "expression_set_bad_genomes"
+        expression_set = {
+            "description": "this_better_fail",
+            "items": [{
+                "ref": make_fake_expression(
+                    "odd_expression",
+                    self.genome_refs[1],
+                    self.annotation_ref,
+                    self.alignment_refs[0],
+                    self.getWsName(),
+                    self.getWsClient()
+                ),
+                "label": "odd_alignment"
+            }, {
+                "ref": self.alignment_refs[1],
+                "label": "not_so_odd"
+            }]
+        }
+        with self.assertRaises(ValueError) as err:
+            self.getImpl().save_expression_set_v1(self.getContext(), {
+                "workspace": self.getWsName(),
+                "output_object_name": expression_set_name,
+                "data": expression_set
+            })
+            self.assertIn("All Expression objects in the set must use "
+                          "the same genome reference.", str(err.exception))
+
+    def test_save_alignment_set_no_data(self):
+        with self.assertRaises(ValueError) as err:
+            self.getImpl().save_expression_set_v1(self.getContext(), {
+                "workspace": self.getWsName(),
+                "output_object_name": "foo",
+                "data": None
+            })
+        self.assertIn('"data" parameter field required to save an ExpressionSet',
+                      str(err.exception))
+
+    def test_save_alignment_set_no_expressions(self):
+        with self.assertRaises(ValueError) as err:
+            self.getImpl().save_expression_set_v1(self.getContext(), {
+                "workspace": self.getWsName(),
+                "output_object_name": "foo",
+                "data": {
+                    "items": []
+                }
+            })
+        self.assertIn("An ExpressionSet must contain at "
+                      "least one Expression object reference.", str(err.exception))
+
+    def test_get_expression_set(self):
+        expression_set_name = "test_expression_set"
+        expression_items = list()
+        for ref in self.expression_refs:
+            expression_items.append({
+                "label": "wt",
+                "ref": ref
+            })
+        expression_set = {
+            "description": "test_alignments",
+            "items": expression_items
+        }
+        expression_set_ref = self.getImpl().save_expression_set_v1(self.getContext(), {
+            "workspace": self.getWsName(),
+            "output_object_name": expression_set_name,
+            "data": expression_set
+        })[0]["set_ref"]
+
+        fetched_set = self.getImpl().get_expression_set_v1(self.getContext(), {
+            "ref": expression_set_ref,
+            "include_item_info": 0
+        })[0]
+        self.assertIsNotNone(fetched_set)
+        self.assertIn("data", fetched_set)
+        self.assertIn("info", fetched_set)
+        self.assertEquals(len(fetched_set["data"]["items"]), 3)
+        self.assertEquals(expression_set_ref, info_to_ref(fetched_set["info"]))
+        for item in fetched_set["data"]["items"]:
+            self.assertNotIn("info", item)
+            self.assertIn("ref", item)
+            self.assertIn("label", item)
+
+        fetched_set_with_info = self.getImpl().get_expression_set_v1(self.getContext(), {
+            "ref": expression_set_ref,
+            "include_item_info": 1
+        })[0]
+        self.assertIsNotNone(fetched_set_with_info)
+        self.assertIn("data", fetched_set_with_info)
+        for item in fetched_set_with_info["data"]["items"]:
+            self.assertIn("info", item)
+            self.assertIn("ref", item)
+            self.assertIn("label", item)
+
+    def test_get_expression_set_bad_ref(self):
+        with self.assertRaises(ValueError) as err:
+            self.getImpl().get_expression_set_v1(self.getContext(), {
+                "ref": "not_a_ref"
+            })
+        self.assertIn('"ref" parameter must be a valid workspace reference', str(err.exception))
+
+    def test_get_expression_set_bad_path(self):
+        with self.assertRaises(Exception):
+            self.getImpl().get_expression_set_v1(self.getContext(), {
+                "ref": "1/2/3",
+                "path_to_set": ["foo", "bar"]
+            })
+
+    def test_get_expression_set_no_ref(self):
+        with self.assertRaises(ValueError) as err:
+            self.getImpl().get_expression_set_v1(self.getContext(), {
+                "ref": None
+            })
+        self.assertIn('"ref" parameter field specifiying the expression set is required',
+                      str(err.exception))

--- a/test/ExpressionSet_basic_test.py
+++ b/test/ExpressionSet_basic_test.py
@@ -1,0 +1,255 @@
+# -*- coding: utf-8 -*-
+import unittest
+import os
+import time
+
+from os import environ
+try:
+    from ConfigParser import ConfigParser  # py2
+except:
+    from configparser import ConfigParser  # py3
+
+from biokbase.workspace.client import Workspace as workspaceService
+from SetAPI.SetAPIImpl import SetAPI
+from SetAPI.SetAPIServer import MethodContext
+
+from FakeObjectsForTests.FakeObjectsForTestsClient import FakeObjectsForTests
+from SetAPI.authclient import KBaseAuth as _KBaseAuth
+from util import (
+    info_to_ref,
+    make_fake_alignment,
+    make_fake_annotation,
+    make_fake_expression
+)
+
+
+class ExpressionSetAPITest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        token = environ.get('KB_AUTH_TOKEN', None)
+        config_file = environ.get('KB_DEPLOYMENT_CONFIG', None)
+        cls.cfg = {}
+        config = ConfigParser()
+        config.read(config_file)
+        for nameval in config.items('SetAPI'):
+            cls.cfg[nameval[0]] = nameval[1]
+        authServiceUrl = cls.cfg.get("auth-service-url",
+                                     "https://kbase.us/services/authorization/Sessions/Login")
+        auth_client = _KBaseAuth(authServiceUrl)
+        user_id = auth_client.get_user(token)
+        # WARNING: don't call any logging methods on the context object,
+        # it'll result in a NoneType error
+        cls.ctx = MethodContext(None)
+        cls.ctx.update({'token': token,
+                        'user_id': user_id,
+                        'provenance': [
+                            {'service': 'SetAPI',
+                             'method': 'please_never_use_it_in_production',
+                             'method_params': []
+                             }],
+                        'authenticated': 1})
+        cls.wsURL = cls.cfg['workspace-url']
+        cls.wsClient = workspaceService(cls.wsURL, token=token)
+        cls.serviceImpl = SetAPI(cls.cfg)
+
+        # setup data at the class level for now (so that the code is run
+        # once for all tests, not before each test case.  Not sure how to
+        # do that outside this function..)
+        suffix = int(time.time() * 1000)
+        wsName = "test_SetAPI_" + str(suffix)
+        cls.wsClient.create_workspace({'workspace': wsName})
+        cls.wsName = wsName
+
+        foft = FakeObjectsForTests(os.environ['SDK_CALLBACK_URL'])
+
+        # Make a fake genome
+        [fake_genome, fake_genome2] = foft.create_fake_genomes({
+            "ws_name": wsName,
+            "obj_names": ["fake_genome", "fake_genome2"]
+        })
+        cls.genome_refs = [info_to_ref(fake_genome), info_to_ref(fake_genome2)]
+
+        # Make some fake reads objects
+        fake_reads_list = foft.create_fake_reads({
+            'ws_name': wsName,
+            "obj_names": ["reads1", "reads2", "reads3"]
+        })
+        cls.alignment_refs = list()
+        cls.reads_refs = list()
+
+        # Make some fake alignments referencing those reads and genome
+        for idx, reads_info in enumerate(fake_reads_list):
+            reads_ref = info_to_ref(reads_info)
+            cls.reads_refs.append(reads_ref)
+            cls.alignment_refs.append(
+                make_fake_alignment("fake_alignment_{}".format(idx), reads_ref, cls.genome_refs[0],
+                                    wsName, cls.wsClient)
+            )
+
+        # Need a fake annotation to get the expression objects
+        cls.annotation_ref = make_fake_annotation("fake_annotation", wsName, cls.wsClient)
+
+        # Now we can phony up some expression objects to build sets out of.
+        # name, genome_ref, annotation_ref, alignment_ref, ws_name, ws_client
+        cls.expression_refs = list()
+        for idx, alignment_ref in enumerate(cls.alignment_refs):
+            cls.expression_refs.append(make_fake_expression(
+                "fake_expression_{}".format(idx),
+                cls.genome_refs[0],
+                cls.annotation_ref,
+                alignment_ref,
+                wsName,
+                cls.wsClient
+            ))
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, 'wsName'):
+            cls.wsClient.delete_workspace({'workspace': cls.wsName})
+            print('Test workspace was deleted')
+
+    def getWsClient(self):
+        return self.__class__.wsClient
+
+    def getWsName(self):
+        return self.__class__.wsName
+
+    def getImpl(self):
+        return self.__class__.serviceImpl
+
+    def getContext(self):
+        return self.__class__.ctx
+
+    def test_save_expression_set(self):
+        expression_set_name = "test_expression_set"
+        expression_items = list()
+        for ref in self.expression_refs:
+            expression_items.append({
+                "label": "foo",
+                "ref": ref
+            })
+        expression_set = {
+            "description": "test_expressions",
+            "items": expression_items
+        }
+        result = self.getImpl().save_expression_set_v1(self.getContext(), {
+            "workspace": self.getWsName(),
+            "output_object_name": expression_set_name,
+            "data": expression_set
+        })[0]
+        self.assertIsNotNone(result)
+        self.assertIn("set_ref", result)
+        self.assertIn("set_info", result)
+        self.assertEqual(result["set_ref"], info_to_ref(result["set_info"]))
+        self.assertEqual(result["set_info"][1], expression_set_name)
+        self.assertIn("KBaseSets.ExpressionSet", result["set_info"][2])
+
+    # def test_save_expression_set_mismatched_genomes(self):
+    #     alignment_set_name = "alignment_set_bad_genomes"
+    #     alignment_set = {
+    #         "description": "this_better_fail",
+    #         "items": [{
+    #             "ref": self.make_fake_alignment(
+    #                 "odd_alignment", self.reads_refs[0], self.genome_refs[1]
+    #             ),
+    #             "label": "odd_alignment"
+    #         }, {
+    #             "ref": self.alignment_refs[1],
+    #             "label": "wt"
+    #         }]
+    #     }
+    #     with self.assertRaises(ValueError) as err:
+    #         self.getImpl().save_reads_alignment_set_v1(self.getContext(), {
+    #             "workspace": self.getWsName(),
+    #             "output_object_name": alignment_set_name,
+    #             "data": alignment_set
+    #         })
+    #         self.assertIn("All ReadsAlignments in the set must be aligned against "
+    #                       "the same genome reference", str(err.exception))
+    #
+    # def test_save_alignment_set_no_data(self):
+    #     with self.assertRaises(ValueError) as err:
+    #         self.getImpl().save_reads_alignment_set_v1(self.getContext(), {
+    #             "workspace": self.getWsName(),
+    #             "output_object_name": "foo",
+    #             "data": None
+    #         })
+    #     self.assertIn('"data" parameter field required to save a ReadsAlignmentSet',
+    #                   str(err.exception))
+    #
+    # def test_save_alignment_set_no_alignments(self):
+    #     with self.assertRaises(ValueError) as err:
+    #         self.getImpl().save_reads_alignment_set_v1(self.getContext(), {
+    #             "workspace": self.getWsName(),
+    #             "output_object_name": "foo",
+    #             "data": {
+    #                 "items": []
+    #             }
+    #         })
+    #     self.assertIn("A ReadsAlignmentSet must contain at "
+    #                   "least one ReadsAlignment reference.", str(err.exception))
+    #
+    # def test_get_alignment_set(self):
+    #     alignment_set_name = "test_alignment_set"
+    #     alignment_items = list()
+    #     for ref in self.alignment_refs:
+    #         alignment_items.append({
+    #             "label": "wt",
+    #             "ref": ref
+    #         })
+    #     alignment_set = {
+    #         "description": "test_alignments",
+    #         "items": alignment_items
+    #     }
+    #     alignment_set_ref = self.getImpl().save_reads_alignment_set_v1(self.getContext(), {
+    #         "workspace": self.getWsName(),
+    #         "output_object_name": alignment_set_name,
+    #         "data": alignment_set
+    #     })[0]["set_ref"]
+    #
+    #     fetched_set = self.getImpl().get_reads_alignment_set_v1(self.getContext(), {
+    #         "ref": alignment_set_ref,
+    #         "include_item_info": 0
+    #     })[0]
+    #     self.assertIsNotNone(fetched_set)
+    #     self.assertIn("data", fetched_set)
+    #     self.assertIn("info", fetched_set)
+    #     self.assertEquals(len(fetched_set["data"]["items"]), 3)
+    #     self.assertEquals(alignment_set_ref, info_to_ref(fetched_set["info"]))
+    #     for item in fetched_set["data"]["items"]:
+    #         self.assertNotIn("info", item)
+    #         self.assertIn("ref", item)
+    #         self.assertIn("label", item)
+    #
+    #     fetched_set_with_info = self.getImpl().get_reads_alignment_set_v1(self.getContext(), {
+    #         "ref": alignment_set_ref,
+    #         "include_item_info": 1
+    #     })[0]
+    #     self.assertIsNotNone(fetched_set_with_info)
+    #     self.assertIn("data", fetched_set_with_info)
+    #     for item in fetched_set_with_info["data"]["items"]:
+    #         self.assertIn("info", item)
+    #         self.assertIn("ref", item)
+    #         self.assertIn("label", item)
+    #
+    # def test_get_alignment_set_bad_ref(self):
+    #     with self.assertRaises(ValueError) as err:
+    #         self.getImpl().get_reads_alignment_set_v1(self.getContext(), {
+    #             "ref": "not_a_ref"
+    #         })
+    #     self.assertIn('"ref" parameter must be a valid workspace reference', str(err.exception))
+    #
+    # def test_get_alignment_set_bad_path(self):
+    #     with self.assertRaises(Exception):
+    #         self.getImpl().get_reads_alignment_set_v1(self.getContext(), {
+    #             "ref": "1/2/3",
+    #             "path_to_set": ["foo", "bar"]
+    #         })
+    #
+    # def test_get_alignment_set_no_ref(self):
+    #     with self.assertRaises(ValueError) as err:
+    #         self.getImpl().get_reads_alignment_set_v1(self.getContext(), {
+    #             "ref": None
+    #         })
+    #     self.assertIn('"ref" parameter field specifiying the reads set is required',
+    #                   str(err.exception))

--- a/test/ReadsAlignmentSet_basic_test.py
+++ b/test/ReadsAlignmentSet_basic_test.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+import unittest
+import os
+import time
+
+from os import environ
+try:
+    from ConfigParser import ConfigParser  # py2
+except:
+    from configparser import ConfigParser  # py3
+
+from biokbase.workspace.client import Workspace as workspaceService
+from SetAPI.SetAPIImpl import SetAPI
+from SetAPI.SetAPIServer import MethodContext
+
+from FakeObjectsForTests.FakeObjectsForTestsClient import FakeObjectsForTests
+from SetAPI.authclient import KBaseAuth as _KBaseAuth
+
+def info_to_ref(info):
+    return "{}/{}/{}".format(info[6], info[0], info[4])
+
+class ReadsAlignmentSetAPITest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        token = environ.get('KB_AUTH_TOKEN', None)
+        config_file = environ.get('KB_DEPLOYMENT_CONFIG', None)
+        cls.cfg = {}
+        config = ConfigParser()
+        config.read(config_file)
+        for nameval in config.items('SetAPI'):
+            cls.cfg[nameval[0]] = nameval[1]
+        authServiceUrl = cls.cfg.get('auth-service-url',
+                "https://kbase.us/services/authorization/Sessions/Login")
+        auth_client = _KBaseAuth(authServiceUrl)
+        user_id = auth_client.get_user(token)
+        # WARNING: don't call any logging methods on the context object,
+        # it'll result in a NoneType error
+        cls.ctx = MethodContext(None)
+        cls.ctx.update({'token': token,
+                        'user_id': user_id,
+                        'provenance': [
+                            {'service': 'SetAPI',
+                             'method': 'please_never_use_it_in_production',
+                             'method_params': []
+                             }],
+                        'authenticated': 1})
+        cls.wsURL = cls.cfg['workspace-url']
+        cls.wsClient = workspaceService(cls.wsURL, token=token)
+        cls.serviceImpl = SetAPI(cls.cfg)
+
+        # setup data at the class level for now (so that the code is run
+        # once for all tests, not before each test case.  Not sure how to
+        # do that outside this function..)
+        suffix = int(time.time() * 1000)
+        wsName = "test_SetAPI_" + str(suffix)
+        ret = cls.wsClient.create_workspace({'workspace': wsName})
+        cls.wsName = wsName
+
+        foft = FakeObjectsForTests(os.environ['SDK_CALLBACK_URL'])
+
+        [fake_genome] = foft.create_fake_genomes({
+            "ws_name": wsName,
+            "obj_names": ["fake_genome"]
+        })
+        cls.genome_ref = info_to_ref(fake_genome)
+        fake_reads_list = foft.create_fake_reads({
+            'ws_name': wsName,
+            "obj_names": ["reads1", "reads2", "reads3"]
+        })
+        cls.alignment_refs = list()
+        cls.reads_refs = list()
+        for idx, reads_info in enumerate(fake_reads_list):
+            reads_ref = info_to_ref(reads_info)
+            cls.reads_refs.append(reads_ref)
+            cls.alignment_refs.append(info_to_ref(foft.create_any_objects({
+                "ws_name": wsName,
+                "obj_names": ["reads_align_{}".format(idx)],
+                "metadata": {
+                    "genome_id": cls.genome_ref,
+                    "read_sample_id": reads_ref
+                }
+            })[0]))
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, 'wsName'):
+            cls.wsClient.delete_workspace({'workspace': cls.wsName})
+            print('Test workspace was deleted')
+
+    def getWsClient(self):
+        return self.__class__.wsClient
+
+    def getWsName(self):
+        if hasattr(self.__class__, 'wsName'):
+            return self.__class__.wsName
+        suffix = int(time.time() * 1000)
+        wsName = "test_SetAPI_" + str(suffix)
+        ret = self.getWsClient().create_workspace({'workspace': wsName})
+        self.__class__.wsName = wsName
+        return wsName
+
+    def getImpl(self):
+        return self.__class__.serviceImpl
+
+    def getContext(self):
+        return self.__class__.ctx
+
+    def test_save_alignment_set(self):
+        alignment_set_name = "test_alignment_set"
+        alignment_items = list()
+        for ref in self.alignment_refs:
+            alignment_items.append({
+                "label": "wt",
+                "ref": ref
+            })
+        alignment_set = {
+            "description": "test_alignments",
+            "items": alignment_items
+        }
+        result = self.getImpl().save_reads_alignment_set_v1(self.getContext(), {
+            "workspace": self.getWsName(),
+            "output_object_name": alignment_set_name,
+            "data": alignment_set
+        })
+        self.assertIsNotNone(result)
+        self.assertIn("set_ref", result)
+        self.assertIn("set_info", result)

--- a/test/util.py
+++ b/test/util.py
@@ -1,0 +1,87 @@
+"""
+Some utility functions to help with testing. These mainly add fake objects to use in making sets.
+"""
+
+
+def info_to_ref(info):
+    """
+    Just a one liner that converts the usual Workspace ObjectInfo list into an object reference
+    string.
+    (Honestly, I just got sick of rewriting this everywhere and forgetting the indices - Bill).
+    """
+    return "{}/{}/{}".format(info[6], info[0], info[4])
+
+
+def make_fake_alignment(name, reads_ref, genome_ref, ws_name, ws_client):
+    """
+    Makes a Fake KBaseRNASeq.RNASeqAlignment object and returns a ref to it.
+    name: the name of the object
+    reads_ref: a reference to a valid (probably fake) reads library
+    genome_ref: a reference to a valid (also probably fake) genome
+    workspace_name: the name of the workspace to save this object
+    workspace_client: a Workspace client tuned to the server of your choice
+    """
+    fake_alignment = {
+        "file": {
+            "id": "not_a_real_handle"
+        },
+        "library_type": "fake",
+        "read_sample_id": reads_ref,
+        "condition": "fake",
+        "genome_id": genome_ref
+    }
+    return make_fake_object(fake_alignment, "KBaseRNASeq.RNASeqAlignment", name, ws_name, ws_client)
+
+
+def make_fake_annotation(name, ws_name, ws_client):
+    annotation = {
+        "handle": {
+            "id": "not_a_real_handle"
+        },
+        "size": 0,
+        "genome_id": "not_a_real_genome",
+        "genome_scientific_name": "Genomus falsus"
+    }
+    return make_fake_object(annotation, "KBaseRNASeq.GFFAnnotation", name, ws_name, ws_client)
+
+
+def make_fake_expression(name, genome_ref, annotation_ref, alignment_ref, ws_name, ws_client):
+    """
+    Makes a Fake KBaseRNASeq.RNASeqExpression object and returns a ref to it.
+    genome_ref: reference to a genome object
+    annotation_ref: reference to a KBaseRNASeq.GFFAnnotation
+    alignment_ref: reference to a KBaseRNASeq.RNASeqAlignment
+    """
+    exp = {
+        "id": "fake",
+        "type": "fake",
+        "numerical_interpretation": "fake",
+        "expression_levels": {"feature_1": 0, "feature_2": 1, "feature_3": 2},
+        "genome_id": genome_ref,
+        "annotation_id": annotation_ref,
+        "mapped_rnaseq_alignment": {"id1": alignment_ref},
+        "condition": "",
+        "tool_used": "none",
+        "tool_version": "0.0.0"
+    }
+    return make_fake_object(exp, "KBaseRNASeq.RNASeqExpression", name, ws_name, ws_client)
+
+
+def make_fake_object(obj, obj_type, name, workspace_name, workspace_client):
+    """
+    Saves a dummy object (obj) of given type obj_type and name to the given workspace_name using the
+    provided workspace client.
+
+    Returns a reference to that object.
+    """
+    return info_to_ref(
+        workspace_client.save_objects({
+            "workspace": workspace_name,
+            "objects": [{
+                "type": obj_type,
+                "meta": {},
+                "data": obj,
+                "name": name
+            }]
+        })[0]
+    )


### PR DESCRIPTION
Much like the previous PR, this adds new support for sets of KBaseRNASeq.RNASeqExpression objects.

Also, like the ReadsAlignmentSets, it enforces that all Expression objects in a set must reference the same genome.

Due to a little sloppiness, this contains the code for the ReadsAlignmentSets, so that PR (#12) should be merged first!