### PR TITLE
List all sets pt IV: not as horrible as it looks -- honest!

### DIFF
--- a/test/AssemblySet_basic_test.py
+++ b/test/AssemblySet_basic_test.py
@@ -81,34 +81,34 @@ class SetAPITest(unittest.TestCase):
                 'output_object_name':setObjName,
                 'workspace': workspace
             })[0]
-        self.assertTrue('set_ref' in res)
-        self.assertTrue('set_info' in res)
-        self.assertEqual(len(res['set_info']), 11)
+        assert 'set_ref' in res
+        assert 'set_info' in res
+        assert len(res['set_info']) == 11
 
-        self.assertEqual(res['set_info'][1], setObjName)
-        self.assertTrue('item_count' in res['set_info'][10])
-        self.assertEqual(res['set_info'][10]['item_count'], '2')
+        assert res['set_info'][1] == setObjName
+        assert 'item_count' in res['set_info'][10]
+        assert res['set_info'][10]['item_count'] == '2'
 
         # test get of that object
         d1 = setAPI.get_assembly_set_v1(self.getContext(), {
                 'ref': workspace + '/' + setObjName
             })[0]
-        self.assertTrue('data' in d1)
-        self.assertTrue('info' in d1)
-        self.assertEqual(len(d1['info']), 11)
-        self.assertTrue('item_count' in d1['info'][10])
-        self.assertEqual(d1['info'][10]['item_count'], '2')
+        assert 'data' in d1
+        assert 'info' in d1
+        assert len(d1['info']) == 11
+        assert 'item_count' in d1['info'][10]
+        assert d1['info'][10]['item_count'] == '2'
 
-        self.assertEqual(d1['data']['description'], 'my first assembly set')
-        self.assertEqual(len(d1['data']['items']), 2)
+        assert d1['data']['description'] == 'my first assembly set'
+        assert len(d1['data']['items']) == 2
 
         item2 = d1['data']['items'][1]
-        self.assertTrue('info' not in item2)
-        self.assertTrue('ref_path' not in item2)
-        self.assertTrue('ref' in item2)
-        self.assertTrue('label' in item2)
-        self.assertEqual(item2['label'],'assembly2')
-        self.assertEqual(item2['ref'],self.assembly2ref)
+        assert 'info' not in item2
+        assert 'ref_path' not in item2
+        assert 'ref' in item2
+        assert 'label' in item2
+        assert item2['label'] == 'assembly2'
+        assert item2['ref'] == self.assembly2ref
 
         # test the call to make sure we get info for each item
         d2 = setAPI.get_reads_set_v1(self.getContext(), {
@@ -116,23 +116,23 @@ class SetAPITest(unittest.TestCase):
                 'include_item_info':1,
                 'include_set_item_ref_paths': 1
             })[0]
-        self.assertTrue('data' in d2)
-        self.assertTrue('info' in d2)
-        self.assertEqual(len(d2['info']), 11)
-        self.assertTrue('item_count' in d2['info'][10])
-        self.assertEqual(d2['info'][10]['item_count'], '2')
+        assert 'data' in d2
+        assert 'info' in d2
+        assert len(d2['info']) == 11
+        assert 'item_count' in d2['info'][10]
+        assert d2['info'][10]['item_count'] == '2'
 
-        self.assertEqual(d2['data']['description'], 'my first assembly set')
-        self.assertEqual(len(d2['data']['items']), 2)
+        assert d2['data']['description'] == 'my first assembly set'
+        assert len(d2['data']['items']) == 2
 
         item2 = d2['data']['items'][1]
-        self.assertTrue('info' in item2)
-        self.assertTrue(len(item2['info']), 11)
-        self.assertTrue('ref' in item2)
-        self.assertEqual(item2['ref'], self.assembly2ref)
+        assert 'info' in item2
+        assert len(item2['info']), 11
+        assert 'ref' in item2
+        assert item2['ref'] == self.assembly2ref
 
-        self.assertTrue('ref_path' in item2)
-        self.assertEqual(item2['ref_path'], res['set_ref'] + ';' + item2['ref'])
+        assert 'ref_path' in item2
+        assert item2['ref_path'] == res['set_ref'] + ';' + item2['ref']
         pprint(d2)
 
     # NOTE: According to Python unittest naming rules test method names should start from 'test'.
@@ -153,38 +153,38 @@ class SetAPITest(unittest.TestCase):
                 'output_object_name':setObjName,
                 'workspace': workspace
             })[0]
-        self.assertTrue('set_ref' in res)
-        self.assertTrue('set_info' in res)
-        self.assertEqual(len(res['set_info']), 11)
+        assert 'set_ref' in res
+        assert 'set_info' in res
+        assert len(res['set_info']) == 11
 
-        self.assertEqual(res['set_info'][1], setObjName)
-        self.assertTrue('item_count' in res['set_info'][10])
-        self.assertEqual(res['set_info'][10]['item_count'], '0')
+        assert res['set_info'][1] == setObjName
+        assert 'item_count' in res['set_info'][10]
+        assert res['set_info'][10]['item_count'] == '0'
 
 
         # test get of that object
         d1 = setAPI.get_assembly_set_v1(self.getContext(), {
                 'ref': workspace + '/' + setObjName
             })[0]
-        self.assertTrue('data' in d1)
-        self.assertTrue('info' in d1)
-        self.assertEqual(len(d1['info']), 11)
-        self.assertTrue('item_count' in d1['info'][10])
-        self.assertEqual(d1['info'][10]['item_count'], '0')
+        assert 'data' in d1
+        assert 'info' in d1
+        assert len(d1['info']) == 11
+        assert 'item_count' in d1['info'][10]
+        assert d1['info'][10]['item_count'] == '0'
 
-        self.assertEqual(d1['data']['description'], 'nothing to see here')
-        self.assertEqual(len(d1['data']['items']), 0)
+        assert d1['data']['description'] == 'nothing to see here'
+        assert len(d1['data']['items']) == 0
 
         d2 = setAPI.get_assembly_set_v1(self.getContext(), {
                 'ref':res['set_ref'],
                 'include_item_info':1
             })[0]
 
-        self.assertTrue('data' in d2)
-        self.assertTrue('info' in d2)
-        self.assertEqual(len(d2['info']), 11)
-        self.assertTrue('item_count' in d2['info'][10])
-        self.assertEqual(d2['info'][10]['item_count'], '0')
+        assert 'data' in d2
+        assert 'info' in d2
+        assert len(d2['info']) == 11
+        assert 'item_count' in d2['info'][10]
+        assert d2['info'][10]['item_count'] == '0'
 
