### PR TITLE
Update sample set spec

### DIFF
--- a/KBaseSets.spec
+++ b/KBaseSets.spec
@@ -219,11 +219,13 @@ module KBaseSets {
 
     /*
         @metadata ws length(samples) as num_samples
+        metadata keys - a list of all fields available as keys within samples of a given sample set.
     */
 
     typedef structure {
         list<sample_info> samples;
         string description;
+        list<string> metadata_keys;
     } SampleSet;
 
 };


### PR DESCRIPTION
Formalizes the definition of the `metadata_keys` field within the `KBaseSets.SampleSet` type. This enables faster lookup times for the metadata keys in crucial parts of the user facing UI components of samples.