### PR TITLE
TASK-1107, TASK-1150, Changes for input 'ref_path_to_set' and 'ref_path' output

### DIFF
--- a/SetAPI.spec
+++ b/SetAPI.spec
@@ -476,6 +476,10 @@ module SetAPI {
         ref - workspace reference to AssemblyGroup object.
         include_item_info - 1 or 0, if 1 additionally provides workspace info (with
                             metadata) for each Assembly object in the Set
+        include_set_item_ref_paths - 1 or 0, if 1, additionally provides ref_path for each item
+                                     in the set. The ref_path returned for each item is either
+                                         ref_path_to_set;item_ref  (if ref_path_to_set is given) or
+                                         set_ref;item_ref  (if ref_path_to_set is not given)
     */
     typedef structure {
         string ref;

--- a/SetAPI.spec
+++ b/SetAPI.spec
@@ -600,6 +600,7 @@ module SetAPI {
 
 
 
+
     /* ******* Generic SET METHODS ************ */
 
 
@@ -612,6 +613,10 @@ module SetAPI {
             and into object info of items (it affects DP raw data as well),
         include_raw_data_palettes - advanced option designed for
             optimization of listing methods in NarrativeService.
+        include_set_item_ref_paths - 1 or 0, if 1, additionally provides ref_path for each item
+                            in the set. The ref_path for each item is either
+                                ref_path_to_set;item_ref  (if ref_path_to_set is given) or
+                                set_ref;item_ref
     */
     typedef structure {
         string workspace;
@@ -619,11 +624,17 @@ module SetAPI {
         boolean include_set_item_info;
         boolean include_metadata;
         boolean include_raw_data_palettes;
+        boolean include_set_item_ref_paths;
     } ListSetParams;
 
+    /*
+        ref_path is optionally returned by list_sets() and get_set_items(),
+        when the input parameter 'include_set_item_ref_paths' is set to 1.
+    */
 
     typedef structure {
         ws_obj_id ref;
+        ws_obj_id ref_path;
         Workspace.object_info info;
     } SetItemInfo;
 
@@ -657,17 +668,23 @@ module SetAPI {
     one level down members of those sets.
     NOTE: DOES NOT PRESERVE ORDERING OF ITEM LIST IN DATA */
     funcdef list_sets(ListSetParams params)
-                returns (ListSetResult result) authentication optional;
+              returns(ListSetResult result) authentication optional;
 
-
+    /*
+        include_set_item_ref_paths - 1 or 0, if 1, additionally provides ref_path for each item
+                            in the set. The ref_path for each item is either
+                                ref_path_to_set;item_ref  (if ref_path_to_set is given) or
+                                set_ref;item_ref
+     */
 
     typedef structure {
         ws_obj_id ref;
-        list <ws_obj_id> path_to_set;
+        list <ws_obj_id> ref_path_to_set;
     } SetReference;
 
     typedef structure {
         list <SetReference> set_refs;
+        boolean include_set_item_ref_paths;
     } GetSetItemsParams;
 
     typedef structure {
@@ -678,6 +695,6 @@ module SetAPI {
     return 'sets' list will match the position in the input ref list.
     NOTE: DOES NOT PRESERVE ORDERING OF ITEM LIST IN DATA */
     funcdef get_set_items(GetSetItemsParams params)
-                returns (GetSetItemsResult result) authentication optional;
+                  returns(GetSetItemsResult result) authentication optional;
 
 };

--- a/SetAPI.spec
+++ b/SetAPI.spec
@@ -36,9 +36,12 @@ module SetAPI {
         When saving a DifferentialExpressionMatrixSet, only 'ref' is required.
         You should never set 'info'.  'info' is provided optionally when fetching
         the DifferentialExpressionMatrixSet.
+        ref_path is optionally returned by get_differential_expression_matrix_set_v1()
+        when its input parameter 'include_set_item_ref_paths' is set to 1.
     */
     typedef structure {
         ws_diffexpmatrix_id ref;
+        ws_diffexpmatrix_id ref_path;
         string label;
         Workspace.object_info info;
     } DifferentialExpressionMatrixSetItem;
@@ -59,10 +62,15 @@ module SetAPI {
         ref - workspace reference to DifferentialExpressionMatrixSet object.
         include_item_info - 1 or 0, if 1 additionally provides workspace info (with
                             metadata) for each DifferentialExpressionMatrix object in the Set
+        include_set_item_ref_paths - 1 or 0, if 1, additionally provides ref_path for each item
+                                     in the set. The ref_path returned for each item is either
+                                         ref_path_to_set;item_ref  (if ref_path_to_set is given) or
+                                         set_ref;item_ref  (if ref_path_to_set is not given)
     */
     typedef structure {
         string ref;
         boolean include_item_info;
+        boolean include_set_item_ref_paths;
         list <string> ref_path_to_set;
     } GetDifferentialExpressionMatrixSetV1Params;
 
@@ -112,9 +120,12 @@ module SetAPI {
         When saving a FeatureSetSet, only 'ref' is required.
         You should never set 'info'.  'info' is provided optionally when fetching
         the FeatureSetSet.
+        ref_path is optionally returned by get_feature_set_set_v1()
+        when its input parameter 'include_set_item_ref_paths' is set to 1.
     */
     typedef structure {
         ws_feature_set_id ref;
+        ws_feature_set_id ref_path;
         string label;
         Workspace.object_info info;
     } FeatureSetSetItem;
@@ -135,10 +146,15 @@ module SetAPI {
         ref - workspace reference to FeatureSetSet object.
         include_item_info - 1 or 0, if 1 additionally provides workspace info (with
                             metadata) for each FeatureSet object in the Set
+        include_set_item_ref_paths - 1 or 0, if 1, additionally provides ref_path for each item
+                                     in the set. The ref_path returned for each item is either
+                                         ref_path_to_set;item_ref  (if ref_path_to_set is given) or
+                                         set_ref;item_ref  (if ref_path_to_set is not given)
     */
     typedef structure {
         string ref;
         boolean include_item_info;
+        boolean include_set_item_ref_paths;
         list <string> ref_path_to_set;
     } GetFeatureSetSetV1Params;
 
@@ -186,9 +202,12 @@ module SetAPI {
         When saving a ExpressionSet, only 'ref' is required.
         You should never set 'info'.  'info' is provided optionally when fetching
         the ExpressionSet.
+        ref_path is optionally returned by get_expression_set_v1()
+        when its input parameter 'include_set_item_ref_paths' is set to 1.
     */
     typedef structure {
         ws_expression_id ref;
+        ws_expression_id ref_path;
         string label;
         list<DataAttachment> data_attachments;
         Workspace.object_info info;
@@ -210,10 +229,15 @@ module SetAPI {
         ref - workspace reference to ExpressionSet object.
         include_item_info - 1 or 0, if 1 additionally provides workspace info (with
                             metadata) for each Expression object in the Set
+        include_set_item_ref_paths - 1 or 0, if 1, additionally provides ref_path for each item
+                                     in the set. The ref_path returned for each item is either
+                                         ref_path_to_set;item_ref  (if ref_path_to_set is given) or
+                                         set_ref;item_ref  (if ref_path_to_set is not given)
     */
     typedef structure {
         string ref;
         boolean include_item_info;
+        boolean include_set_item_ref_paths;
         list <string> ref_path_to_set;
     } GetExpressionSetV1Params;
 
@@ -261,9 +285,12 @@ module SetAPI {
         When saving a ReadsAlignmentSet, only 'ref' is required.
         You should never set 'info'.  'info' is provided optionally when fetching
         the ReadsAlignmentSet.
+        ref_path is optionally returned by get_reads_alignment_set_v1()
+        when its input parameter 'include_set_item_ref_paths' is set to 1.
     */
     typedef structure {
         ws_reads_align_id ref;
+        ws_reads_align_id ref_path;
         string label;
         Workspace.object_info info;
         list<DataAttachment> data_attachments;
@@ -285,10 +312,15 @@ module SetAPI {
         ref - workspace reference to ReadsAlignmentSet object.
         include_item_info - 1 or 0, if 1 additionally provides workspace info (with
                             metadata) for each ReadsAlignment object in the Set
+        include_set_item_ref_paths - 1 or 0, if 1, additionally provides ref_path for each item
+                                     in the set. The ref_path returned for each item is either
+                                         ref_path_to_set;item_ref  (if ref_path_to_set is given) or
+                                         set_ref;item_ref  (if ref_path_to_set is not given)
     */
     typedef structure {
         string ref;
         boolean include_item_info;
+        boolean include_set_item_ref_paths;
         list <string> ref_path_to_set;
     } GetReadsAlignmentSetV1Params;
 
@@ -337,9 +369,12 @@ module SetAPI {
         When saving a ReadsSet, only 'ref' is required.  You should
         never set 'info'.  'info' is provided optionally when fetching
         the ReadsSet.
+        ref_path is optionally returned by get_reads_set_v1()
+        when its input parameter 'include_set_item_ref_paths' is set to 1.
     */
     typedef structure {
         ws_reads_id ref;
+        ws_reads_id ref_path;
         string label;
         list <DataAttachment> data_attachments;
         Workspace.object_info info;
@@ -359,10 +394,15 @@ module SetAPI {
         ref - workspace reference to ReadsGroup object.
         include_item_info - 1 or 0, if 1 additionally provides workspace info (with
                             metadata) for each Reads object in the Set
+        include_set_item_ref_paths - 1 or 0, if 1, additionally provides ref_path for each item
+                                     in the set. The ref_path returned for each item is either
+                                         ref_path_to_set;item_ref  (if ref_path_to_set is given) or
+                                         set_ref;item_ref  (if ref_path_to_set is not given)
     */
     typedef structure {
         string ref;
         boolean include_item_info;
+        boolean include_set_item_ref_paths;
         list <string> ref_path_to_set;
     } GetReadsSetV1Params;
 
@@ -412,9 +452,12 @@ module SetAPI {
         When saving an AssemblySet, only 'ref' is required.
         You should never set 'info'.  'info' is provided optionally when fetching
         the AssemblySet.
+        ref_path is optionally returned by get_assembly_set_v1()
+        when its input parameter 'include_set_item_ref_paths' is set to 1.
     */
     typedef structure {
         ws_assembly_id ref;
+        ws_assembly_id ref_path;
         string label;
         Workspace.object_info info;
     } AssemblySetItem;
@@ -437,6 +480,7 @@ module SetAPI {
     typedef structure {
         string ref;
         boolean include_item_info;
+        boolean include_set_item_ref_paths;
         list <string> ref_path_to_set;
     } GetAssemblySetV1Params;
 
@@ -485,9 +529,12 @@ module SetAPI {
         When saving an GenomeSet, only 'ref' is required.
         You should never set 'info'.  'info' is provided optionally when fetching
         the GenomeSet.
+        ref_path is optionally returned by get_genome_set_v1()
+        when its input parameter 'include_set_item_ref_paths' is set to 1.
     */
     typedef structure {
         ws_genome_id ref;
+        ws_genome_id ref_path;
         string label;
         Workspace.object_info info;
     } GenomeSetItem;
@@ -506,10 +553,15 @@ module SetAPI {
         ref - workspace reference to GenomeGroup object.
         include_item_info - 1 or 0, if 1 additionally provides workspace info (with
                             metadata) for each Genome object in the Set
+        include_set_item_ref_paths - 1 or 0, if 1, additionally provides ref_path for each item
+                            in the set. The ref_path for each item is either
+                                ref_path_to_set;item_ref  (if ref_path_to_set is given) or
+                                set_ref;item_ref
     */
     typedef structure {
         string ref;
         boolean include_item_info;
+        boolean include_set_item_ref_paths;
         list <string> ref_path_to_set;
     } GetGenomeSetV1Params;
 
@@ -540,9 +592,6 @@ module SetAPI {
 
     funcdef save_genome_set_v1(SaveGenomeSetV1Params params)
         returns (SaveGenomeSetV1Result result) authentication required;
-
-
-
 
 
 

--- a/lib/SetAPI/assembly/AssemblySetInterfaceV1.py
+++ b/lib/SetAPI/assembly/AssemblySetInterfaceV1.py
@@ -1,16 +1,9 @@
-
-
-
-from SetAPI.generic.SetInterfaceV1 import SetInterfaceV1
-
-from biokbase.workspace.client import Workspace
-
 from pprint import pprint
 
-
+from SetAPI.generic.SetInterfaceV1 import SetInterfaceV1
+from biokbase.workspace.client import Workspace
 
 class AssemblySetInterfaceV1:
-
 
     def __init__(self, workspace_client):
         self.ws = workspace_client
@@ -23,16 +16,15 @@ class AssemblySetInterfaceV1:
             raise ValueError('"data" parameter field required to save an AssemblySet')
 
         save_result = self.setInterface.save_set(
-                'KBaseSets.AssemblySet',
-                ctx['provenance'],
-                params
-            )
+                                'KBaseSets.AssemblySet',
+                                ctx['provenance'],
+                                params
+                                )
         info = save_result[0]
         return {
             'set_ref': str(info[6]) + '/' + str(info[0]) + '/' + str(info[4]),
             'set_info': info
         }
-
 
     def _validate_assembly_set_data(self, data):
         # TODO: add checks that only one copy of each assembly data is in the set
@@ -47,8 +39,6 @@ class AssemblySetInterfaceV1:
         if 'description' not in data:
             data['description'] = ''
 
-
-
     def get_assembly_set(self, ctx, params):
         self._check_get_assembly_set_params(params)
 
@@ -61,10 +51,16 @@ class AssemblySetInterfaceV1:
         if 'ref_path_to_set' in params:
             ref_path_to_set = params['ref_path_to_set']
 
+        include_set_item_ref_paths = False
+        if 'include_set_item_ref_paths' in params:
+            if params['include_set_item_ref_paths'] == 1:
+                include_set_item_ref_paths = True
+
         set_data = self.setInterface.get_set(
                 params['ref'],
                 include_item_info,
-                ref_path_to_set
+                ref_path_to_set,
+                include_set_item_ref_paths
             )
         set_data = self._normalize_assembly_set_data(set_data)
 
@@ -76,7 +72,6 @@ class AssemblySetInterfaceV1:
         if 'include_item_info' in params:
             if params['include_item_info'] not in [0,1]:
                 raise ValueError('"include_item_info" parameter field can only be set to 0 or 1')
-
 
     def _normalize_assembly_set_data(self, set_data):
         # make sure that optional/missing fields are filled in or are defined

--- a/lib/SetAPI/differentialexpressionmatrix/DifferentialExpressionMatrixSetInterfaceV1.py
+++ b/lib/SetAPI/differentialexpressionmatrix/DifferentialExpressionMatrixSetInterfaceV1.py
@@ -62,6 +62,11 @@ class DifferentialExpressionMatrixSetInterfaceV1:
             if params['include_item_info'] == 1:
                 include_item_info = True
 
+        include_set_item_ref_paths = False
+        if 'include_set_item_ref_paths' in params:
+            if params['include_set_item_ref_paths'] == 1:
+                include_set_item_ref_paths = True
+
         ref_path_to_set = []
         if 'ref_path_to_set' in params:
             ref_path_to_set = params['ref_path_to_set']
@@ -69,7 +74,8 @@ class DifferentialExpressionMatrixSetInterfaceV1:
         set_data = self.set_interface.get_set(
                 params['ref'],
                 include_item_info,
-                ref_path_to_set
+                ref_path_to_set,
+                include_set_item_ref_paths
             )
         return set_data
 

--- a/lib/SetAPI/expression/ExpressionSetInterfaceV1.py
+++ b/lib/SetAPI/expression/ExpressionSetInterfaceV1.py
@@ -54,7 +54,7 @@ class ExpressionSetInterfaceV1:
                              "the same genome reference.")
 
     def get_expression_set(self, ctx, params):
-        self._check_get_expression_set_params(params)
+        set_type, obj_spec = self._check_get_expression_set_params(params)
 
         include_item_info = False
         if 'include_item_info' in params:
@@ -70,13 +70,54 @@ class ExpressionSetInterfaceV1:
         if 'ref_path_to_set' in params:
             ref_path_to_set = params['ref_path_to_set']
 
-        set_data = self.set_interface.get_set(
-                params['ref'],
-                include_item_info,
-                ref_path_to_set,
-                include_set_item_ref_paths
-            )
-        return set_data
+        if "KBaseSets" in set_type:
+            # If it's a KBaseSets type, then we know the usual interface will work...
+            return self.set_interface.get_set(
+                    params['ref'],
+                    include_item_info,
+                    ref_path_to_set,
+                    include_set_item_ref_paths
+                )
+        else:
+            # ...otherwise, we need to fetch it directly from the workspace and tweak it into the
+            # expected return object
+
+            obj_data = self.workspace_client.get_objects2({"objects": [obj_spec]})["data"][0]
+
+            obj = obj_data["data"]
+            obj_info = obj_data["info"]
+
+            if "sample_expression_ids" in obj:
+                expression_ref_list = obj["sample_expression_ids"]
+            else:
+                alignments_to_expressions = obj.get('mapped_expression_ids')
+
+                refs = set()
+                for mapping in alignments_to_expressions:
+                    refs.update(mapping.values())
+                expression_ref_list = list(refs)
+
+            expression_items = [{"ref": i} for i in expression_ref_list]
+
+            item_infos = self.workspace_client.get_object_info3(
+                {"objects": expression_items, "includeMetadata": 1})["infos"]
+            for idx, ref in enumerate(expression_items):
+                expression_items[idx]["label"] = item_infos[idx][10].get("condition", None)
+                if include_item_info:
+                    expression_items[idx]["info"] = item_infos[idx]
+            """
+            If include_set_item_ref_paths is set, then add a field ref_path in alignment items
+            """
+            if include_set_item_ref_paths:
+                util.populate_item_object_ref_paths(expression_items, obj_spec)
+
+            return {
+                "data": {
+                    "items": expression_items,
+                    "description": ""
+                },
+                "info": obj_info
+            }
 
     def _check_get_expression_set_params(self, params):
         if 'ref' not in params or params['ref'] is None:
@@ -86,3 +127,8 @@ class ExpressionSetInterfaceV1:
         if 'include_item_info' in params:
             if params['include_item_info'] not in [0, 1]:
                 raise ValueError('"include_item_info" parameter field can only be set to 0 or 1')
+        obj_spec = util.build_ws_obj_selector(params.get('ref'),
+                                              params.get('ref_path_to_set', []))
+        info = self.workspace_client.get_object_info3({"objects": [obj_spec]})
+
+        return info["infos"][0][2], obj_spec

--- a/lib/SetAPI/expression/ExpressionSetInterfaceV1.py
+++ b/lib/SetAPI/expression/ExpressionSetInterfaceV1.py
@@ -2,8 +2,7 @@
 An interface for handling sets of Expression objects.
 """
 from SetAPI.generic.SetInterfaceV1 import SetInterfaceV1
-from SetAPI.util import check_reference
-
+from SetAPI import util
 
 class ExpressionSetInterfaceV1:
     def __init__(self, workspace_client):
@@ -62,6 +61,11 @@ class ExpressionSetInterfaceV1:
             if params['include_item_info'] == 1:
                 include_item_info = True
 
+        include_set_item_ref_paths = False
+        if 'include_set_item_ref_paths' in params:
+            if params['include_set_item_ref_paths'] == 1:
+                include_set_item_ref_paths = True
+
         ref_path_to_set = []
         if 'ref_path_to_set' in params:
             ref_path_to_set = params['ref_path_to_set']
@@ -69,14 +73,15 @@ class ExpressionSetInterfaceV1:
         set_data = self.set_interface.get_set(
                 params['ref'],
                 include_item_info,
-                ref_path_to_set
+                ref_path_to_set,
+                include_set_item_ref_paths
             )
         return set_data
 
     def _check_get_expression_set_params(self, params):
         if 'ref' not in params or params['ref'] is None:
             raise ValueError('"ref" parameter field specifiying the expression set is required')
-        elif not check_reference(params['ref']):
+        elif not util.check_reference(params['ref']):
             raise ValueError('"ref" parameter must be a valid workspace reference')
         if 'include_item_info' in params:
             if params['include_item_info'] not in [0, 1]:

--- a/lib/SetAPI/featureset/FeatureSetSetInterfaceV1.py
+++ b/lib/SetAPI/featureset/FeatureSetSetInterfaceV1.py
@@ -6,7 +6,6 @@ from SetAPI.util import (
     check_reference
 )
 
-
 class FeatureSetSetInterfaceV1:
     def __init__(self, workspace_client):
         self.ws = workspace_client
@@ -48,6 +47,11 @@ class FeatureSetSetInterfaceV1:
             if params['include_item_info'] == 1:
                 include_item_info = True
 
+        include_set_item_ref_paths = False
+        if 'include_set_item_ref_paths' in params:
+            if params['include_set_item_ref_paths'] == 1:
+                include_set_item_ref_paths = True
+
         ref_path_to_set = []
         if 'ref_path_to_set' in params:
             ref_path_to_set = params['ref_path_to_set']
@@ -55,7 +59,8 @@ class FeatureSetSetInterfaceV1:
         set_data = self.set_interface.get_set(
                 params['ref'],
                 include_item_info,
-                ref_path_to_set
+                ref_path_to_set,
+                include_set_item_ref_paths
             )
         set_data = self._normalize_feature_set_set_data(set_data)
 

--- a/lib/SetAPI/generic/GenericSetNavigator.py
+++ b/lib/SetAPI/generic/GenericSetNavigator.py
@@ -1,21 +1,16 @@
 # -*- coding: utf-8 -*-
 
 import time
-
-
-from Workspace.WorkspaceClient import Workspace
-
 from pprint import pprint
 
+from Workspace.WorkspaceClient import Workspace
 from SetAPI.generic.WorkspaceListObjectsIterator import WorkspaceListObjectsIterator
-
+from SetAPI import util
 
 class GenericSetNavigator:
 
-
     SET_TYPES = ['KBaseSets.ReadsSet']
     DEBUG = False
-
 
     def __init__(self, workspace_client, data_palette_cache=None, token=None):
         self.ws = workspace_client
@@ -44,7 +39,7 @@ class GenericSetNavigator:
         # the list of obj refs contained in each of those sets
         top_level_sets = self._get_top_level_sets(all_sets)
 
-        if 'include_set_item_info' in params and params['include_set_item_info']==1:
+        if 'include_set_item_info' in params and params['include_set_item_info'] == 1:
             top_level_sets = self._populate_set_item_info(top_level_sets)
 
         if self.DEBUG:
@@ -58,7 +53,6 @@ class GenericSetNavigator:
             ret['raw_data_palette_refs'] = raw_dp_refs
         return ret
 
-
     def _validate_list_params(self, params):
         if ('workspace' not in params) and ('workspaces' not in params):
             raise ValueError('One of "workspace" or "workspaces" field required to list sets')
@@ -66,7 +60,6 @@ class GenericSetNavigator:
         if 'include_set_item_info' in params and params['include_set_item_info'] is not None:
             if params['include_set_item_info'] not in [0,1]:
                 raise ValueError('"include_set_item_info" field must be set to 0 or 1')
-
 
     def _list_all_sets(self, workspaces, include_metadata):
         ws_info_list = []
@@ -116,7 +109,6 @@ class GenericSetNavigator:
 
         return [sets, raw_dp, raw_dp_refs]
 
-
     def _get_workspace_info(self, workspace):
         # typedef tuple<ws_id 0:id, ws_name 1:workspace, username 2:owner, timestamp 3:moddate,
         # int 4max_objid, permission 5user_permission, permission 6globalread,
@@ -127,8 +119,6 @@ class GenericSetNavigator:
         else:
             ws_identity['workspace'] = workspace
         return self.ws.get_workspace_info(ws_identity)
-
-
 
     def _get_top_level_sets(self, set_list):
         '''
@@ -157,9 +147,6 @@ class GenericSetNavigator:
 
         return top_level_sets
 
-
-
-
     def _populate_set_refs(self, set_list):
 
         objects = []
@@ -169,21 +156,20 @@ class GenericSetNavigator:
                 set_ref = s['dp_ref'] + ';' + set_ref
             objects.append({'ref': set_ref})
 
-        if len(objects)>0:
+        if len(objects) > 0:
             obj_data = self.ws.get_objects2({
-                    'objects':objects,
-                    'no_data':1
+                    'objects': objects,
+                    'no_data': 1
                 })['data']
 
             # if ws call worked, then len(obj_data)==len(set_list)
-            for k in range(0,len(obj_data)):
+            for k in range(0, len(obj_data)):
                 items = []
                 for item_ref in obj_data[k]['refs']:
-                    items.append({'ref':item_ref})
+                    items.append({'ref': item_ref})
                 set_list[k]['items'] = items
 
         return set_list
-
 
     def _populate_set_item_info(self, set_list):
 
@@ -206,12 +192,11 @@ class GenericSetNavigator:
                     'ref': item_refs[ref] + ';' + ref
                 })
 
-        if len(objects)>0:
+        if len(objects) > 0:
             obj_info_list = self.ws.get_object_info_new({
-                                        'objects':objects,
-                                        'includeMetadata':1
+                                        'objects': objects,
+                                        'includeMetadata': 1
                                     })
-
             # build info lookup
             item_info = {}
             for o in obj_info_list:
@@ -224,14 +209,10 @@ class GenericSetNavigator:
 
         return set_list
 
-
-
     def _build_obj_ref(self, obj_info):
         return str(obj_info[6]) + '/' + str(obj_info[0]) + '/' + str(obj_info[4])
 
 
-
-    
     # typedef structure {
     #     ws_obj_id ref;
     #     list <ws_obj_id> path_to_set;
@@ -246,7 +227,6 @@ class GenericSetNavigator:
     # } GetSetItemsResult;
 
 
-
     def get_set_items(self, params):
         '''
         Given a list of reference to set objects, get the list of items for each set
@@ -259,8 +239,7 @@ class GenericSetNavigator:
         set_list = self._populate_set_refs(set_list)
         set_list = self._populate_set_item_info(set_list)
 
-        return { 'sets': set_list }
-
+        return {'sets': set_list}
 
     def _validate_get_set_items_params(self, params):
         if 'set_refs' not in params:
@@ -269,26 +248,16 @@ class GenericSetNavigator:
             if 'ref' not in s:
                 raise ValueError('"ref" field in each object of "set_refs" list is required')
 
-
-
     def _get_set_info(self, set_refs):
 
         objects = []
         for s in set_refs:
-            if 'path_to_set' in s and s['path_to_set'] is not None and len(s['path_to_set'])>0:
-                obj_ref_path = s['path_to_set'][1:]
-                obj_ref_path.append(s['ref'])
-                objects.append({
-                        'ref': s['path_to_set'][0],
-                        'obj_ref_path': obj_ref_path
-                    })
-            else:
-                objects.append({'ref':s['ref']})
+            objects.append(util.build_ws_obj_selector(s['ref'], s.get('path_to_set', [])))
 
-        if len(objects)>0:
+        if len(objects) > 0:
             obj_info_list = self.ws.get_object_info_new({
-                                        'objects':objects,
-                                        'includeMetadata':1
+                                        'objects': objects,
+                                        'includeMetadata': 1
                                     })
             set_list = []
             for o in obj_info_list:
@@ -297,7 +266,6 @@ class GenericSetNavigator:
                         'info': o
                     })
         return set_list
-
 
     def _list_from_data_palette(self, workspaces, type_list, include_metadata):
         if not self.dpc:
@@ -312,7 +280,6 @@ class GenericSetNavigator:
             if obj_type in type_map:
                 dp_info_list.append({'info': info, 'dp_ref': item['dp_ref']})
         return [dp_info_list, dp_ret['data'], dp_ret['data_palette_refs']]
-
 
     # def _populate_set_item_info(self, set_list):
 

--- a/lib/SetAPI/generic/GenericSetNavigator.py
+++ b/lib/SetAPI/generic/GenericSetNavigator.py
@@ -42,6 +42,9 @@ class GenericSetNavigator:
         if 'include_set_item_info' in params and params['include_set_item_info'] == 1:
             top_level_sets = self._populate_set_item_info(top_level_sets)
 
+        if 'include_set_item_ref_paths' in params and params['include_set_item_ref_paths'] == 1:
+            top_level_sets = self._populate_set_item_ref_path(top_level_sets)
+
         if self.DEBUG:
             print("Time of populate_sets: " + str(time.time() - t2))
             print("Total time of list_sets: " + str(time.time() - t1))
@@ -209,6 +212,15 @@ class GenericSetNavigator:
 
         return set_list
 
+    def _populate_set_item_ref_path(self, set_list):
+
+        for s in set_list:
+            obj_spec = util.build_ws_obj_selector(s['ref'],
+                                                  s.get('ref_path_to_set', []))
+            util.populate_item_object_ref_paths(s['items'], obj_spec)
+
+        return set_list
+
     def _build_obj_ref(self, obj_info):
         return str(obj_info[6]) + '/' + str(obj_info[0]) + '/' + str(obj_info[4])
 
@@ -238,6 +250,9 @@ class GenericSetNavigator:
 
         set_list = self._populate_set_refs(set_list)
         set_list = self._populate_set_item_info(set_list)
+
+        if 'include_set_item_ref_paths' in params and params['include_set_item_ref_paths'] == 1:
+            set_list = self._populate_set_item_ref_path(set_list)
 
         return {'sets': set_list}
 

--- a/lib/SetAPI/generic/SetInterfaceV1.py
+++ b/lib/SetAPI/generic/SetInterfaceV1.py
@@ -1,15 +1,9 @@
-
-
-
-from biokbase.workspace.client import Workspace
-
 from pprint import pprint
 
-
-
+from biokbase.workspace.client import Workspace
+from SetAPI import util
 
 class SetInterfaceV1:
-
 
     def __init__(self, workspace_client):
         self.ws = workspace_client;
@@ -23,7 +17,6 @@ class SetInterfaceV1:
         results = self.ws.save_objects(save_params)
         return results
 
-
     def _check_save_set_params(self, params):
         if 'data' not in params:
             raise ValueError('"data" parameter field specifiying the set is required')
@@ -31,7 +24,6 @@ class SetInterfaceV1:
             raise ValueError('"workspace" or "workspace_id" or "workspace_name" parameter field is required')
         if 'output_object_name' not in params:
             raise ValueError('"output_object_name" parameter field is required')
-
 
     def _build_ws_save_obj_params(self, set_type, provenance, params):
 
@@ -44,7 +36,6 @@ class SetInterfaceV1:
                 'hidden': 0
             }]
         }
-
         if 'workspace' in params:
             if str(params['workspace']).isdigit():
                 save_params['id'] = int(params['workspace'])
@@ -57,69 +48,56 @@ class SetInterfaceV1:
 
         return save_params
 
-
-
-    def get_set(self, ref, include_item_info=False, ref_path_to_set=[]):
+    def get_set(self, ref, include_item_info=False, ref_path_to_set=[], include_set_item_ref_paths=False):
         '''
         Get a set object from the Workspace using the set_type provided (e.g. set_type=KBaseSets.ReadsSet)
         '''
-        ws_data = self._get_set_from_ws(ref, ref_path_to_set)
+        obj_selector = util.build_ws_obj_selector(ref, ref_path_to_set)
+        ws_data = self._get_set_from_ws(obj_selector)
 
         if include_item_info:
             self._populate_item_object_info(ws_data, ref_path_to_set)
 
+        if include_set_item_ref_paths:
+            set_items = ws_data['data']['items']
+            util.populate_item_object_ref_paths(set_items, obj_selector)
+
         return ws_data
-    
 
-
-    def _get_set_from_ws(self, ref, ref_path_to_set):
+    def _get_set_from_ws(self, selector):
 
         # typedef structure {
         #     list<ObjectSpecification> objects;
         #     boolean ignoreErrors;
         #     boolean no_data;
         # } GetObjects2Params;
-        selector = self._build_ws_obj_selector(ref, ref_path_to_set)
-        ws_data = self.ws.get_objects2({'objects': [selector] })
+
+        ws_data = self.ws.get_objects2({'objects': [selector]})
 
         data = ws_data['data'][0]['data']
         info = ws_data['data'][0]['info']
 
-        return { 'data': data, 'info': info }
-
-
+        return {'data': data, 'info': info}
 
     def _populate_item_object_info(self, set, ref_path_to_set):
 
-        info = set['info']
         items = set['data']['items']
-        set_ref = str(info[6]) + '/' + str(info[0]) + '/' + str(info[4])
-        ref_path_to_item = ref_path_to_set + [set_ref]
 
         objects = []
         for item in items:
+            ref_path_to_item = ref_path_to_set + [item['ref']]
             objects.append(
-                self._build_ws_obj_selector(item['ref'], ref_path_to_item))
+                util.build_ws_obj_selector(item['ref'], ref_path_to_item))
 
-        if len(objects)>0:
+        if len(objects) > 0:
             obj_info_list = self.ws.get_object_info_new({
                                         'objects': objects,
-                                        'includeMetadata': 1 })
+                                        'includeMetadata': 1})
 
             for k in range(0, len(obj_info_list)):
                 items[k]['info'] = obj_info_list[k]
 
 
-    def _build_ws_obj_selector(self, ref, ref_path_to_set):
-        if ref_path_to_set and len(ref_path_to_set)>0:
-            obj_ref_path = []
-            for r in ref_path_to_set[1:]:
-                obj_ref_path.append(r)
-            obj_ref_path.append(ref)
-            return {
-                'ref': ref_path_to_set[0],
-                'obj_ref_path':obj_ref_path
-            }
-        return { 'ref': ref } 
+
 
 

--- a/lib/SetAPI/genome/GenomeSetInterfaceV1.py
+++ b/lib/SetAPI/genome/GenomeSetInterfaceV1.py
@@ -57,6 +57,11 @@ class GenomeSetInterfaceV1:
             if params['include_item_info'] == 1:
                 include_item_info = True
 
+        include_set_item_ref_paths = False
+        if 'include_set_item_ref_paths' in params:
+            if params['include_set_item_ref_paths'] == 1:
+                include_set_item_ref_paths = True
+
         ref_path_to_set = []
         if 'ref_path_to_set' in params:
             ref_path_to_set = params['ref_path_to_set']
@@ -64,7 +69,8 @@ class GenomeSetInterfaceV1:
         set_data = self.setInterface.get_set(
                 params['ref'],
                 include_item_info,
-                ref_path_to_set
+                ref_path_to_set,
+                include_set_item_ref_paths
             )
         set_data = self._normalize_genome_set_data(set_data)
 

--- a/lib/SetAPI/util.py
+++ b/lib/SetAPI/util.py
@@ -3,7 +3,6 @@ This module contains some utility functions for the SetAPI.
 """
 import re
 
-
 def check_reference(ref):
     """
     Returns True if ref looks like an actual object reference: xx/yy/zz or xx/yy
@@ -14,3 +13,19 @@ def check_reference(ref):
     if ref is None or not obj_ref_regex.match(ref):
         return False
     return True
+
+def build_ws_obj_selector(ref, ref_path_to_set):
+    if ref_path_to_set and len(ref_path_to_set) > 0:
+        return {
+            'ref': ';'.join(ref_path_to_set)
+        }
+    return {'ref': ref}
+
+def populate_item_object_ref_paths(set_items, obj_selector):
+    """
+    Called when include_set_item_ref_paths is set.
+    Add a field ref_path to each item in set
+    """
+    for set_item in set_items:
+        set_item["ref_path"] = obj_selector['ref'] + ';' + set_item['ref']
+    return set_items

--- a/test/AssemblySet_basic_test.py
+++ b/test/AssemblySet_basic_test.py
@@ -153,6 +153,7 @@ class SetAPITest(unittest.TestCase):
 
         item2 = d1['data']['items'][1]
         self.assertTrue('info' not in item2)
+        self.assertTrue('ref_path' not in item2)
         self.assertTrue('ref' in item2)
         self.assertTrue('label' in item2)
         self.assertEqual(item2['label'],'assembly2')
@@ -161,7 +162,8 @@ class SetAPITest(unittest.TestCase):
         # test the call to make sure we get info for each item
         d2 = setAPI.get_reads_set_v1(self.getContext(), {
                 'ref':res['set_ref'],
-                'include_item_info':1
+                'include_item_info':1,
+                'include_set_item_ref_paths': 1
             })[0]
         self.assertTrue('data' in d2)
         self.assertTrue('info' in d2)
@@ -176,10 +178,13 @@ class SetAPITest(unittest.TestCase):
         self.assertTrue('info' in item2)
         self.assertTrue(len(item2['info']), 11)
         self.assertTrue('ref' in item2)
-        self.assertEqual(item2['ref'],self.assembly2ref)
+        self.assertEqual(item2['ref'], self.assembly2ref)
 
+        self.assertTrue('ref_path' in item2)
+        self.assertEqual(item2['ref_path'], res['set_ref'] + ';' + item2['ref'])
+        pprint(d2)
 
-        # NOTE: According to Python unittest naming rules test method names should start from 'test'.
+    # NOTE: According to Python unittest naming rules test method names should start from 'test'.
     def skip_test_save_and_get_of_emtpy_set(self):
 
         workspace = self.getWsName()

--- a/test/DifferentialExpressionMatrixSet_basic_test.py
+++ b/test/DifferentialExpressionMatrixSet_basic_test.py
@@ -2,6 +2,7 @@
 import unittest
 import os
 import time
+from pprint import pprint
 
 from os import environ
 try:
@@ -211,7 +212,7 @@ class DifferentialExpressionMatrixSetAPITest(unittest.TestCase):
                 "ref": ref
             })
         dem_set = {
-            "description": "test_alignments",
+            "description": "test_test_diffExprMatrixSet",
             "items": set_items
         }
         dem_set_ref = self.getImpl().save_differential_expression_matrix_set_v1(self.getContext(), {
@@ -232,6 +233,7 @@ class DifferentialExpressionMatrixSetAPITest(unittest.TestCase):
         for item in fetched_set["data"]["items"]:
             self.assertNotIn("info", item)
             self.assertIn("ref", item)
+            self.assertNotIn("ref_path", item)
             self.assertIn("label", item)
 
         fetched_set_with_info = self.getImpl().get_differential_expression_matrix_set_v1(
@@ -247,6 +249,42 @@ class DifferentialExpressionMatrixSetAPITest(unittest.TestCase):
             self.assertIn("info", item)
             self.assertIn("ref", item)
             self.assertIn("label", item)
+
+    def test_get_dem_set_ref_path(self):
+        set_name = "test_diff_expression_set_ref_path"
+        set_items = list()
+        for ref in self.diff_exps_no_genome:
+            set_items.append({
+                "label": "wt",
+                "ref": ref
+            })
+        dem_set = {
+            "description": "test_diffExprMatrixSet_ref_path",
+            "items": set_items
+        }
+        dem_set_ref = self.getImpl().save_differential_expression_matrix_set_v1(self.getContext(), {
+            "workspace": self.getWsName(),
+            "output_object_name": set_name,
+            "data": dem_set
+        })[0]["set_ref"]
+
+        fetched_set_with_ref_path = self.getImpl().get_differential_expression_matrix_set_v1(self.getContext(), {
+            "ref": dem_set_ref,
+            "include_item_info": 0,
+            "include_set_item_ref_paths": 1
+        })[0]
+        self.assertIsNotNone(fetched_set_with_ref_path)
+        self.assertIn("data", fetched_set_with_ref_path)
+        self.assertIn("info", fetched_set_with_ref_path)
+        self.assertEquals(len(fetched_set_with_ref_path["data"]["items"]), 3)
+        self.assertEquals(dem_set_ref, info_to_ref(fetched_set_with_ref_path["info"]))
+        for item in fetched_set_with_ref_path["data"]["items"]:
+            self.assertNotIn("info", item)
+            self.assertIn("ref", item)
+            self.assertIn("label", item)
+            self.assertIn("ref_path", item)
+            self.assertEqual(item["ref_path"], dem_set_ref + ';' + item["ref"])
+        #pprint(fetched_set_with_ref_path)
 
     def test_get_dem_set_bad_ref(self):
         with self.assertRaises(ValueError) as err:

--- a/test/ExpressionSet_basic_test.py
+++ b/test/ExpressionSet_basic_test.py
@@ -28,6 +28,9 @@ from util import (
 import shutil
 
 class ExpressionSetAPITest(unittest.TestCase):
+
+    DEBUG =False
+
     @classmethod
     def setUpClass(cls):
         token = environ.get('KB_AUTH_TOKEN', None)
@@ -321,41 +324,6 @@ class ExpressionSetAPITest(unittest.TestCase):
             self.assertIn("ref_path", item)
             self.assertEquals(item["ref_path"], expression_set_ref + ";" + item["ref"])
 
-    # NOTE: Comment the following line to run the test
-    @unittest.skip("skipped test_get_expression_set_ref_path")
-    def test_get_narrative_expression_set_ref_path(self):
-
-        appdev_kbasesets_expression_set_ref = '5264/38/2'
-
-        fetched_set_with_ref_path = self.getImpl().get_expression_set_v1(self.getContext(), {
-            "ref": appdev_kbasesets_expression_set_ref,
-            "include_item_info": 0,
-            "include_set_item_ref_paths": 1
-        })[0]
-
-        for item in fetched_set_with_ref_path["data"]["items"]:
-            self.assertIn("ref", item)
-            self.assertIn("label", item)
-            self.assertIn("ref_path", item)
-            self.assertEquals(item["ref_path"],
-                              appdev_kbasesets_expression_set_ref + ";" + item["ref"])
-
-        print("INPUT: Appdev KBasesets.ExpressionSet: " + appdev_kbasesets_expression_set_ref)
-        pprint(fetched_set_with_ref_path)
-        print("==========================")
-
-        appdev_rnaseq_expression_set_ref = '4389/45/1'
-
-        fetched_set_with_ref_path = self.getImpl().get_expression_set_v1(self.getContext(), {
-            "ref": appdev_rnaseq_expression_set_ref,
-            "include_item_info": 0,
-            "include_set_item_ref_paths": 1
-        })[0]
-
-        print("=============  FETCHED SET RNASEQ  ===============")
-        pprint(fetched_set_with_ref_path)
-        print("============  END FETCHED SET RNASEQ  ============")
-
     def test_get_created_rnaseq_expression_set_ref_path(self):
 
         created_expression_set_ref = self.fake_rnaseq_expression_set
@@ -372,10 +340,10 @@ class ExpressionSetAPITest(unittest.TestCase):
             self.assertIn("ref_path", item)
             self.assertEquals(item["ref_path"],
                               created_expression_set_ref + ";" + item["ref"])
-
-        print("INPUT: CREATED KBasesets.ExpressionSet: " + created_expression_set_ref)
-        pprint(fetched_set_with_ref_path)
-        print("==========================")
+        if self.DEBUG:
+            print("INPUT: CREATED KBasesets.ExpressionSet: " + created_expression_set_ref)
+            pprint(fetched_set_with_ref_path)
+            print("==========================")
 
     def test_get_expression_set_bad_ref(self):
         with self.assertRaises(ValueError) as err:

--- a/test/FeatureSetSet_test.py
+++ b/test/FeatureSetSet_test.py
@@ -171,12 +171,14 @@ class FeatureSetSetAPITest(unittest.TestCase):
         self.assertEquals(featureset_set_ref, info_to_ref(fetched_set["info"]))
         for item in fetched_set["data"]["items"]:
             self.assertNotIn("info", item)
+            self.assertNotIn("ref_path", item)
             self.assertIn("ref", item)
             self.assertIn("label", item)
 
         fetched_set_with_info = self.getImpl().get_feature_set_set_v1(self.getContext(), {
             "ref": featureset_set_ref,
-            "include_item_info": 1
+            "include_item_info": 1,
+            "include_set_item_ref_paths": 1
         })[0]
         self.assertIsNotNone(fetched_set_with_info)
         self.assertIn("data", fetched_set_with_info)
@@ -184,6 +186,8 @@ class FeatureSetSetAPITest(unittest.TestCase):
             self.assertIn("info", item)
             self.assertIn("ref", item)
             self.assertIn("label", item)
+            self.assertIn("ref_path", item)
+            self.assertEquals(item["ref_path"], featureset_set_ref + ";" + item["ref"])
 
     def test_get_feature_set_set_bad_ref(self):
         with self.assertRaises(ValueError) as err:

--- a/test/GenomeSet_basic_test.py
+++ b/test/GenomeSet_basic_test.py
@@ -149,7 +149,8 @@ class SetAPITest(unittest.TestCase):
         # test the call to make sure we get info for each item
         d2 = setAPI.get_reads_set_v1(self.getContext(), {
                 'ref':res['set_ref'],
-                'include_item_info':1
+                'include_item_info':1,
+                'include_set_item_ref_paths': 1
             })[0]
         self.assertTrue('data' in d2)
         self.assertTrue('info' in d2)
@@ -166,9 +167,13 @@ class SetAPITest(unittest.TestCase):
         self.assertTrue('ref' in item2)
         self.assertEqual(item2['ref'],self.genome2ref)
 
+        self.assertTrue('ref_path' in item2)
+        self.assertEqual(item2['ref_path'], res['set_ref'] + ';' + item2['ref'])
+        pprint(d2)
 
-        # NOTE: According to Python unittest naming rules test method names should start from 'test'.
-    def skip_test_save_and_get_of_emtpy_set(self):
+    # NOTE: Comment the following line to run the test
+    @unittest.skip("skipped test_save_and_get_of_emtpy_set")
+    def test_save_and_get_of_emtpy_set(self):
 
         workspace = self.getWsName()
         setObjName = 'nada_set'
@@ -193,7 +198,6 @@ class SetAPITest(unittest.TestCase):
         self.assertEqual(res['set_info'][1], setObjName)
         self.assertTrue('item_count' in res['set_info'][10])
         self.assertEqual(res['set_info'][10]['item_count'], '0')
-
 
         # test get of that object
         d1 = setAPI.get_genome_set_v1(self.getContext(), {

--- a/test/ReadsAlignmentSet_basic_test.py
+++ b/test/ReadsAlignmentSet_basic_test.py
@@ -20,12 +20,16 @@ from util import (
     info_to_ref,
     make_fake_alignment,
     make_fake_sampleset,
-    make_fake_old_alignment_set
+    make_fake_annotation,
+    make_fake_expression,
+    make_fake_old_alignment_set,
+    make_fake_old_expression_set
 )
 import shutil
 
 
 class ReadsAlignmentSetAPITest(unittest.TestCase):
+    DEBUG = False
 
     @classmethod
     def setUpClass(cls):
@@ -121,6 +125,41 @@ class ReadsAlignmentSetAPITest(unittest.TestCase):
             cls.wsClient,
             include_sample_alignments=True
         )
+
+        # Need a fake annotation to get the expression objects
+        cls.annotation_ref = make_fake_annotation(
+            os.environ['SDK_CALLBACK_URL'],
+            cls.dummy_path,
+            "fake_annotation",
+            wsName,
+            cls.wsClient)
+
+        # Now we can phony up some expression objects to build sets out of.
+        # name, genome_ref, annotation_ref, alignment_ref, ws_name, ws_client
+        cls.expression_refs = list()
+        for idx, alignment_ref in enumerate(cls.alignment_refs):
+            cls.expression_refs.append(make_fake_expression(
+                os.environ['SDK_CALLBACK_URL'],
+                cls.dummy_path,
+                "fake_expression_{}".format(idx),
+                cls.genome_refs[0],
+                cls.annotation_ref,
+                alignment_ref,
+                wsName,
+                cls.wsClient
+            ))
+
+        # Make a fake RNASeq Expression Set object
+        cls.fake_rnaseq_expression_set = make_fake_old_expression_set(
+            "fake_rnaseq_expression_set",
+            cls.genome_refs[0],
+            cls.sampleset_ref,
+            cls.alignment_refs,
+            cls.fake_rnaseq_alignment_set1,
+            cls.expression_refs,
+            wsName,
+            cls.wsClient,
+            True)
 
     @classmethod
     def tearDownClass(cls):
@@ -231,7 +270,8 @@ class ReadsAlignmentSetAPITest(unittest.TestCase):
 
             fetched_set_with_info = self.getImpl().get_reads_alignment_set_v1(self.getContext(), {
                 "ref": ref,
-                "include_item_info": 1
+                "include_item_info": 1,
+                "include_set_item_ref_paths": 1
             })[0]
             self.assertIsNotNone(fetched_set_with_info)
             self.assertIn("data", fetched_set_with_info)
@@ -239,6 +279,35 @@ class ReadsAlignmentSetAPITest(unittest.TestCase):
                 self.assertIn("info", item)
                 self.assertIn("ref", item)
                 self.assertIn("label", item)
+                self.assertIn("ref_path", item)
+                self.assertEquals(item["ref_path"], ref + ";" + item["ref"])
+
+    def test_get_old_alignment_set_ref_path_to_set(self):
+        alignment_ref = self.fake_rnaseq_alignment_set1
+        ref_path_to_set = [self.fake_rnaseq_expression_set, alignment_ref]
+
+        fetched_set = self.getImpl().get_reads_alignment_set_v1(self.getContext(), {
+            "ref": alignment_ref,
+            "ref_path_to_set": ref_path_to_set,
+            "include_item_info": 0,
+            "include_set_item_ref_paths": 1
+        })[0]
+        self.assertIsNotNone(fetched_set)
+        self.assertIn("data", fetched_set)
+        self.assertIn("info", fetched_set)
+        self.assertEquals(len(fetched_set["data"]["items"]), 3)
+        self.assertEquals(alignment_ref, info_to_ref(fetched_set["info"]))
+        for item in fetched_set["data"]["items"]:
+            self.assertNotIn("info", item)
+            self.assertIn("ref", item)
+            self.assertIn("label", item)
+            self.assertIn("ref_path", item)
+            self.assertEquals(item["ref_path"], ";".join(ref_path_to_set) + ";" + item["ref"])
+
+        if self.DEBUG:
+            print('======  RNASeq Alignment with ref_path_to_set ========')
+            pprint(fetched_set)
+            print('======================================================')
 
     def test_get_alignment_set(self):
         alignment_set_name = "test_alignment_set"
@@ -283,7 +352,7 @@ class ReadsAlignmentSetAPITest(unittest.TestCase):
             self.assertIn("ref", item)
             self.assertIn("label", item)
 
-    def test_get_alignment_set_ref_path_to_set(self):
+    def test_get_alignment_set_ref_path(self):
         alignment_set_name = "test_alignment_set_ref_path"
         alignment_items = list()
         for ref in self.alignment_refs:
@@ -317,57 +386,6 @@ class ReadsAlignmentSetAPITest(unittest.TestCase):
             self.assertIn("label", item)
             self.assertIn("ref_path", item)
             self.assertEquals(item["ref_path"], alignment_set_ref + ";" + item["ref"])
-
-    # Following test uses object refs from a narrative. Comment the next line to run the test
-    @unittest.skip("skipped test_get_rnaseq_alignment_set_ref_path")
-    def test_get_rnaseq_alignment_set_ref_path(self):
-        """
-        appdev RNASeqAlignmentSet ref
-        """
-        alignment_set_ref = '4389/40/1'
-        ref_path_to_set = ['4389/45/1', '4389/40/1']
-        fetched_set_with_ref_path = self.getImpl().get_reads_alignment_set_v1(self.getContext(), {
-            "ref": alignment_set_ref,
-            "include_item_info": 0,
-            "ref_path_to_set": ref_path_to_set,
-            "include_set_item_ref_paths": 1
-        })[0]
-
-        for item in fetched_set_with_ref_path["data"]["items"]:
-            self.assertNotIn("info", item)
-            self.assertIn("ref", item)
-            self.assertIn("label", item)
-            self.assertIn("ref_path", item)
-            self.assertEquals(item["ref_path"], ";".join(ref_path_to_set) + ";" + item["ref"])
-
-        print("INPUT: Appdev RNASeqAlignmentSet: " + alignment_set_ref)
-        pprint(fetched_set_with_ref_path)
-        print("==========================")
-
-    # Following test uses object refs from a narrative. Comment the next line to run the test
-    @unittest.skip("skipped test_get_kbasesets_alignment_set_ref_path")
-    def test_get_kbasesets_alignment_set_ref_path(self):
-        """
-        appdev KBasesets.AlignmentSet ref
-        """
-        alignment_set_ref = '5264/36/10'
-        fetched_set_with_ref_path = self.getImpl().get_reads_alignment_set_v1(self.getContext(), {
-            "ref": alignment_set_ref,
-            "include_item_info": 0,
-            "ref_path_to_set": [],
-            "include_set_item_ref_paths": 1
-        })[0]
-
-        for item in fetched_set_with_ref_path["data"]["items"]:
-            self.assertNotIn("info", item)
-            self.assertIn("ref", item)
-            self.assertIn("label", item)
-            self.assertIn("ref_path", item)
-            self.assertEquals(item["ref_path"], alignment_set_ref + ";" + item["ref"])
-
-        print("INPUT: Appdev KBasesets.AlignmentSet: " + alignment_set_ref)
-        pprint(fetched_set_with_ref_path)
-        print("==========================")
 
     def test_get_alignment_set_bad_ref(self):
         with self.assertRaises(ValueError) as err:

--- a/test/ReadsSet_basic_test.py
+++ b/test/ReadsSet_basic_test.py
@@ -165,11 +165,11 @@ class SetAPITest(unittest.TestCase):
         self.assertEqual(item3['label'],'')
         self.assertEqual(item3['ref'],self.read3ref)
 
-
         # test the call to make sure we get info for each item
         d2 = setAPI.get_reads_set_v1(self.getContext(), {
                 'ref':res['set_ref'],
-                'include_item_info':1
+                'include_item_info':1,
+                'include_set_item_ref_paths': 1
             })[0]
         self.assertTrue('data' in d2)
         self.assertTrue('info' in d2)
@@ -186,9 +186,13 @@ class SetAPITest(unittest.TestCase):
         self.assertTrue('ref' in item2)
         self.assertEqual(item2['ref'],self.read2ref)
 
+        self.assertTrue('ref_path' in item2)
+        self.assertEqual(item2['ref_path'], res['set_ref'] + ';' + item2['ref'])
+        pprint(d2)
 
-        # NOTE: According to Python unittest naming rules test method names should start from 'test'.
-    def skip_test_save_and_get_of_empty_set(self):
+    # NOTE: Comment the following line to run the test
+    @unittest.skip("skipped test_save_and_get_of_emtpy_set")
+    def test_save_and_get_of_empty_set(self):
 
         workspace = self.getWsName()
         setObjName = 'nada_set'

--- a/test/generic_set_access_test.py
+++ b/test/generic_set_access_test.py
@@ -23,7 +23,6 @@ from DataPaletteService.DataPaletteServiceClient import DataPaletteService
 from FakeObjectsForTests.FakeObjectsForTestsClient import FakeObjectsForTests
 from SetAPI.authclient import KBaseAuth as _KBaseAuth
 
-
 class SetAPITest(unittest.TestCase):
 
     @classmethod
@@ -95,7 +94,6 @@ class SetAPITest(unittest.TestCase):
     def getContext(self):
         return self.__class__.ctx
 
-
     def create_sets(self):
         if hasattr(self.__class__, 'setNames'):
             return
@@ -118,7 +116,6 @@ class SetAPITest(unittest.TestCase):
                     }
                 ]
             }
-
             # test a save
             res = setAPI.save_reads_set_v1(self.getContext(), {
                     'data':set_data,
@@ -126,7 +123,6 @@ class SetAPITest(unittest.TestCase):
                     'workspace': workspace
                 })[0]
             self.setRefs.append(res['set_ref'])
-
 
     # NOTE: According to Python unittest naming rules test method names should start from 'test'.
     def test_list_sets(self):
@@ -139,7 +135,6 @@ class SetAPITest(unittest.TestCase):
                 'workspace':workspace,
                 'include_set_item_info':1
             })[0]
-
 
         # create the test sets
         self.create_sets()
@@ -159,7 +154,7 @@ class SetAPITest(unittest.TestCase):
             for item in s['items']:
                 self.assertTrue('ref' in item)
                 self.assertTrue('info' in item)
-                self.assertEqual(len(item['info']),11)
+                self.assertEqual(len(item['info']), 11)
 
         res2 = setAPI.list_sets(self.getContext(), {
                 'workspace':workspace
@@ -176,7 +171,6 @@ class SetAPITest(unittest.TestCase):
                 self.assertTrue('ref' in item)
                 self.assertTrue('info' not in item)
 
-
         res = setAPI.get_set_items(self.getContext(), {
                 'set_refs': [{'ref':self.setRefs[0]}]
             })[0]
@@ -190,7 +184,7 @@ class SetAPITest(unittest.TestCase):
             for item in s['items']:
                 self.assertTrue('ref' in item)
                 self.assertTrue('info' in item)
-                self.assertEqual(len(item['info']),11)
+                self.assertEqual(len(item['info']), 11)
 
         set_obj_name = self.setNames[0]
         wsName2 = "test_SetAPI_" + str(int(time.time() * 1000)) + "_two"
@@ -231,7 +225,6 @@ class SetAPITest(unittest.TestCase):
                     self.assertIsNotNone(item['info'][10])
         finally:
             self.getWsClient().delete_workspace({'workspace': wsName2})
-
 
     def test_bulk_list_sets(self):
         try:

--- a/test/generic_set_access_test.py
+++ b/test/generic_set_access_test.py
@@ -55,7 +55,6 @@ class SetAPITest(unittest.TestCase):
         cls.serviceWizardURL = cls.cfg['service-wizard']
         cls.dataPaletteServiceVersion = cls.cfg['datapaletteservice-version']
 
-
         # setup data at the class level for now (so that the code is run
         # once for all tests, not before each test case.  Not sure how to
         # do that outside this function..)
@@ -106,7 +105,7 @@ class SetAPITest(unittest.TestCase):
         for s in self.setNames:
 
             set_data = {
-                'description':'my first reads',
+                'description': 'my first reads',
                 'items': [ {
                         'ref': self.read1ref,
                         'label':'reads1'
@@ -118,8 +117,8 @@ class SetAPITest(unittest.TestCase):
             }
             # test a save
             res = setAPI.save_reads_set_v1(self.getContext(), {
-                    'data':set_data,
-                    'output_object_name':s,
+                    'data': set_data,
+                    'output_object_name': s,
                     'workspace': workspace
                 })[0]
             self.setRefs.append(res['set_ref'])
@@ -132,16 +131,17 @@ class SetAPITest(unittest.TestCase):
 
         # make sure we can see an empty list of sets before WS has any
         res = setAPI.list_sets(self.getContext(), {
-                'workspace':workspace,
-                'include_set_item_info':1
+                'workspace': workspace,
+                'include_set_item_info': 1
             })[0]
+        self.assertEqual(len(res['sets']), 0)
 
         # create the test sets
         self.create_sets()
 
         res = setAPI.list_sets(self.getContext(), {
-                'workspace':workspace,
-                'include_set_item_info':1
+                'workspace': workspace,
+                'include_set_item_info': 1
             })[0]
         self.assertTrue('sets' in res)
         self.assertEqual(len(res['sets']), len(self.setNames))
@@ -149,8 +149,8 @@ class SetAPITest(unittest.TestCase):
             self.assertTrue('ref' in s)
             self.assertTrue('info' in s)
             self.assertTrue('items' in s)
-            self.assertEqual(len(s['info']),11)
-            self.assertEqual(len(s['items']),2)
+            self.assertEqual(len(s['info']), 11)
+            self.assertEqual(len(s['items']), 2)
             for item in s['items']:
                 self.assertTrue('ref' in item)
                 self.assertTrue('info' in item)
@@ -165,26 +165,36 @@ class SetAPITest(unittest.TestCase):
             self.assertTrue('ref' in s)
             self.assertTrue('info' in s)
             self.assertTrue('items' in s)
-            self.assertEqual(len(s['info']),11)
-            self.assertEqual(len(s['items']),2)
+            self.assertEqual(len(s['info']), 11)
+            self.assertEqual(len(s['items']), 2)
             for item in s['items']:
                 self.assertTrue('ref' in item)
                 self.assertTrue('info' not in item)
 
-        res = setAPI.get_set_items(self.getContext(), {
-                'set_refs': [{'ref':self.setRefs[0]}]
-            })[0]
-        self.assertEqual(len(res['sets']), 1)
-        for s in res['sets']:
+        res3 = setAPI.list_sets(self.getContext(), {
+                    'workspace': workspace,
+                    'include_set_item_ref_paths': 1
+                })[0]
+        '''
+        print('Result from list_items with ref_paths')
+        pprint(res3)
+        print('=====================================')
+        '''
+        self.assertTrue('sets' in res3)
+        self.assertEqual(len(res3['sets']), len(self.setNames))
+        for s in res3['sets']:
             self.assertTrue('ref' in s)
             self.assertTrue('info' in s)
             self.assertTrue('items' in s)
-            self.assertEqual(len(s['info']),11)
-            self.assertEqual(len(s['items']),2)
+            self.assertEqual(len(s['info']), 11)
+            self.assertEqual(len(s['items']), 2)
             for item in s['items']:
                 self.assertTrue('ref' in item)
-                self.assertTrue('info' in item)
-                self.assertEqual(len(item['info']), 11)
+                self.assertTrue('info' not in item)
+                self.assertTrue('ref_path' in item)
+                self.assertEquals(item['ref_path'], s['ref'] + ';' + item['ref'])
+
+        self.unit_test_get_set_items()
 
         set_obj_name = self.setNames[0]
         wsName2 = "test_SetAPI_" + str(int(time.time() * 1000)) + "_two"
@@ -249,3 +259,30 @@ class SetAPITest(unittest.TestCase):
             print("Objects found: " + str(len(ret['sets'])) + ", time=" + str(time.time() - t1))
         finally:
             GenericSetNavigator.DEBUG = False
+
+    def unit_test_get_set_items(self):
+
+        res = self.getImpl().get_set_items(self.getContext(), {
+                                            'set_refs': [{'ref': self.setRefs[0]},
+                                                         {'ref': self.setRefs[1]},
+                                                         {'ref': self.setRefs[2]}],
+                                            'include_set_item_ref_paths': 1
+                                            })[0]
+        '''
+        print('Result from get_set_items with ref_paths')
+        pprint(res)
+        print('========================================')
+        '''
+        self.assertEqual(len(res['sets']), 3)
+        for s in res['sets']:
+            self.assertTrue('ref' in s)
+            self.assertTrue('info' in s)
+            self.assertTrue('items' in s)
+            self.assertEqual(len(s['info']), 11)
+            self.assertEqual(len(s['items']), 2)
+            for item in s['items']:
+                self.assertTrue('ref' in item)
+                self.assertTrue('info' in item)
+                self.assertEqual(len(item['info']), 11)
+                self.assertTrue('ref_path' in item)
+                self.assertEquals(item["ref_path"], s["ref"] + ";" + item["ref"])

--- a/test/generic_set_access_test.py
+++ b/test/generic_set_access_test.py
@@ -24,6 +24,7 @@ from FakeObjectsForTests.FakeObjectsForTestsClient import FakeObjectsForTests
 from SetAPI.authclient import KBaseAuth as _KBaseAuth
 
 class SetAPITest(unittest.TestCase):
+    DEBUG = False
 
     @classmethod
     def setUpClass(cls):
@@ -175,11 +176,12 @@ class SetAPITest(unittest.TestCase):
                     'workspace': workspace,
                     'include_set_item_ref_paths': 1
                 })[0]
-        '''
-        print('Result from list_items with ref_paths')
-        pprint(res3)
-        print('=====================================')
-        '''
+
+        if self.DEBUG:
+            print('Result from list_items with ref_paths')
+            pprint(res3)
+            print('=====================================')
+
         self.assertTrue('sets' in res3)
         self.assertEqual(len(res3['sets']), len(self.setNames))
         for s in res3['sets']:
@@ -268,11 +270,11 @@ class SetAPITest(unittest.TestCase):
                                                          {'ref': self.setRefs[2]}],
                                             'include_set_item_ref_paths': 1
                                             })[0]
-        '''
-        print('Result from get_set_items with ref_paths')
-        pprint(res)
-        print('========================================')
-        '''
+        if self.DEBUG:
+            print('Result from get_set_items with ref_paths')
+            pprint(res)
+            print('========================================')
+
         self.assertEqual(len(res['sets']), 3)
         for s in res['sets']:
             self.assertTrue('ref' in s)

--- a/test/util.py
+++ b/test/util.py
@@ -3,7 +3,6 @@ Some utility functions to help with testing. These mainly add fake objects to us
 """
 from DataFileUtil.DataFileUtilClient import DataFileUtil
 
-
 def info_to_ref(info):
     """
     Just a one liner that converts the usual Workspace ObjectInfo list into an object reference
@@ -84,6 +83,36 @@ def make_fake_old_alignment_set(name, reads_refs, genome_ref, sampleset_ref, ali
     if include_sample_alignments:
         fake_rnaseq_alignment_set["sample_alignments"] = alignments_refs
     return make_fake_object(fake_rnaseq_alignment_set, "KBaseRNASeq.RNASeqAlignmentSet",
+                            name, ws_name, ws_client)
+
+def make_fake_old_expression_set(name, genome_ref, sampleset_ref,
+                                 alignments_refs, alignmentset_ref,
+                                 expressions_refs, ws_name, ws_client,
+                                 include_sample_expressions=False):
+    """
+    Make a fake set object for KBaseRNASeq.RNASeqAlignmentSet objects
+    Needs a whole bunch of stuff:
+        list of reads_refs
+        list of alignments_refs
+        genome_ref
+        sampleset_ref (can be dummied up with make_fake_sampleset)
+    Setting include_sample_alignments to True will include the optional "sample_alignments"
+    attribute of the object.
+    """
+    mapped_expression_ids = list()
+    for idx, ref in enumerate(alignments_refs):
+        mapped_expression_ids.append({ref: expressions_refs[idx]})
+
+    fake_rnaseq_expression_set = {
+        "sampleset_id": sampleset_ref,
+        "genome_id": genome_ref,
+        "mapped_expression_ids": mapped_expression_ids,
+        "mapped_expression_objects": [],
+        "alignmentSet_id": alignmentset_ref
+    }
+    if include_sample_expressions:
+        fake_rnaseq_expression_set["sample_expression_ids"] = expressions_refs
+    return make_fake_object(fake_rnaseq_expression_set, "KBaseRNASeq.RNASeqExpressionSet",
                             name, ws_name, ws_client)
 
 def make_fake_annotation(callback_url, dummy_file, name, ws_name, ws_client):

--- a/test/util.py
+++ b/test/util.py
@@ -12,10 +12,8 @@ def info_to_ref(info):
     """
     return "{}/{}/{}".format(info[6], info[0], info[4])
 
-
 def get_fake_file_handle(file_path):
     pass
-
 
 def make_fake_alignment(callback_url, dummy_file, name, reads_ref, genome_ref, ws_name, ws_client):
     """
@@ -42,7 +40,6 @@ def make_fake_alignment(callback_url, dummy_file, name, reads_ref, genome_ref, w
     }
     return make_fake_object(fake_alignment, "KBaseRNASeq.RNASeqAlignment", name, ws_name, ws_client)
 
-
 def make_fake_sampleset(name, reads_refs, conditions, ws_name, ws_client):
     """
     Make a fake KBaseRNASeq.RNASeqSampleSet object.
@@ -61,7 +58,6 @@ def make_fake_sampleset(name, reads_refs, conditions, ws_name, ws_client):
     }
     return make_fake_object(fake_sampleset, "KBaseRNASeq.RNASeqSampleSet", name, ws_name, ws_client)
 
-
 def make_fake_old_alignment_set(name, reads_refs, genome_ref, sampleset_ref, alignments_refs,
                                 ws_name, ws_client, include_sample_alignments=False):
     """
@@ -74,7 +70,6 @@ def make_fake_old_alignment_set(name, reads_refs, genome_ref, sampleset_ref, ali
     Setting include_sample_alignments to True will include the optional "sample_alignments"
     attribute of the object.
     """
-
     mapped_alignments_ids = list()
     for idx, ref in enumerate(reads_refs):
         mapped_alignments_ids.append({ref: alignments_refs[idx]})
@@ -91,7 +86,6 @@ def make_fake_old_alignment_set(name, reads_refs, genome_ref, sampleset_ref, ali
     return make_fake_object(fake_rnaseq_alignment_set, "KBaseRNASeq.RNASeqAlignmentSet",
                             name, ws_name, ws_client)
 
-
 def make_fake_annotation(callback_url, dummy_file, name, ws_name, ws_client):
     dfu = DataFileUtil(callback_url)
     dummy_shock_info = dfu.file_to_shock({
@@ -105,7 +99,6 @@ def make_fake_annotation(callback_url, dummy_file, name, ws_name, ws_client):
         "genome_scientific_name": "Genomus falsus"
     }
     return make_fake_object(annotation, "KBaseRNASeq.GFFAnnotation", name, ws_name, ws_client)
-
 
 def make_fake_expression(callback_url, dummy_file, name, genome_ref, annotation_ref, alignment_ref, ws_name, ws_client):
     """
@@ -134,7 +127,6 @@ def make_fake_expression(callback_url, dummy_file, name, genome_ref, annotation_
     }
     return make_fake_object(exp, "KBaseRNASeq.RNASeqExpression", name, ws_name, ws_client)
 
-
 def make_fake_feature_set(name, genome_ref, ws_name, ws_client):
     """
     Makes a fake KBaseCollections.FeatureSet object and returns a ref to it.
@@ -155,7 +147,6 @@ def make_fake_feature_set(name, genome_ref, ws_name, ws_client):
         }
     }
     return make_fake_object(feature_set, "KBaseCollections.FeatureSet", name, ws_name, ws_client)
-
 
 def make_fake_diff_exp_matrix(name, ws_name, ws_client, genome_ref=None):
     """
@@ -201,7 +192,6 @@ def make_fake_diff_exp_matrix(name, ws_name, ws_client, genome_ref=None):
         diff_exp_matrix['genome_ref'] = genome_ref
     return make_fake_object(diff_exp_matrix, "KBaseFeatureValues.DifferentialExpressionMatrix",
                             name, ws_name, ws_client)
-
 
 def make_fake_object(obj, obj_type, name, workspace_name, workspace_client):
     """


### PR DESCRIPTION
Changes include the following:

TASK-1150
- The way object selector is created to get objects using 'ref_path_to_set' input parameter.
TASK-1107
- Addition of input parameter 'include_set_item_ref_paths' to all SetAPI get functions.
  include_set_item_ref_paths - 1 or 0, if 1, additionally provides ref_path for each item
                                     in the set. The ref_path returned for each item is either
                                         ref_path_to_set;item_ref  (if ref_path_to_set is given) or
                                         set_ref;item_ref  (if ref_path_to_set is not given)
- Addition of tests for this additional parameter in all SetAPI get functions