-        self.assertEqual(d2['data']['description'], 'nothing to see here')
-        self.assertEqual(len(d2['data']['items']), 0)
+        assert d2['data']['description'] == 'nothing to see here'
+        assert len(d2['data']['items']) == 0

--- a/test/DifferentialExpressionMatrixSet_basic_test.py
+++ b/test/DifferentialExpressionMatrixSet_basic_test.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 import os
 import unittest
+import pytest
+import pprint
 from test.test_config import get_test_config
 from installed_clients.FakeObjectsForTestsClient import FakeObjectsForTests
 from test.util import (
@@ -80,12 +82,12 @@ class DifferentialExpressionMatrixSetAPITest(unittest.TestCase):
             "output_object_name": set_name,
             "data": matrix_set
         })[0]
-        self.assertIsNotNone(result)
-        self.assertIn("set_ref", result)
-        self.assertIn("set_info", result)
-        self.assertEqual(result["set_ref"], info_to_ref(result["set_info"]))
-        self.assertEqual(result["set_info"][1], set_name)
-        self.assertIn("KBaseSets.DifferentialExpressionMatrixSet", result["set_info"][2])
+        assert result is not None
+        assert "set_ref" in result
+        assert "set_info" in result
+        assert result["set_ref"] == info_to_ref(result["set_info"])
+        assert result["set_info"][1] == set_name
+        assert "KBaseSets.DifferentialExpressionMatrixSet" in result["set_info"][2]
 
     def test_save_diff_exp_matrix_set_no_genome(self):
         set_name = "test_de_matrix_set_no_genome"
@@ -104,12 +106,12 @@ class DifferentialExpressionMatrixSetAPITest(unittest.TestCase):
             "output_object_name": set_name,
             "data": matrix_set
         })[0]
-        self.assertIsNotNone(result)
-        self.assertIn("set_ref", result)
-        self.assertIn("set_info", result)
-        self.assertEqual(result["set_ref"], info_to_ref(result["set_info"]))
-        self.assertEqual(result["set_info"][1], set_name)
-        self.assertIn("KBaseSets.DifferentialExpressionMatrixSet", result["set_info"][2])
+        assert result is not None
+        assert "set_ref" in result
+        assert "set_info" in result
+        assert result["set_ref"] == info_to_ref(result["set_info"])
+        assert result["set_info"][1] == set_name
+        assert "KBaseSets.DifferentialExpressionMatrixSet" in result["set_info"][2]
 
     def test_save_dem_set_mismatched_genomes(self):
         set_name = "dem_set_bad_genomes"
@@ -128,27 +130,32 @@ class DifferentialExpressionMatrixSetAPITest(unittest.TestCase):
                 "label": "not_so_odd"
             }]
         }
-        with self.assertRaises(ValueError) as err:
+        with pytest.raises(
+            ValueError,
+            match="All Differential Expression Matrix objects in the set must use the same genome reference."
+        ):
             self.getImpl().save_differential_expression_matrix_set_v1(self.getContext(), {
                 "workspace": self.getWsName(),
                 "output_object_name": set_name,
                 "data": dem_set
             })
-            self.assertIn("All Expression objects in the set must use "
-                          "the same genome reference.", str(err.exception))
 
     def test_save_dem_set_no_data(self):
-        with self.assertRaises(ValueError) as err:
+        with pytest.raises(
+            ValueError,
+            match='"data" parameter field required to save a DifferentialExpressionMatrixSet'
+        ):
             self.getImpl().save_differential_expression_matrix_set_v1(self.getContext(), {
                 "workspace": self.getWsName(),
                 "output_object_name": "foo",
                 "data": None
             })
-        self.assertIn('"data" parameter field required to save a DifferentialExpressionMatrixSet',
-                      str(err.exception))
 
     def test_save_dem_set_no_dem(self):
-        with self.assertRaises(ValueError) as err:
+        with pytest.raises(
+            ValueError,
+            match="A DifferentialExpressionMatrixSet must contain at least one DifferentialExpressionMatrix object reference."
+        ):
             self.getImpl().save_differential_expression_matrix_set_v1(self.getContext(), {
                 "workspace": self.getWsName(),
                 "output_object_name": "foo",
@@ -156,9 +163,6 @@ class DifferentialExpressionMatrixSetAPITest(unittest.TestCase):
                     "items": []
                 }
             })
-        self.assertIn("A DifferentialExpressionMatrixSet must contain at "
-                      "least one DifferentialExpressionMatrix object reference.",
-                      str(err.exception))
 
     def test_get_dem_set(self):
         set_name = "test_expression_set"
@@ -182,16 +186,16 @@ class DifferentialExpressionMatrixSetAPITest(unittest.TestCase):
             "ref": dem_set_ref,
             "include_item_info": 0
         })[0]
-        self.assertIsNotNone(fetched_set)
-        self.assertIn("data", fetched_set)
-        self.assertIn("info", fetched_set)
-        self.assertEqual(len(fetched_set["data"]["items"]), 3)
-        self.assertEqual(dem_set_ref, info_to_ref(fetched_set["info"]))
+        assert fetched_set is not None
+        assert "data" in fetched_set
+        assert "info" in fetched_set
+        assert len(fetched_set["data"]["items"]) == 3
+        assert dem_set_ref == info_to_ref(fetched_set["info"])
         for item in fetched_set["data"]["items"]:
-            self.assertNotIn("info", item)
-            self.assertIn("ref", item)
-            self.assertNotIn("ref_path", item)
-            self.assertIn("label", item)
+            assert "info" not in item
+            assert "ref" in item
+            assert "ref_path" not in item
+            assert "label" in item
 
         fetched_set_with_info = self.getImpl().get_differential_expression_matrix_set_v1(
             self.getContext(),
@@ -200,16 +204,16 @@ class DifferentialExpressionMatrixSetAPITest(unittest.TestCase):
                 "include_item_info": 1
             }
         )[0]
-        self.assertIsNotNone(fetched_set_with_info)
-        self.assertIn("data", fetched_set_with_info)
+        assert fetched_set_with_info is not None
+        assert "data" in fetched_set_with_info
         for item in fetched_set_with_info["data"]["items"]:
-            self.assertIn("info", item)
-            self.assertIn("ref", item)
-            self.assertIn("label", item)
+            assert "info" in item
+            assert "ref" in item
+            assert "label" in item
 
     def test_get_dem_set_ref_path(self):
         set_name = "test_diff_expression_set_ref_path"
-        set_items = list()
+        set_items = []
         for ref in self.diff_exps_no_genome:
             set_items.append({
                 "label": "wt",
@@ -230,37 +234,40 @@ class DifferentialExpressionMatrixSetAPITest(unittest.TestCase):
             "include_item_info": 0,
             "include_set_item_ref_paths": 1
         })[0]
-        self.assertIsNotNone(fetched_set_with_ref_path)
-        self.assertIn("data", fetched_set_with_ref_path)
-        self.assertIn("info", fetched_set_with_ref_path)
-        self.assertEqual(len(fetched_set_with_ref_path["data"]["items"]), 3)
-        self.assertEqual(dem_set_ref, info_to_ref(fetched_set_with_ref_path["info"]))
+        assert fetched_set_with_ref_path is not None
+        assert "data" in fetched_set_with_ref_path
+        assert "info" in fetched_set_with_ref_path
+        assert len(fetched_set_with_ref_path["data"]["items"]) == 3
+        assert dem_set_ref == info_to_ref(fetched_set_with_ref_path["info"])
         for item in fetched_set_with_ref_path["data"]["items"]:
-            self.assertNotIn("info", item)
-            self.assertIn("ref", item)
-            self.assertIn("label", item)
-            self.assertIn("ref_path", item)
-            self.assertEqual(item["ref_path"], dem_set_ref + ';' + item["ref"])
+            assert "info" not in item
+            assert "ref" in item
+            assert "label" in item
+            assert "ref_path" in item
+            assert item["ref_path"] == dem_set_ref + ';' + item["ref"]
         #pprint(fetched_set_with_ref_path)
 
     def test_get_dem_set_bad_ref(self):
-        with self.assertRaises(ValueError) as err:
+        with pytest.raises(
+            ValueError,
+            match='"ref" parameter must be a valid workspace reference'
+        ):
             self.getImpl().get_differential_expression_matrix_set_v1(self.getContext(), {
                 "ref": "not_a_ref"
             })
-        self.assertIn('"ref" parameter must be a valid workspace reference', str(err.exception))
 
     def test_get_dem_set_bad_path(self):
-        with self.assertRaises(Exception):
+        with pytest.raises(Exception):
             self.getImpl().get_differential_expression_matrix_set_v1(self.getContext(), {
                 "ref": "1/2/3",
                 "path_to_set": ["foo", "bar"]
             })
 
     def test_get_dem_set_no_ref(self):
-        with self.assertRaises(ValueError) as err:
+        with pytest.raises(
+            ValueError,
+            match='"ref" parameter field specifiying the DifferentialExpressionMatrix set is required'
+        ):
             self.getImpl().get_differential_expression_matrix_set_v1(self.getContext(), {
                 "ref": None
             })
-        self.assertIn('"ref" parameter field specifiying the DifferentialExpressionMatrix set is required',
-                      str(err.exception))

--- a/test/GenomeSet_basic_test.py
+++ b/test/GenomeSet_basic_test.py
@@ -74,33 +74,33 @@ class SetAPITest(unittest.TestCase):
                 'output_object_name':setObjName,
                 'workspace': workspace
             })[0]
-        self.assertTrue('set_ref' in res)
-        self.assertTrue('set_info' in res)
-        self.assertEqual(len(res['set_info']), 11)
+        assert 'set_ref' in res
+        assert 'set_info' in res
+        assert len(res['set_info']) == 11
 
-        self.assertEqual(res['set_info'][1], setObjName)
-        self.assertTrue('item_count' in res['set_info'][10])
-        self.assertEqual(res['set_info'][10]['item_count'], '2')
+        assert res['set_info'][1] == setObjName
+        assert 'item_count' in res['set_info'][10]
+        assert res['set_info'][10]['item_count'] == '2'
 
         # test get of that object
         d1 = setAPI.get_genome_set_v1(self.getContext(), {
                 'ref': workspace + '/' + setObjName
             })[0]
-        self.assertTrue('data' in d1)
-        self.assertTrue('info' in d1)
-        self.assertEqual(len(d1['info']), 11)
-        self.assertTrue('item_count' in d1['info'][10])
-        self.assertEqual(d1['info'][10]['item_count'], '2')
+        assert 'data' in d1
+        assert 'info' in d1
+        assert len(d1['info']) == 11
+        assert 'item_count' in d1['info'][10]
+        assert d1['info'][10]['item_count'] == '2'
 
-        self.assertEqual(d1['data']['description'], 'my first genome set')
-        self.assertEqual(len(d1['data']['items']), 2)
+        assert d1['data']['description'] == 'my first genome set'
+        assert len(d1['data']['items']) == 2
 
         item2 = d1['data']['items'][1]
-        self.assertTrue('info' not in item2)
-        self.assertTrue('ref' in item2)
-        self.assertTrue('label' in item2)
-        self.assertEqual(item2['label'],'genome2')
-        self.assertEqual(item2['ref'],self.genome2ref)
+        assert 'info' not in item2
+        assert 'ref' in item2
+        assert 'label' in item2
+        assert item2['label'] == 'genome2'
+        assert item2['ref'] == self.genome2ref
 
         # test the call to make sure we get info for each item
         d2 = setAPI.get_reads_set_v1(self.getContext(), {
@@ -108,23 +108,23 @@ class SetAPITest(unittest.TestCase):
                 'include_item_info':1,
                 'include_set_item_ref_paths': 1
             })[0]
-        self.assertTrue('data' in d2)
-        self.assertTrue('info' in d2)
-        self.assertEqual(len(d2['info']), 11)
-        self.assertTrue('item_count' in d2['info'][10])
-        self.assertEqual(d2['info'][10]['item_count'], '2')
+        assert 'data' in d2
+        assert 'info' in d2
+        assert len(d2['info']) == 11
+        assert 'item_count' in d2['info'][10]
+        assert d2['info'][10]['item_count'] == '2'
 
-        self.assertEqual(d2['data']['description'], 'my first genome set')
-        self.assertEqual(len(d2['data']['items']), 2)
+        assert d2['data']['description'] == 'my first genome set'
+        assert len(d2['data']['items']) == 2
 
         item2 = d2['data']['items'][1]
-        self.assertTrue('info' in item2)
-        self.assertTrue(len(item2['info']), 11)
-        self.assertTrue('ref' in item2)
-        self.assertEqual(item2['ref'],self.genome2ref)
+        assert 'info' in item2
+        assert len(item2['info']), 11
+        assert 'ref' in item2
+        assert item2['ref'] == self.genome2ref
 
-        self.assertTrue('ref_path' in item2)
-        self.assertEqual(item2['ref_path'], res['set_ref'] + ';' + item2['ref'])
+        assert 'ref_path' in item2
+        assert item2['ref_path'] == res['set_ref'] + ';' + item2['ref']
         pprint(d2)
 
     def test_save_and_get_kbasesearch_genome(self):
@@ -156,33 +156,33 @@ class SetAPITest(unittest.TestCase):
                 'save_search_set': True
             })[0]
 
-        self.assertTrue('set_ref' in res)
-        self.assertTrue('set_info' in res)
-        self.assertEqual(len(res['set_info']), 11)
+        assert 'set_ref' in res
+        assert 'set_info' in res
+        assert len(res['set_info']) == 11
 
-        self.assertEqual(res['set_info'][1], setObjName)
-        self.assertTrue('KBaseSearch.GenomeSet' in res['set_info'][2])
+        assert res['set_info'][1] == setObjName
+        assert 'KBaseSearch.GenomeSet' in res['set_info'][2]
 
         # test get of that object
         d1 = setAPI.get_genome_set_v1(self.getContext(), {
                 'ref': workspace + '/' + setObjName
             })[0]
-        self.assertTrue('data' in d1)
-        self.assertTrue('info' in d1)
-        self.assertEqual(len(d1['info']), 11)
-        self.assertTrue('KBaseSearch.GenomeSet' in res['set_info'][2])
+        assert 'data' in d1
+        assert 'info' in d1
+        assert len(d1['info']) == 11
+        assert 'KBaseSearch.GenomeSet' in res['set_info'][2]
 
-        self.assertEqual(d1['data']['description'], 'my kbasesearch genome set')
-        self.assertEqual(len(d1['data']['elements']), 2)
+        assert d1['data']['description'] == 'my kbasesearch genome set'
+        assert len(d1['data']['elements']) == 2
 
         elements = d1['data']['elements']
-        self.assertTrue(self.genome1ref in elements)
-        self.assertTrue(self.genome2ref in elements)
+        assert self.genome1ref in elements
+        assert self.genome2ref in elements
 
         genome_2 = elements.get(self.genome2ref)
-        self.assertTrue('ref' in genome_2)
-        self.assertEqual(genome_2.get('ref'), self.genome2ref)
-        self.assertEqual(genome_2['metadata']['test_metadata'], 'metadata')
+        assert 'ref' in genome_2
+        assert genome_2.get('ref') == self.genome2ref
+        assert genome_2['metadata']['test_metadata'] == 'metadata'
 
     # NOTE: Comment the following line to run the test
     @unittest.skip("skipped test_save_and_get_of_emtpy_set")
@@ -204,37 +204,37 @@ class SetAPITest(unittest.TestCase):
                 'output_object_name':setObjName,
                 'workspace': workspace
             })[0]
-        self.assertTrue('set_ref' in res)
-        self.assertTrue('set_info' in res)
-        self.assertEqual(len(res['set_info']), 11)
+        assert 'set_ref' in res
+        assert 'set_info' in res
+        assert len(res['set_info']) == 11
 
-        self.assertEqual(res['set_info'][1], setObjName)
-        self.assertTrue('item_count' in res['set_info'][10])
-        self.assertEqual(res['set_info'][10]['item_count'], '0')
+        assert res['set_info'][1] == setObjName
+        assert 'item_count' in res['set_info'][10]
+        assert res['set_info'][10]['item_count'] == '0'
 
         # test get of that object
         d1 = setAPI.get_genome_set_v1(self.getContext(), {
                 'ref': workspace + '/' + setObjName
             })[0]
-        self.assertTrue('data' in d1)
-        self.assertTrue('info' in d1)
-        self.assertEqual(len(d1['info']), 11)
-        self.assertTrue('item_count' in d1['info'][10])
-        self.assertEqual(d1['info'][10]['item_count'], '0')
+        assert 'data' in d1
+        assert 'info' in d1
+        assert len(d1['info']) == 11
+        assert 'item_count' in d1['info'][10]
+        assert d1['info'][10]['item_count'] == '0'
 
-        self.assertEqual(d1['data']['description'], 'nothing to see here')
-        self.assertEqual(len(d1['data']['items']), 0)
+        assert d1['data']['description'] == 'nothing to see here'
+        assert len(d1['data']['items']) == 0
 
         d2 = setAPI.get_genome_set_v1(self.getContext(), {
                 'ref':res['set_ref'],
                 'include_item_info':1
             })[0]
 
-        self.assertTrue('data' in d2)
-        self.assertTrue('info' in d2)
-        self.assertEqual(len(d2['info']), 11)
-        self.assertTrue('item_count' in d2['info'][10])
-        self.assertEqual(d2['info'][10]['item_count'], '0')
+        assert 'data' in d2
+        assert 'info' in d2
+        assert len(d2['info']) == 11
+        assert 'item_count' in d2['info'][10]
+        assert d2['info'][10]['item_count'] == '0'
 
-        self.assertEqual(d2['data']['description'], 'nothing to see here')
-        self.assertEqual(len(d2['data']['items']), 0)
+        assert d2['data']['description'] == 'nothing to see here'
+        assert len(d2['data']['items']) == 0

--- a/test/ReadsSet_basic_test.py
+++ b/test/ReadsSet_basic_test.py
@@ -4,7 +4,7 @@ import time
 import unittest
 from pprint import pprint
 from test.test_config import get_test_config
-
+import pytest
 from installed_clients.FakeObjectsForTestsClient import FakeObjectsForTests
 from test.util import make_fake_sampleset
 
@@ -85,41 +85,41 @@ class SetAPITest(unittest.TestCase):
                 'output_object_name':setObjName,
                 'workspace': workspace
             })[0]
-        self.assertTrue('set_ref' in res)
-        self.assertTrue('set_info' in res)
-        self.assertEqual(len(res['set_info']), 11)
+        assert 'set_ref' in res
+        assert 'set_info' in res
+        assert len(res['set_info']) == 11
 
-        self.assertEqual(res['set_info'][1], setObjName)
-        self.assertTrue('item_count' in res['set_info'][10])
-        self.assertEqual(res['set_info'][10]['item_count'], '3')
+        assert res['set_info'][1] == setObjName
+        assert 'item_count' in res['set_info'][10]
+        assert res['set_info'][10]['item_count'] == '3'
 
 
         # test get of that object
         d1 = setAPI.get_reads_set_v1(self.getContext(), {
                 'ref': workspace + '/' + setObjName
             })[0]
-        self.assertTrue('data' in d1)
-        self.assertTrue('info' in d1)
-        self.assertEqual(len(d1['info']), 11)
-        self.assertTrue('item_count' in d1['info'][10])
-        self.assertEqual(d1['info'][10]['item_count'], '3')
+        assert 'data' in d1
+        assert 'info' in d1
+        assert len(d1['info']) == 11
+        assert 'item_count' in d1['info'][10]
+        assert d1['info'][10]['item_count'] == '3'
 
-        self.assertEqual(d1['data']['description'], 'my first reads')
-        self.assertEqual(len(d1['data']['items']), 3)
+        assert d1['data']['description'] == 'my first reads'
+        assert len(d1['data']['items']) == 3
 
         item2 = d1['data']['items'][1]
-        self.assertTrue('info' not in item2)
-        self.assertTrue('ref' in item2)
-        self.assertTrue('label' in item2)
-        self.assertEqual(item2['label'],'reads2')
-        self.assertEqual(item2['ref'],self.read2ref)
+        assert 'info' not in item2
+        assert 'ref' in item2
+        assert 'label' in item2
+        assert item2['label'] == 'reads2'
+        assert item2['ref'] == self.read2ref
 
         item3 = d1['data']['items'][2]
-        self.assertTrue('info' not in item3)
-        self.assertTrue('ref' in item3)
-        self.assertTrue('label' in item3)
-        self.assertEqual(item3['label'],'')
-        self.assertEqual(item3['ref'],self.read3ref)
+        assert 'info' not in item3
+        assert 'ref' in item3
+        assert 'label' in item3
+        assert item3['label'] == ''
+        assert item3['ref'] == self.read3ref
 
         # test the call to make sure we get info for each item
         d2 = setAPI.get_reads_set_v1(self.getContext(), {
@@ -127,23 +127,23 @@ class SetAPITest(unittest.TestCase):
                 'include_item_info':1,
                 'include_set_item_ref_paths': 1
             })[0]
-        self.assertTrue('data' in d2)
-        self.assertTrue('info' in d2)
-        self.assertEqual(len(d2['info']), 11)
-        self.assertTrue('item_count' in d2['info'][10])
-        self.assertEqual(d2['info'][10]['item_count'], '3')
+        assert 'data' in d2
+        assert 'info' in d2
+        assert len(d2['info']) == 11
+        assert 'item_count' in d2['info'][10]
+        assert d2['info'][10]['item_count'] == '3'
 
-        self.assertEqual(d2['data']['description'], 'my first reads')
-        self.assertEqual(len(d2['data']['items']), 3)
+        assert d2['data']['description'] == 'my first reads'
+        assert len(d2['data']['items']) == 3
 
         item2 = d2['data']['items'][1]
-        self.assertTrue('info' in item2)
-        self.assertTrue(len(item2['info']), 11)
-        self.assertTrue('ref' in item2)
-        self.assertEqual(item2['ref'],self.read2ref)
+        assert 'info' in item2
+        assert len(item2['info']), 11
+        assert 'ref' in item2
+        assert item2['ref'] == self.read2ref
 
-        self.assertTrue('ref_path' in item2)
-        self.assertEqual(item2['ref_path'], res['set_ref'] + ';' + item2['ref'])
+        assert 'ref_path' in item2
+        assert item2['ref_path'] == res['set_ref'] + ';' + item2['ref']
         pprint(d2)
 
     # NOTE: Comment the following line to run the test
@@ -167,41 +167,41 @@ class SetAPITest(unittest.TestCase):
                 'output_object_name':setObjName,
                 'workspace': workspace
             })[0]
-        self.assertTrue('set_ref' in res)
-        self.assertTrue('set_info' in res)
-        self.assertEqual(len(res['set_info']), 11)
+        assert 'set_ref' in res
+        assert 'set_info' in res
+        assert len(res['set_info']) == 11
 
-        self.assertEqual(res['set_info'][1], setObjName)
-        self.assertTrue('item_count' in res['set_info'][10])
-        self.assertEqual(res['set_info'][10]['item_count'], '0')
+        assert res['set_info'][1] == setObjName
+        assert 'item_count' in res['set_info'][10]
+        assert res['set_info'][10]['item_count'] == '0'
 
 
         # test get of that object
         d1 = setAPI.get_reads_set_v1(self.getContext(), {
                 'ref': workspace + '/' + setObjName
             })[0]
-        self.assertTrue('data' in d1)
-        self.assertTrue('info' in d1)
-        self.assertEqual(len(d1['info']), 11)
-        self.assertTrue('item_count' in d1['info'][10])
-        self.assertEqual(d1['info'][10]['item_count'], '0')
+        assert 'data' in d1
+        assert 'info' in d1
+        assert len(d1['info']) == 11
+        assert 'item_count' in d1['info'][10]
+        assert d1['info'][10]['item_count'] == '0'
 
-        self.assertEqual(d1['data']['description'], 'nothing to see here')
-        self.assertEqual(len(d1['data']['items']), 0)
+        assert d1['data']['description'] == 'nothing to see here'
+        assert len(d1['data']['items']) == 0
 
         d2 = setAPI.get_reads_set_v1(self.getContext(), {
                 'ref':res['set_ref'],
                 'include_item_info':1
             })[0]
 
-        self.assertTrue('data' in d2)
-        self.assertTrue('info' in d2)
-        self.assertEqual(len(d2['info']), 11)
-        self.assertTrue('item_count' in d2['info'][10])
-        self.assertEqual(d2['info'][10]['item_count'], '0')
+        assert 'data' in d2
+        assert 'info' in d2
+        assert len(d2['info']) == 11
+        assert 'item_count' in d2['info'][10]
+        assert d2['info'][10]['item_count'] == '0'
 
-        self.assertEqual(d2['data']['description'], 'nothing to see here')
-        self.assertEqual(len(d2['data']['items']), 0)
+        assert d2['data']['description'] == 'nothing to see here'
+        assert len(d2['data']['items']) == 0
 
     def test_get_sampleset_as_readsset(self):
         param_set = [{
@@ -215,26 +215,30 @@ class SetAPITest(unittest.TestCase):
         }]
         for params in param_set:
             res = self.getImpl().get_reads_set_v1(self.getContext(), params)[0]
-            self.assertIn('data', res)
-            self.assertIn('items', res['data'])
-            self.assertIn('info', res)
-            self.assertEqual(len(res['info']), 11)
-            self.assertIn('item_count', res['info'][10])
-            self.assertEqual(res['info'][10]['item_count'], 3)
+            assert 'data' in res
+            assert 'items' in res['data']
+            assert 'info' in res
+            assert len(res['info']) == 11
+            assert 'item_count' in res['info'][10]
+            assert res['info'][10]['item_count'] == 3
             for item in res['data']['items']:
-                self.assertIn('ref', item)
+                assert 'ref' in item
                 if params.get("include_item_info", 0) == 1:
-                    self.assertIn('info', item)
-                    self.assertEqual(len(item['info']), 11)
+                    assert 'info' in item
+                    assert len(item['info']) == 11
                 else:
-                    self.assertNotIn('info', item)
+                    assert 'info' not in item
 
     def test_get_reads_set_bad_ref(self):
-        with self.assertRaises(ValueError) as err:
+        with pytest.raises(
+            ValueError,
+            match='"ref" parameter must be a valid workspace reference'
+        ):
             self.getImpl().get_reads_set_v1(self.getContext(), {'ref': 'not_a_ref'})
-        self.assertEqual('"ref" parameter must be a valid workspace reference', str(err.exception))
 
     def test_get_reads_set_bad_type(self):
-        with self.assertRaises(ValueError) as err:
+        with pytest.raises(
+            ValueError,
+            match='is invalid for get_reads_set_v1'
+        ):
             self.getImpl().get_reads_set_v1(self.getContext(), {'ref': self.read1ref})
-        self.assertIn('is invalid for get_reads_set_v1', str(err.exception))

--- a/test/SampleSetSearch_test.py
+++ b/test/SampleSetSearch_test.py
@@ -4,7 +4,7 @@ import time
 import json
 import unittest
 from test.test_config import get_test_config
-
+import pytest
 from installed_clients.DataFileUtilClient import DataFileUtil
 
 
@@ -43,21 +43,21 @@ class SetAPITest(unittest.TestCase):
         return self.__class__.ctx
 
     def _compare_samples(self, s1, s2):
-        self.assertEqual(s1['num_found'], s2['num_found'])
-        self.assertEqual(s1['start'], s2['start'])
-        self.assertEqual(s1['samples'], s2['samples'])
+        assert s1['num_found'] == s2['num_found']
+        assert s1['start'] == s2['start']
+        assert s1['samples'] == s2['samples']
 
     # @unittest.skip('x')
     def test_param_error_conditions(self):
         # test without ref argument
-        with self.assertRaises(ValueError):
-            ret = self.serviceImpl.sample_set_to_samples_info(self.ctx, {
+        with pytest.raises(ValueError):
+            self.serviceImpl.sample_set_to_samples_info(self.ctx, {
                 "start": 0,
                 "limit": 10
             })
-        with self.assertRaises(ValueError):
-            ret = self.serviceImpl.sample_set_to_samples_info(self.ctx, {
-            })
+
+        with pytest.raises(ValueError):
+            self.serviceImpl.sample_set_to_samples_info(self.ctx, {})
 
     @unittest.skip('x')
     # test_sample_set_to_sample_info

--- a/test/SampleSet_basic_test.py
+++ b/test/SampleSet_basic_test.py
@@ -4,7 +4,7 @@ import time
 import unittest
 from pprint import pprint
 from test.test_config import get_test_config
-
+import pytest
 from installed_clients.FakeObjectsForTestsClient import FakeObjectsForTests
 from installed_clients.DataFileUtilClient import DataFileUtil
 
@@ -125,40 +125,40 @@ class SetAPITest(unittest.TestCase):
         print('======  Returned val from create_sample_set  ======')
         pprint(res)
 
-        self.assertTrue('set_ref' in res)
-        self.assertTrue('set_info' in res)
-        self.assertEqual(len(res['set_info']), 11)
+        assert 'set_ref' in res
+        assert 'set_info' in res
+        assert len(res['set_info']) == 11
 
-        self.assertEqual(res['set_info'][1], setObjName)
-        self.assertTrue('num_samples' in res['set_info'][10])
-        self.assertEqual(res['set_info'][10]['num_samples'], '3')
+        assert res['set_info'][1] == setObjName
+        assert 'num_samples' in res['set_info'][10]
+        assert res['set_info'][10]['num_samples'] == '3'
 
         # test get of that object
         d1 = setAPI.get_reads_set_v1(self.getContext(), {
                 'ref': workspace + '/' + setObjName
             })[0]
-        self.assertTrue('data' in d1)
-        self.assertTrue('info' in d1)
-        self.assertEqual(len(d1['info']), 11)
-        self.assertTrue('item_count' in d1['info'][10])
-        self.assertEqual(d1['info'][10]['item_count'], 3)
+        assert 'data' in d1
+        assert 'info' in d1
+        assert len(d1['info']) == 11
+        assert 'item_count' in d1['info'][10]
+        assert d1['info'][10]['item_count'] == 3
 
-        self.assertEqual(d1['data']['description'], 'first pass at testing algae GFFs from NCBI')
-        self.assertEqual(len(d1['data']['items']), 3)
+        assert d1['data']['description'] == 'first pass at testing algae GFFs from NCBI'
+        assert len(d1['data']['items']) == 3
 
         item2 = d1['data']['items'][1]
-        self.assertTrue('info' not in item2)
-        self.assertTrue('ref' in item2)
-        self.assertTrue('label' in item2)
-        self.assertEqual(item2['label'], self.condition_2)
-        self.assertEqual(item2['ref'], self.read2ref)
+        assert 'info' not in item2
+        assert 'ref' in item2
+        assert 'label' in item2
+        assert item2['label'] == self.condition_2
+        assert item2['ref'] == self.read2ref
 
         item3 = d1['data']['items'][2]
-        self.assertTrue('info' not in item3)
-        self.assertTrue('ref' in item3)
-        self.assertTrue('label' in item3)
-        self.assertEqual(item3['label'], self.condition_2)
-        self.assertEqual(item3['ref'], self.read3ref)
+        assert 'info' not in item3
+        assert 'ref' in item3
+        assert 'label' in item3
+        assert item3['label'] == self.condition_2
+        assert item3['ref'] == self.read3ref
 
         # test the call to make sure we get info for each item
         d2 = setAPI.get_reads_set_v1(self.getContext(), {
@@ -166,23 +166,23 @@ class SetAPITest(unittest.TestCase):
                 'include_item_info': 1,
                 'include_set_item_ref_paths': 1
             })[0]
-        self.assertTrue('data' in d2)
-        self.assertTrue('info' in d2)
-        self.assertEqual(len(d2['info']), 11)
-        self.assertTrue('item_count' in d2['info'][10])
-        self.assertEqual(d2['info'][10]['item_count'], 3)
+        assert 'data' in d2
+        assert 'info' in d2
+        assert len(d2['info']) == 11
+        assert 'item_count' in d2['info'][10]
+        assert d2['info'][10]['item_count'] == 3
 
-        self.assertEqual(d2['data']['description'], 'first pass at testing algae GFFs from NCBI')
-        self.assertEqual(len(d2['data']['items']), 3)
+        assert d2['data']['description'] == 'first pass at testing algae GFFs from NCBI'
+        assert len(d2['data']['items']) == 3
 
         item2 = d2['data']['items'][1]
-        self.assertTrue('info' in item2)
-        self.assertTrue(len(item2['info']), 11)
-        self.assertTrue('ref' in item2)
-        self.assertEqual(item2['ref'],self.read2ref)
+        assert 'info' in item2
+        assert len(item2['info']), 11
+        assert 'ref' in item2
+        assert item2['ref'] == self.read2ref
 
-        self.assertTrue('ref_path' in item2)
-        self.assertEqual(item2['ref_path'], res['set_ref'] + ';' + item2['ref'])
+        assert 'ref_path' in item2
+        assert item2['ref_path'] == res['set_ref'] + ';' + item2['ref']
 
         pprint(d2)
 
@@ -215,40 +215,40 @@ class SetAPITest(unittest.TestCase):
         print('======  Returned val from create_sample_set  ======')
         pprint(res)
 
-        self.assertTrue('set_ref' in res)
-        self.assertTrue('set_info' in res)
-        self.assertEqual(len(res['set_info']), 11)
+        assert 'set_ref' in res
+        assert 'set_info' in res
+        assert len(res['set_info']) == 11
 
-        self.assertEqual(res['set_info'][1], setObjName)
-        self.assertTrue('num_samples' in res['set_info'][10])
-        self.assertEqual(res['set_info'][10]['num_samples'], '3')
+        assert res['set_info'][1] == setObjName
+        assert 'num_samples' in res['set_info'][10]
+        assert res['set_info'][10]['num_samples'] == '3'
 
         # test get of that object
         d1 = setAPI.get_reads_set_v1(self.getContext(), {
                 'ref': workspace + '/' + setObjName
             })[0]
-        self.assertTrue('data' in d1)
-        self.assertTrue('info' in d1)
-        self.assertEqual(len(d1['info']), 11)
-        self.assertTrue('item_count' in d1['info'][10])
-        self.assertEqual(d1['info'][10]['item_count'], 3)
+        assert 'data' in d1
+        assert 'info' in d1
+        assert len(d1['info']) == 11
+        assert 'item_count' in d1['info'][10]
+        assert d1['info'][10]['item_count'] == 3
 
-        self.assertEqual(d1['data']['description'], 'first pass at testing algae GFFs from NCBI')
-        self.assertEqual(len(d1['data']['items']), 3)
+        assert d1['data']['description'] == 'first pass at testing algae GFFs from NCBI'
+        assert len(d1['data']['items']) == 3
 
         item2 = d1['data']['items'][1]
-        self.assertTrue('info' not in item2)
-        self.assertTrue('ref' in item2)
-        self.assertTrue('label' in item2)
-        self.assertEqual(item2['label'], self.condition_2)
-        self.assertEqual(item2['ref'], self.read2ref)
+        assert 'info' not in item2
+        assert 'ref' in item2
+        assert 'label' in item2
+        assert item2['label'] == self.condition_2
+        assert item2['ref'] == self.read2ref
 
         item3 = d1['data']['items'][2]
-        self.assertTrue('info' not in item3)
-        self.assertTrue('ref' in item3)
-        self.assertTrue('label' in item3)
-        self.assertEqual(item3['label'], self.condition_2)
-        self.assertEqual(item3['ref'], self.read3ref)
+        assert 'info' not in item3
+        assert 'ref' in item3
+        assert 'label' in item3
+        assert item3['label'] == self.condition_2
+        assert item3['ref'] == self.read3ref
 
         # test the call to make sure we get info for each item
         d2 = setAPI.get_reads_set_v1(self.getContext(), {
@@ -256,23 +256,23 @@ class SetAPITest(unittest.TestCase):
                 'include_item_info': 1,
                 'include_set_item_ref_paths': 1
             })[0]
-        self.assertTrue('data' in d2)
-        self.assertTrue('info' in d2)
-        self.assertEqual(len(d2['info']), 11)
-        self.assertTrue('item_count' in d2['info'][10])
-        self.assertEqual(d2['info'][10]['item_count'], 3)
+        assert 'data' in d2
+        assert 'info' in d2
+        assert len(d2['info']) == 11
+        assert 'item_count' in d2['info'][10]
+        assert d2['info'][10]['item_count'] == 3
 
-        self.assertEqual(d2['data']['description'], 'first pass at testing algae GFFs from NCBI')
-        self.assertEqual(len(d2['data']['items']), 3)
+        assert d2['data']['description'] == 'first pass at testing algae GFFs from NCBI'
+        assert len(d2['data']['items']) == 3
 
         item2 = d2['data']['items'][1]
-        self.assertTrue('info' in item2)
-        self.assertTrue(len(item2['info']), 11)
-        self.assertTrue('ref' in item2)
-        self.assertEqual(item2['ref'],self.read2ref)
+        assert 'info' in item2
+        assert len(item2['info']), 11
+        assert 'ref' in item2
+        assert item2['ref'] == self.read2ref
 
-        self.assertTrue('ref_path' in item2)
-        self.assertEqual(item2['ref_path'], res['set_ref'] + ';' + item2['ref'])
+        assert 'ref_path' in item2
+        assert item2['ref_path'] == res['set_ref'] + ';' + item2['ref']
 
         pprint(d2)
 
@@ -304,8 +304,10 @@ class SetAPITest(unittest.TestCase):
         # test a save
         setAPI = self.getImpl()
 
-        with self.assertRaisesRegex(
-                ValueError, 'ERROR: Given conditions'):
+        with pytest.raises(
+            ValueError,
+            match='ERROR: Given conditions'
+        ):
             setAPI.create_sample_set(self.getContext(), create_ss_params)
 
     def test_non_list_string_conditions(self):
@@ -333,6 +335,8 @@ class SetAPITest(unittest.TestCase):
         # test a save
         setAPI = self.getImpl()
 
-        with self.assertRaisesRegex(
-                ValueError, 'ERROR: condition should be either a list or a string'):
+        with pytest.raises(
+            ValueError,
+            match='ERROR: condition should be either a list or a string'
+        ):
             setAPI.create_sample_set(self.getContext(), create_ss_params)

--- a/test/generic_set_access_test.py
+++ b/test/generic_set_access_test.py
@@ -4,7 +4,7 @@ import time
 import unittest
 from pprint import pprint
 from test.test_config import get_test_config
-
+import pytest
 from SetAPI.generic.GenericSetNavigator import GenericSetNavigator
 from installed_clients.FakeObjectsForTestsClient import FakeObjectsForTests
 
@@ -82,13 +82,17 @@ class SetAPITest(unittest.TestCase):
         ctx = self.getContext()
         set_api = self.getImpl()
 
-        with self.assertRaises(ValueError) as err:
+        with pytest.raises(
+            ValueError,
+            match='One of "workspace" or "workspaces" field required to list sets'
+        ):
             set_api.list_sets(ctx, {'include_set_item_info': 1})
-        self.assertIn('One of "workspace" or "workspaces" field required to list sets', str(err.exception))
 
-        with self.assertRaises(ValueError) as err:
+        with pytest.raises(
+            ValueError,
+            match='"include_set_item_info" field must be set to 0 or 1'
+        ):
             set_api.list_sets(ctx, {'workspace': 12345, 'include_set_item_info': 'foo'})
-        self.assertIn('"include_set_item_info" field must be set to 0 or 1', str(err.exception))
 
     def test_list_sets(self):
         workspace = self.getWsName()
@@ -99,7 +103,7 @@ class SetAPITest(unittest.TestCase):
                 'workspace': workspace,
                 'include_set_item_info': 1
             })[0]
-        self.assertEqual(len(res['sets']), 0)
+        assert len(res['sets']) == 0
 
         # create the test sets, adds a ReadsSet object in the workspace
         self.create_sets()
@@ -109,34 +113,34 @@ class SetAPITest(unittest.TestCase):
                 'workspace': workspace,
                 'include_set_item_info': 1
             })[0]
-        self.assertTrue('sets' in res)
-        self.assertEqual(len(res['sets']), len(self.setNames))
+        assert 'sets' in res
+        assert len(res['sets']) == len(self.setNames)
         for s in res['sets']:
-            self.assertTrue('ref' in s)
-            self.assertTrue('info' in s)
-            self.assertTrue('items' in s)
-            self.assertEqual(len(s['info']), 11)
-            self.assertEqual(len(s['items']), 2)
+            assert 'ref' in s
+            assert 'info' in s
+            assert 'items' in s
+            assert len(s['info']) == 11
+            assert len(s['items']) == 2
             for item in s['items']:
-                self.assertTrue('ref' in item)
-                self.assertTrue('info' in item)
-                self.assertEqual(len(item['info']), 11)
+                assert 'ref' in item
+                assert 'info' in item
+                assert len(item['info']) == 11
 
         # Get the sets in a workspace without their item info (just the refs)
         res2 = setAPI.list_sets(self.getContext(), {
                 'workspace':workspace
             })[0]
-        self.assertTrue('sets' in res2)
-        self.assertEqual(len(res2['sets']), len(self.setNames))
+        assert 'sets' in res2
+        assert len(res2['sets']) == len(self.setNames)
         for s in res2['sets']:
-            self.assertTrue('ref' in s)
-            self.assertTrue('info' in s)
-            self.assertTrue('items' in s)
-            self.assertEqual(len(s['info']), 11)
-            self.assertEqual(len(s['items']), 2)
+            assert 'ref' in s
+            assert 'info' in s
+            assert 'items' in s
+            assert len(s['info']) == 11
+            assert len(s['items']) == 2
             for item in s['items']:
-                self.assertTrue('ref' in item)
-                self.assertTrue('info' not in item)
+                assert 'ref' in item
+                assert 'info' not in item
 
         # Get the sets with their reference paths
         res3 = setAPI.list_sets(self.getContext(), {
@@ -149,19 +153,19 @@ class SetAPITest(unittest.TestCase):
             pprint(res3)
             print('=====================================')
 
-        self.assertTrue('sets' in res3)
-        self.assertEqual(len(res3['sets']), len(self.setNames))
+        assert 'sets' in res3
+        assert len(res3['sets']) == len(self.setNames)
         for s in res3['sets']:
-            self.assertTrue('ref' in s)
-            self.assertTrue('info' in s)
-            self.assertTrue('items' in s)
-            self.assertEqual(len(s['info']), 11)
-            self.assertEqual(len(s['items']), 2)
+            assert 'ref' in s
+            assert 'info' in s
+            assert 'items' in s
+            assert len(s['info']) == 11
+            assert len(s['items']) == 2
             for item in s['items']:
-                self.assertTrue('ref' in item)
-                self.assertTrue('info' not in item)
-                self.assertTrue('ref_path' in item)
-                self.assertEqual(item['ref_path'], s['ref'] + ';' + item['ref'])
+                assert 'ref' in item
+                assert 'info' not in item
+                assert 'ref_path' in item
+                assert item['ref_path'] == s['ref'] + ';' + item['ref']
 
         self.unit_test_get_set_items()
 
@@ -201,16 +205,16 @@ class SetAPITest(unittest.TestCase):
             pprint(res)
             print('========================================')
 
-        self.assertEqual(len(res['sets']), 3)
+        assert len(res['sets']) == 3
         for s in res['sets']:
-            self.assertTrue('ref' in s)
-            self.assertTrue('info' in s)
-            self.assertTrue('items' in s)
-            self.assertEqual(len(s['info']), 11)
-            self.assertEqual(len(s['items']), 2)
+            assert 'ref' in s
+            assert 'info' in s
+            assert 'items' in s
+            assert len(s['info']) == 11
+            assert len(s['items']) == 2
             for item in s['items']:
-                self.assertTrue('ref' in item)
-                self.assertTrue('info' in item)
-                self.assertEqual(len(item['info']), 11)
-                self.assertTrue('ref_path' in item)
-                self.assertEqual(item["ref_path"], s["ref"] + ";" + item["ref"])
+                assert 'ref' in item
+                assert 'info' in item
+                assert len(item['info']) == 11
+                assert 'ref_path' in item
+                assert item["ref_path"] == s["ref"] + ";" + item["ref"]


### PR DESCRIPTION
I converted all the unittest-style testing statements over to using `assert` and `pytest.raises` to further pytestify the repo. This basically involved a load of search and replacing in VSCode:

* `self.assertEqual(x, y)` ==> `assert x == y`
* `self.assertTrue(statement)` -- all but one was in the form `x in y`, so they were converted to `assert x in y`
* `self.assertIn(x, y)` ==> `assert x in y`
* `self.assertNotIn(x, y)` ==> `assert x not in y`
* `self.assertIsNotNone(x)` ==> `assert x is not None`
* `self.assertRaises` / `self.assertRaisesRegex`, usually followed by a check of the error message ==> `with pytest.raises(<errorType>, match=<errorMessage>)`

After each replacement operation, I reran the tests to ensure that everything still passed.

I found one error during my search-n-replace odyssey - an incorrectly indented test statement that was checking for the wrong message. I will leave a comment in the code where I found it.