### PR TITLE
List all sets: sampleset `ws_id` parameter fix

### DIFF
--- a/lib/SetAPI/assembly/AssemblySetInterfaceV1.py
+++ b/lib/SetAPI/assembly/AssemblySetInterfaceV1.py
@@ -1,10 +1,11 @@
 from SetAPI.generic.SetInterfaceV1 import SetInterfaceV1
+from SetAPI.util import info_to_ref
 
 
 class AssemblySetInterfaceV1:
     def __init__(self, workspace_client):
         self.ws = workspace_client
-        self.setInterface = SetInterfaceV1(workspace_client)
+        self.set_interface = SetInterfaceV1(workspace_client)
 
     def save_assembly_set(self, ctx, params):
         if "data" in params:
@@ -12,12 +13,12 @@ class AssemblySetInterfaceV1:
         else:
             raise ValueError('"data" parameter field required to save an AssemblySet')
 
-        save_result = self.setInterface.save_set(
+        save_result = self.set_interface.save_set(
             "KBaseSets.AssemblySet", ctx["provenance"], params
         )
         info = save_result[0]
         return {
-            "set_ref": str(info[6]) + "/" + str(info[0]) + "/" + str(info[4]),
+            "set_ref": info_to_ref(info),
             "set_info": info,
         }
 
@@ -53,7 +54,7 @@ class AssemblySetInterfaceV1:
             if params["include_set_item_ref_paths"] == 1:
                 include_set_item_ref_paths = True
 
-        set_data = self.setInterface.get_set(
+        set_data = self.set_interface.get_set(
             params["ref"],
             include_item_info,
             ref_path_to_set,

--- a/lib/SetAPI/differentialexpressionmatrix/DifferentialExpressionMatrixSetInterfaceV1.py
+++ b/lib/SetAPI/differentialexpressionmatrix/DifferentialExpressionMatrixSetInterfaceV1.py
@@ -2,7 +2,7 @@
 An interface for handling sets of Expression objects.
 """
 from SetAPI.generic.SetInterfaceV1 import SetInterfaceV1
-from SetAPI.util import check_reference
+from SetAPI.util import check_reference, info_to_ref
 
 
 class DifferentialExpressionMatrixSetInterfaceV1:
@@ -23,7 +23,7 @@ class DifferentialExpressionMatrixSetInterfaceV1:
         )
         info = save_result[0]
         return {
-            "set_ref": str(info[6]) + "/" + str(info[0]) + "/" + str(info[4]),
+            "set_ref": info_to_ref(info),
             "set_info": info,
         }
 
@@ -90,10 +90,9 @@ class DifferentialExpressionMatrixSetInterfaceV1:
             raise ValueError(
                 '"ref" parameter field specifiying the DifferentialExpressionMatrix set is required'
             )
-        elif not check_reference(params["ref"]):
+        if not check_reference(params["ref"]):
             raise ValueError('"ref" parameter must be a valid workspace reference')
-        if "include_item_info" in params:
-            if params["include_item_info"] not in [0, 1]:
-                raise ValueError(
-                    '"include_item_info" parameter field can only be set to 0 or 1'
-                )
+        if "include_item_info" in params and params["include_item_info"] not in [0, 1]:
+            raise ValueError(
+                '"include_item_info" parameter field can only be set to 0 or 1'
+            )

--- a/lib/SetAPI/expression/ExpressionSetInterfaceV1.py
+++ b/lib/SetAPI/expression/ExpressionSetInterfaceV1.py
@@ -3,6 +3,7 @@ An interface for handling sets of Expression objects.
 """
 from SetAPI import util
 from SetAPI.generic.SetInterfaceV1 import SetInterfaceV1
+from SetAPI.util import info_to_ref
 
 
 class ExpressionSetInterfaceV1:
@@ -21,7 +22,7 @@ class ExpressionSetInterfaceV1:
         )
         info = save_result[0]
         return {
-            "set_ref": str(info[6]) + "/" + str(info[0]) + "/" + str(info[4]),
+            "set_ref": info_to_ref(info),
             "set_info": info,
         }
 
@@ -131,13 +132,12 @@ class ExpressionSetInterfaceV1:
             raise ValueError(
                 '"ref" parameter field specifiying the expression set is required'
             )
-        elif not util.check_reference(params["ref"]):
+        if not util.check_reference(params["ref"]):
             raise ValueError('"ref" parameter must be a valid workspace reference')
-        if "include_item_info" in params:
-            if params["include_item_info"] not in [0, 1]:
-                raise ValueError(
-                    '"include_item_info" parameter field can only be set to 0 or 1'
-                )
+        if "include_item_info" in params and params["include_item_info"] not in [0, 1]:
+            raise ValueError(
+                '"include_item_info" parameter field can only be set to 0 or 1'
+            )
         obj_spec = util.build_ws_obj_selector(
             params.get("ref"), params.get("ref_path_to_set", [])
         )

--- a/lib/SetAPI/featureset/FeatureSetSetInterfaceV1.py
+++ b/lib/SetAPI/featureset/FeatureSetSetInterfaceV1.py
@@ -2,7 +2,7 @@
 An interface for saving and retrieving Sets of FeatureSets.
 """
 from SetAPI.generic.SetInterfaceV1 import SetInterfaceV1
-from SetAPI.util import check_reference
+from SetAPI.util import check_reference, info_to_ref
 
 
 class FeatureSetSetInterfaceV1:
@@ -21,7 +21,7 @@ class FeatureSetSetInterfaceV1:
         )
         info = save_result[0]
         return {
-            "set_ref": str(info[6]) + "/" + str(info[0]) + "/" + str(info[4]),
+            "set_ref": info_to_ref(info),
             "set_info": info,
         }
 
@@ -70,13 +70,12 @@ class FeatureSetSetInterfaceV1:
             raise ValueError(
                 '"ref" parameter field specifiying the FeatureSet set is required'
             )
-        elif not check_reference(params["ref"]):
+        if not check_reference(params["ref"]):
             raise ValueError('"ref" parameter must be a valid workspace reference')
-        if "include_item_info" in params:
-            if params["include_item_info"] not in [0, 1]:
-                raise ValueError(
-                    '"include_item_info" parameter field can only be set to 0 or 1'
-                )
+        if "include_item_info" in params and params["include_item_info"] not in [0, 1]:
+            raise ValueError(
+                '"include_item_info" parameter field can only be set to 0 or 1'
+            )
 
     def _normalize_feature_set_set_data(self, set_data):
         # make sure that optional/missing fields are filled in or are defined

--- a/lib/SetAPI/generic/SetInterfaceV1.py
+++ b/lib/SetAPI/generic/SetInterfaceV1.py
@@ -40,17 +40,8 @@ class SetInterfaceV1:
                 }
             ]
         }
-        if "workspace" in params:
-            if str(params["workspace"]).isdigit():
-                save_params["id"] = int(params["workspace"])
-            else:
-                save_params["workspace"] = params["workspace"]
-        elif "workspace_name" in params:
-            save_params["workspace"] = params["workspace_name"]
-        elif "workspace_id" in params:
-            save_params["id"] = params["workspace_id"]
-
-        return save_params
+        ws_params = util.convert_workspace_param(params)
+        return {**save_params, **ws_params}
 
     def get_set(
         self,
@@ -83,10 +74,7 @@ class SetInterfaceV1:
 
         ws_data = self.ws.get_objects2({"objects": [selector]})
 
-        data = ws_data["data"][0]["data"]
-        info = ws_data["data"][0]["info"]
-
-        return {"data": data, "info": info}
+        return {"data": ws_data["data"][0]["data"], "info": ws_data["data"][0]["info"]}
 
     def _populate_item_object_info(self, set, ref_path_to_set):
         items = set["data"]["items"]

--- a/lib/SetAPI/genome/GenomeSetInterfaceV1.py
+++ b/lib/SetAPI/genome/GenomeSetInterfaceV1.py
@@ -1,10 +1,11 @@
 from SetAPI.generic.SetInterfaceV1 import SetInterfaceV1
+from SetAPI.util import info_to_ref
 
 
 class GenomeSetInterfaceV1:
     def __init__(self, workspace_client):
         self.ws = workspace_client
-        self.setInterface = SetInterfaceV1(workspace_client)
+        self.set_interface = SetInterfaceV1(workspace_client)
 
     def save_genome_set(self, ctx, params):
         """
@@ -22,10 +23,12 @@ class GenomeSetInterfaceV1:
         if save_search_set:
             genome_type = "KBaseSearch.GenomeSet"
 
-        save_result = self.setInterface.save_set(genome_type, ctx["provenance"], params)
+        save_result = self.set_interface.save_set(
+            genome_type, ctx["provenance"], params
+        )
         info = save_result[0]
         return {
-            "set_ref": str(info[6]) + "/" + str(info[0]) + "/" + str(info[4]),
+            "set_ref": info_to_ref(info),
             "set_info": info,
         }
 
@@ -69,7 +72,7 @@ class GenomeSetInterfaceV1:
         if "ref_path_to_set" in params:
             ref_path_to_set = params["ref_path_to_set"]
 
-        set_data = self.setInterface.get_set(
+        set_data = self.set_interface.get_set(
             params["ref"],
             include_item_info,
             ref_path_to_set,

--- a/lib/SetAPI/readsalignment/ReadsAlignmentSetInterfaceV1.py
+++ b/lib/SetAPI/readsalignment/ReadsAlignmentSetInterfaceV1.py
@@ -2,10 +2,13 @@
 An interface for handling sets of ReadsAlignments.
 """
 
-from pprint import pprint
-
 from SetAPI.generic.SetInterfaceV1 import SetInterfaceV1
-from SetAPI import util
+from SetAPI.util import (
+    populate_item_object_ref_paths,
+    check_reference,
+    build_ws_obj_selector,
+    info_to_ref,
+)
 
 
 class ReadsAlignmentSetInterfaceV1:
@@ -26,7 +29,7 @@ class ReadsAlignmentSetInterfaceV1:
         )
         info = save_result[0]
         return {
-            "set_ref": str(info[6]) + "/" + str(info[0]) + "/" + str(info[4]),
+            "set_ref": info_to_ref(info),
             "set_info": info,
         }
 
@@ -131,7 +134,7 @@ class ReadsAlignmentSetInterfaceV1:
             If include_set_item_ref_paths is set, then add a field ref_path in alignment items
             """
             if include_set_item_ref_paths:
-                util.populate_item_object_ref_paths(alignment_items, obj_spec)
+                populate_item_object_ref_paths(alignment_items, obj_spec)
 
             return {
                 "data": {"items": alignment_items, "description": ""},
@@ -143,7 +146,7 @@ class ReadsAlignmentSetInterfaceV1:
             raise ValueError(
                 '"ref" parameter field specifiying the reads alignment set is required'
             )
-        elif not util.check_reference(params["ref"]):
+        if not check_reference(params["ref"]):
             raise ValueError('"ref" parameter must be a valid workspace reference')
         if "include_item_info" in params:
             if params["include_item_info"] not in [0, 1]:
@@ -151,7 +154,7 @@ class ReadsAlignmentSetInterfaceV1:
                     '"include_item_info" parameter field can only be set to 0 or 1'
                 )
 
-        obj_spec = util.build_ws_obj_selector(
+        obj_spec = build_ws_obj_selector(
             params.get("ref"), params.get("ref_path_to_set", [])
         )
 

--- a/lib/SetAPI/util.py
+++ b/lib/SetAPI/util.py
@@ -3,7 +3,6 @@ This module contains some utility functions for the SetAPI.
 """
 import os
 import re
-
 from installed_clients.DataFileUtilClient import DataFileUtil
 
 
@@ -12,11 +11,48 @@ def check_reference(ref):
     Returns True if ref looks like an actual object reference: xx/yy/zz or xx/yy
     Returns False otherwise.
     """
-    obj_ref_regex = re.compile("^((\d+)|[A-Za-z].*)\/((\d+)|[A-Za-z].*)(\/\d+)?$")
+    obj_ref_regex = re.compile(r"^((\d+)|[A-Za-z].*)\/((\d+)|[A-Za-z].*)(\/\d+)?$")
     # obj_ref_regex = re.compile("^(?P<wsid>\d+)\/(?P<objid>\d+)(\/(?P<ver>\d+))?$")
     if ref is None or not obj_ref_regex.match(ref):
         return False
     return True
+
+
+def info_to_ref(info: list[str | int | dict[str, str]]) -> str:
+    """Extract the KBase UPA from a KBase object info list.
+
+    :param info: object info list, as produced by the workspace
+    :type info: list[str | int | dict[str, str]]
+    :return: KBase UPA for the object
+    :rtype: str
+    """
+    return f"{info[6]}/{info[0]}/{info[4]}"
+
+
+def convert_workspace_param(params: dict[str, int | str]) -> dict[str, int | str]:
+    """Find and convert the workspace name or ID into the appropriate version for ws.save_objects.
+
+    :param params: parameters
+    :type params: dict[str, str]
+    :return: the key and value to be used in the WS request
+    :rtype: dict[str, str]
+    """
+    if "workspace" in params:
+        if str(params["workspace"]).isdigit():
+            return {"id": int(params["workspace"])}
+        return {"workspace": params["workspace"]}
+
+    if "workspace_id" in params:
+        return {"id": params["workspace_id"]}
+    if "ws_id" in params:
+        return {"id": params["ws_id"]}
+
+    if "workspace_name" in params:
+        return {"workspace": params["workspace_name"]}
+    if "ws_name" in params:
+        return {"workspace": params["ws_name"]}
+
+    raise ValueError("No appropriate key found for workspace name or ID")
 
 
 def build_ws_obj_selector(ref, ref_path_to_set):
@@ -37,6 +73,4 @@ def populate_item_object_ref_paths(set_items, obj_selector):
 
 def dfu_get_obj_data(obj_ref):
     dfu = DataFileUtil(os.environ["SDK_CALLBACK_URL"])
-    obj_data = dfu.get_objects({"object_refs": [obj_ref]})["data"][0]["data"]
-
-    return obj_data
+    return dfu.get_objects({"object_refs": [obj_ref]})["data"][0]["data"]

--- a/lib/installed_clients/AssemblyUtilClient.py
+++ b/lib/installed_clients/AssemblyUtilClient.py
@@ -53,6 +53,46 @@ class AssemblyUtil(object):
         return self._client.run_job('AssemblyUtil.get_assembly_as_fasta',
                                     [params], self._service_ver, context)
 
+    def get_fastas(self, params, context=None):
+        """
+        Given a reference list of KBase objects constructs a local Fasta file with the sequence data for each ref.
+        :param params: instance of type "KBaseOjbReferences" -> structure:
+           parameter "ref_lst" of list of type "ref" (ref: workspace
+           reference. KBaseOjbReferences: ref_lst: is an object wrapped array
+           of KBase object references, which can be of the following types: -
+           KBaseGenomes.Genome - KBaseSets.AssemblySet -
+           KBaseMetagenome.BinnedContigs - KBaseGenomes.ContigSet -
+           KBaseGenomeAnnotations.Assembly - KBaseSearch.GenomeSet -
+           KBaseSets.GenomeSet ref_fastas paths - list of paths to fasta
+           files associated with workspace object. type - workspace object
+           type parent_refs - (optional) list of associated workspace object
+           references if different from the output key)
+        :returns: instance of mapping from type "ref" (ref: workspace
+           reference. KBaseOjbReferences: ref_lst: is an object wrapped array
+           of KBase object references, which can be of the following types: -
+           KBaseGenomes.Genome - KBaseSets.AssemblySet -
+           KBaseMetagenome.BinnedContigs - KBaseGenomes.ContigSet -
+           KBaseGenomeAnnotations.Assembly - KBaseSearch.GenomeSet -
+           KBaseSets.GenomeSet ref_fastas paths - list of paths to fasta
+           files associated with workspace object. type - workspace object
+           type parent_refs - (optional) list of associated workspace object
+           references if different from the output key) to type "ref_fastas"
+           -> structure: parameter "paths" of list of String, parameter
+           "parent_refs" of list of type "ref" (ref: workspace reference.
+           KBaseOjbReferences: ref_lst: is an object wrapped array of KBase
+           object references, which can be of the following types: -
+           KBaseGenomes.Genome - KBaseSets.AssemblySet -
+           KBaseMetagenome.BinnedContigs - KBaseGenomes.ContigSet -
+           KBaseGenomeAnnotations.Assembly - KBaseSearch.GenomeSet -
+           KBaseSets.GenomeSet ref_fastas paths - list of paths to fasta
+           files associated with workspace object. type - workspace object
+           type parent_refs - (optional) list of associated workspace object
+           references if different from the output key), parameter "type" of
+           String
+        """
+        return self._client.run_job('AssemblyUtil.get_fastas',
+                                    [params], self._service_ver, context)
+
     def export_assembly_as_fasta(self, params, context=None):
         """
         A method designed especially for download, this calls 'get_assembly_as_fasta' to do
@@ -66,45 +106,144 @@ class AssemblyUtil(object):
         return self._client.run_job('AssemblyUtil.export_assembly_as_fasta',
                                     [params], self._service_ver, context)
 
-    def save_assembly_from_fasta(self, params, context=None):
+    def save_assembly_from_fasta2(self, params, context=None):
         """
-        WARNING: has the side effect of moving the file to a temporary staging directory, because the upload
-        script for assemblies currently requires a working directory, not a specific file.  It will attempt
-        to upload everything in that directory.  This will move the file back to the original location, but
-        if you are trying to keep an open file handle or are trying to do things concurrently to that file,
-        this will break.  So this method is certainly NOT thread safe on the input file.
-        :param params: instance of type "SaveAssemblyParams" (Options
-           supported: file / shock_id / ftp_url - mutualy exclusive
-           parameters pointing to file content workspace_name - target
-           workspace assembly_name - target object name type - should be one
-           of 'isolate', 'metagenome', (maybe 'transcriptome')
-           min_contig_length - if set and value is greater than 1, this will
-           only include sequences with length greater or equal to the
-           min_contig_length specified, discarding all other sequences
-           taxon_ref         - sets the taxon_ref if present contig_info     
-           - map from contig_id to a small structure that can be used to set
-           the is_circular and description fields for Assemblies (optional)
-           Uploader options not yet supported taxon_reference: The ws
-           reference the assembly points to.  (Optional) source: The source
-           of the data (Ex: Refseq) date_string: Date (or date range)
-           associated with data. (Optional)) -> structure: parameter "file"
+        Save a KBase Workspace assembly object from a FASTA file.
+        :param params: instance of type "SaveAssemblyParams" (Required
+           arguments: Exactly one of: file - a pre-existing FASTA file to
+           import. The 'assembly_name' field in the FastaAssemblyFile object
+           is ignored. shock_id - an ID of a node in the Blobstore containing
+           the FASTA file. Exactly one of: workspace_id - the immutable,
+           numeric ID of the target workspace. Always prefer providing the ID
+           over the name. workspace_name - the name of the target workspace.
+           assembly_name - target object name Optional arguments: type -
+           should be one of 'isolate', 'metagenome', (maybe 'transcriptome').
+           Defaults to 'Unknown' min_contig_length - if set and value is
+           greater than 1, this will only include sequences with length
+           greater or equal to the min_contig_length specified, discarding
+           all other sequences contig_info - map from contig_id to a small
+           structure that can be used to set the is_circular and description
+           fields for Assemblies (optional)) -> structure: parameter "file"
            of type "FastaAssemblyFile" -> structure: parameter "path" of
            String, parameter "assembly_name" of String, parameter "shock_id"
-           of type "ShockNodeId", parameter "ftp_url" of String, parameter
+           of type "ShockNodeId", parameter "workspace_id" of Long, parameter
            "workspace_name" of String, parameter "assembly_name" of String,
-           parameter "external_source" of String, parameter
-           "external_source_id" of String, parameter "taxon_ref" of String,
-           parameter "min_contig_length" of Long, parameter "contig_info" of
-           mapping from String to type "ExtraContigInfo" (Structure for
-           setting additional Contig information per contig is_circ - flag if
-           contig is circular, 0 is false, 1 is true, missing indicates
-           unknown description - if set, sets the description of the field in
-           the assembly object which may override what was in the fasta file)
-           -> structure: parameter "is_circ" of Long, parameter "description"
-           of String
+           parameter "type" of String, parameter "external_source" of String,
+           parameter "external_source_id" of String, parameter
+           "min_contig_length" of Long, parameter "contig_info" of mapping
+           from String to type "ExtraContigInfo" (Structure for setting
+           additional Contig information per contig is_circ - flag if contig
+           is circular, 0 is false, 1 is true, missing indicates unknown
+           description - if set, sets the description of the field in the
+           assembly object which may override what was in the fasta file) ->
+           structure: parameter "is_circ" of Long, parameter "description" of
+           String
+        :returns: instance of type "SaveAssemblyResult" (Results from saving
+           an assembly. upa - the address of the resulting workspace object.
+           filtered_input - the filtered input file if the minimum contig
+           length parameter is present and > 0. null otherwise.) ->
+           structure: parameter "upa" of type "upa" (A Unique Permanent
+           Address for a workspace object, which is of the form W/O/V, where
+           W is the numeric workspace ID, O is the numeric object ID, and V
+           is the object version.), parameter "filtered_input" of String
+        """
+        return self._client.run_job('AssemblyUtil.save_assembly_from_fasta2',
+                                    [params], self._service_ver, context)
+
+    def save_assembly_from_fasta(self, params, context=None):
+        """
+        @deprecated AssemblyUtil.save_assembly_from_fasta2
+        :param params: instance of type "SaveAssemblyParams" (Required
+           arguments: Exactly one of: file - a pre-existing FASTA file to
+           import. The 'assembly_name' field in the FastaAssemblyFile object
+           is ignored. shock_id - an ID of a node in the Blobstore containing
+           the FASTA file. Exactly one of: workspace_id - the immutable,
+           numeric ID of the target workspace. Always prefer providing the ID
+           over the name. workspace_name - the name of the target workspace.
+           assembly_name - target object name Optional arguments: type -
+           should be one of 'isolate', 'metagenome', (maybe 'transcriptome').
+           Defaults to 'Unknown' min_contig_length - if set and value is
+           greater than 1, this will only include sequences with length
+           greater or equal to the min_contig_length specified, discarding
+           all other sequences contig_info - map from contig_id to a small
+           structure that can be used to set the is_circular and description
+           fields for Assemblies (optional)) -> structure: parameter "file"
+           of type "FastaAssemblyFile" -> structure: parameter "path" of
+           String, parameter "assembly_name" of String, parameter "shock_id"
+           of type "ShockNodeId", parameter "workspace_id" of Long, parameter
+           "workspace_name" of String, parameter "assembly_name" of String,
+           parameter "type" of String, parameter "external_source" of String,
+           parameter "external_source_id" of String, parameter
+           "min_contig_length" of Long, parameter "contig_info" of mapping
+           from String to type "ExtraContigInfo" (Structure for setting
+           additional Contig information per contig is_circ - flag if contig
+           is circular, 0 is false, 1 is true, missing indicates unknown
+           description - if set, sets the description of the field in the
+           assembly object which may override what was in the fasta file) ->
+           structure: parameter "is_circ" of Long, parameter "description" of
+           String
         :returns: instance of String
         """
         return self._client.run_job('AssemblyUtil.save_assembly_from_fasta',
+                                    [params], self._service_ver, context)
+
+    def save_assemblies_from_fastas(self, params, context=None):
+        """
+        Save multiple assembly objects from FASTA files.
+        WARNING: The code currently saves all assembly object data in memory before sending it
+        to the workspace in a single batch. Since the object data doesn't include sequences,
+        it is typically small and so in most cases this shouldn't cause issues. However, many
+        assemblies and / or many contigs could conceivably cause memeory issues or could
+        cause the workspace to reject the data package if the serialized data is > 1GB.
+        TODO: If this becomes a common issue (not particularly likely?) update the code to
+         Save assembly object data on disk if it becomes too large
+         Batch uploads to the workspace based on data size
+        :param params: instance of type "SaveAssembliesParams" (Input for the
+           save_assemblies_from_fastas function. Required arguments:
+           workspace_id - the numerical ID of the workspace in which to save
+           the Assemblies. inputs - a list of FASTA files to import. All of
+           the files must be from the same source - either all local files or
+           all Blobstore nodes. Optional arguments: min_contig_length - an
+           integer > 1. If present, sequences of lesser length will be
+           removed from the input FASTA files.) -> structure: parameter
+           "workspace_id" of Long, parameter "inputs" of list of type
+           "FASTAInput" (An input FASTA file and metadata for import.
+           Required arguments: Exactly one of: file - a path to an input
+           FASTA file. Must be accessible inside the AssemblyUtil docker
+           continer. node - a node ID for a Blobstore (formerly Shock) node
+           containing an input FASTA file. assembly_name - the workspace name
+           under which to save the Assembly object. Optional arguments: type
+           - should be one of 'isolate', 'metagenome', (maybe
+           'transcriptome'). Defaults to 'Unknown' external_source - the
+           source of the input data. E.g. JGI, NCBI, etc. external_source_id
+           - the ID of the input data at the source. contig_info - map from
+           contig_id to a small structure that can be used to set the
+           is_circular and description fields for Assemblies) -> structure:
+           parameter "file" of String, parameter "node" of String, parameter
+           "assembly_name" of String, parameter "type" of String, parameter
+           "external_source" of String, parameter "external_source_id" of
+           String, parameter "contig_info" of mapping from String to type
+           "ExtraContigInfo" (Structure for setting additional Contig
+           information per contig is_circ - flag if contig is circular, 0 is
+           false, 1 is true, missing indicates unknown description - if set,
+           sets the description of the field in the assembly object which may
+           override what was in the fasta file) -> structure: parameter
+           "is_circ" of Long, parameter "description" of String, parameter
+           "min_contig_length" of Long
+        :returns: instance of type "SaveAssembliesResults" (Results for the
+           save_assemblies_from_fastas function. results - the results of the
+           save operation in the same order as the input.) -> structure:
+           parameter "results" of list of type "SaveAssemblyResult" (Results
+           from saving an assembly. upa - the address of the resulting
+           workspace object. filtered_input - the filtered input file if the
+           minimum contig length parameter is present and > 0. null
+           otherwise.) -> structure: parameter "upa" of type "upa" (A Unique
+           Permanent Address for a workspace object, which is of the form
+           W/O/V, where W is the numeric workspace ID, O is the numeric
+           object ID, and V is the object version.), parameter
+           "filtered_input" of String
+        """
+        return self._client.run_job('AssemblyUtil.save_assemblies_from_fastas',
                                     [params], self._service_ver, context)
 
     def status(self, context=None):

--- a/lib/installed_clients/DataFileUtilClient.py
+++ b/lib/installed_clients/DataFileUtilClient.py
@@ -123,26 +123,27 @@ class DataFileUtil(object):
         :param params: instance of type "FileToShockParams" (Input for the
            file_to_shock function. Required parameters: file_path - the
            location of the file (or directory if using the pack parameter) to
-           load to Shock. Optional parameters: attributes - user-specified
-           attributes to save to the Shock node along with the file.
-           make_handle - make a Handle Service handle for the shock node.
-           Default false. pack - compress a file or archive a directory
-           before loading to Shock. The file_path argument will be appended
-           with the appropriate file extension prior to writing. For gzips
-           only, if the file extension denotes that the file is already
-           compressed, it will be skipped. If file_path is a directory and
-           tarring or zipping is specified, the created file name will be set
-           to the directory name, possibly overwriting an existing file.
-           Attempting to pack the root directory is an error. Do not attempt
-           to pack the scratch space root as noted in the module description.
-           The allowed values are: gzip - gzip the file given by file_path.
-           targz - tar and gzip the directory specified by the directory
-           portion of the file_path into the file specified by the file_path.
-           zip - as targz but zip the directory.) -> structure: parameter
-           "file_path" of String, parameter "attributes" of mapping from
-           String to unspecified object, parameter "make_handle" of type
-           "boolean" (A boolean - 0 for false, 1 for true. @range (0, 1)),
-           parameter "pack" of String
+           load to Shock. Optional parameters: attributes - DEPRECATED:
+           attributes are currently ignored by the upload function and will
+           be removed entirely in a future version. User-specified attributes
+           to save to the Shock node along with the file. make_handle - make
+           a Handle Service handle for the shock node. Default false. pack -
+           compress a file or archive a directory before loading to Shock.
+           The file_path argument will be appended with the appropriate file
+           extension prior to writing. For gzips only, if the file extension
+           denotes that the file is already compressed, it will be skipped.
+           If file_path is a directory and tarring or zipping is specified,
+           the created file name will be set to the directory name, possibly
+           overwriting an existing file. Attempting to pack the root
+           directory is an error. Do not attempt to pack the scratch space
+           root as noted in the module description. The allowed values are:
+           gzip - gzip the file given by file_path. targz - tar and gzip the
+           directory specified by the directory portion of the file_path into
+           the file specified by the file_path. zip - as targz but zip the
+           directory.) -> structure: parameter "file_path" of String,
+           parameter "attributes" of mapping from String to unspecified
+           object, parameter "make_handle" of type "boolean" (A boolean - 0
+           for false, 1 for true. @range (0, 1)), parameter "pack" of String
         :returns: instance of type "FileToShockOutput" (Output of the
            file_to_shock function. shock_id - the ID of the new Shock node.
            handle - the new handle, if created. Null otherwise.
@@ -166,8 +167,8 @@ class DataFileUtil(object):
         """
         Using the same logic as unpacking a Shock file, this method will cause
         any bzip or gzip files to be uncompressed, and then unpack tar and zip
-        archive files (uncompressing gzipped or bzipped archive files if 
-        necessary). If the file is an archive, it will be unbundled into the 
+        archive files (uncompressing gzipped or bzipped archive files if
+        necessary). If the file is an archive, it will be unbundled into the
         directory containing the original output file.
         :param params: instance of type "UnpackFileParams" -> structure:
            parameter "file_path" of String
@@ -175,6 +176,42 @@ class DataFileUtil(object):
            "file_path" of String
         """
         return self._client.run_job('DataFileUtil.unpack_file',
+                                    [params], self._service_ver, context)
+
+    def unpack_files(self, params, context=None):
+        """
+        Using the same logic as unpacking a Shock file, this method will cause
+        any bzip or gzip files to be uncompressed, and then unpack tar and zip
+        archive files (uncompressing gzipped or bzipped archive files if 
+        necessary). If the file is an archive, it will be unbundled into the 
+        directory containing the original output file.
+        The ordering of the input and output files is preserved in the input and output lists.
+        :param params: instance of list of type "UnpackFilesParams" (Input
+           parameters for the unpack_files function. Required parameter:
+           file_path - the path to the file to unpack. The file will be
+           unpacked into the file's parent directory. Optional parameter:
+           unpack - either 'uncompress' or 'unpack'. 'uncompress' will cause
+           any bzip or gzip files to be uncompressed. 'unpack' will behave
+           the same way, but it will also unpack tar and zip archive files
+           (uncompressing gzipped or bzipped archive files if necessary). If
+           'uncompress' is specified and an archive file is encountered, an
+           error will be thrown. If the file is an archive, it will be
+           unbundled into the directory containing the original output file.
+           Defaults to 'unpack'. Note that if the file name (either as
+           provided by the user or by Shock) without the a decompression
+           extension (e.g. .gz, .zip or .tgz -> .tar) points to an existing
+           file and unpack is specified, that file will be overwritten by the
+           decompressed Shock file.) -> structure: parameter "file_path" of
+           String, parameter "unpack" of String
+        :returns: instance of list of type "UnpackFilesResult" (Output
+           parameters for the unpack_files function. file_path - the path to
+           either a) the unpacked file or b) in the case of archive files,
+           the path to the original archive file, possibly uncompressed, or
+           c) in the case of regular files that don't need processing, the
+           path to the input file.) -> structure: parameter "file_path" of
+           String
+        """
+        return self._client.run_job('DataFileUtil.unpack_files',
                                     [params], self._service_ver, context)
 
     def pack_file(self, params, context=None):
@@ -219,11 +256,13 @@ class DataFileUtil(object):
            produce info-files in JSON format containing workspace metadata
            and provenance structures. It produces new files in folder pointed
            by file_path (or folder containing file pointed by file_path if
-           it's not folder). Optional parameters: attributes - user-specified
-           attributes to save to the Shock node along with the file.) ->
-           structure: parameter "file_path" of String, parameter "attributes"
-           of mapping from String to unspecified object, parameter "ws_refs"
-           of list of String
+           it's not folder). Optional parameters: attributes - DEPRECATED:
+           attributes are currently ignored by the upload function and will
+           be removed entirely in a future version. User-specified attributes
+           to save to the Shock node along with the file.) -> structure:
+           parameter "file_path" of String, parameter "attributes" of mapping
+           from String to unspecified object, parameter "ws_refs" of list of
+           String
         :returns: instance of type "PackageForDownloadOutput" (Output of the
            package_for_download function. shock_id - the ID of the new Shock
            node. node_file_name - the name of the file stored in Shock. size
@@ -241,7 +280,9 @@ class DataFileUtil(object):
            for the file_to_shock function. Required parameters: file_path -
            the location of the file (or directory if using the pack
            parameter) to load to Shock. Optional parameters: attributes -
-           user-specified attributes to save to the Shock node along with the
+           DEPRECATED: attributes are currently ignored by the upload
+           function and will be removed entirely in a future version.
+           User-specified attributes to save to the Shock node along with the
            file. make_handle - make a Handle Service handle for the shock
            node. Default false. pack - compress a file or archive a directory
            before loading to Shock. The file_path argument will be appended
@@ -352,8 +393,13 @@ class DataFileUtil(object):
 
     def save_objects(self, params, context=None):
         """
-        Save objects to the workspace. Saving over a deleted object undeletes
-        it.
+        Save objects to the workspace.
+        The objects will be sorted prior to saving to avoid the Workspace sort memory limit.
+        Note that if the object contains workspace object refs in mapping keys that may cause
+        the Workspace to resort the data. To avoid this, convert any refs in mapping keys to UPA
+        format (e.g. #/#/#, where # is a positive integer).
+        If the data is very large, using the WSLargeDataIO SDK module is advised.
+        Saving over a deleted object undeletes it.
         :param params: instance of type "SaveObjectsParams" (Input parameters
            for the "save_objects" function. Required parameters: id - the
            numerical ID of the workspace. objects - the objects to save. The
@@ -362,15 +408,12 @@ class DataFileUtil(object):
            type "ObjectSaveData" (An object and associated data required for
            saving. Required parameters: type - the workspace type string for
            the object. Omit the version information to use the latest
-           version. data - the object data. Optional parameters: One of an
-           object name or id. If no name or id is provided the name will be
-           set to 'auto' with the object id appended as a string, possibly
-           with -\d+ appended if that object id already exists as a name.
-           name - the name of the object. objid - the id of the object to
-           save over. meta - arbitrary user-supplied metadata for the object,
-           not to exceed 16kb; if the object type specifies automatic
-           metadata extraction with the 'meta ws' annotation, and your
-           metadata name conflicts, then your metadata will be silently
+           version. data - the object data. One of an object name or id: name
+           - the name of the object. objid - the id of the object to save
+           over. Optional parameters: meta - arbitrary user-supplied metadata
+           for the object, not to exceed 16kb; if the object type specifies
+           automatic metadata extraction with the 'meta ws' annotation, and
+           your metadata name conflicts, then your metadata will be silently
            overwritten. hidden - true if this object should not be listed
            when listing workspace objects. extra_provenance_input_refs -
            (optional) if set, these refs will be appended to the primary

--- a/lib/installed_clients/FakeObjectsForTestsClient.py
+++ b/lib/installed_clients/FakeObjectsForTestsClient.py
@@ -25,7 +25,7 @@ class FakeObjectsForTests(object):
             trust_all_ssl_certificates=False,
             auth_svc='https://ci.kbase.us/services/auth/api/legacy/KBase/Sessions/Login',
             service_ver='dev',
-            async_job_check_time_ms=100, async_job_check_time_scale_percent=150, 
+            async_job_check_time_ms=100, async_job_check_time_scale_percent=150,
             async_job_check_max_time_ms=300000):
         if url is None:
             raise ValueError('A url is required')

--- a/lib/installed_clients/GenomeFileUtilClient.py
+++ b/lib/installed_clients/GenomeFileUtilClient.py
@@ -45,28 +45,29 @@ class GenomeFileUtil(object):
            - becomes the name of the object workspace_name - the name of the
            workspace it gets saved to. source - Source of the file typically
            something like RefSeq or Ensembl taxon_ws_name - where the
-           reference taxons are : ReferenceTaxons taxon_reference - if
-           defined, will try to link the Genome to the specified taxonomy
-           object insteas of performing the lookup during upload release -
-           Release or version number of the data per example Ensembl has
-           numbered releases of all their data: Release 31
-           generate_ids_if_needed - If field used for feature id is not
-           there, generate ids (default behavior is raising an exception)
-           genetic_code - Genetic code of organism. Overwrites determined GC
-           from taxon object generate_missing_genes - If the file has CDS or
-           mRNA with no corresponding gene, generate a spoofed gene.
-           use_existing_assembly - Supply an existing assembly reference) ->
-           structure: parameter "file" of type "File" -> structure: parameter
-           "path" of String, parameter "shock_id" of String, parameter
-           "ftp_url" of String, parameter "genome_name" of String, parameter
-           "workspace_name" of String, parameter "source" of String,
-           parameter "taxon_wsname" of String, parameter "taxon_reference" of
-           String, parameter "release" of String, parameter
-           "generate_ids_if_needed" of String, parameter "genetic_code" of
-           Long, parameter "metadata" of type "usermeta" -> mapping from
-           String to String, parameter "generate_missing_genes" of type
-           "boolean" (A boolean - 0 for false, 1 for true. @range (0, 1)),
-           parameter "use_existing_assembly" of String
+           reference taxons are : ReferenceTaxons taxon_id - if defined, will
+           try to link the Genome to the specified taxonomy id in lieu of
+           performing the lookup during upload release - Release or version
+           number of the data per example Ensembl has numbered releases of
+           all their data: Release 31 generate_ids_if_needed - If field used
+           for feature id is not there, generate ids (default behavior is
+           raising an exception) genetic_code - Genetic code of organism.
+           Overwrites determined GC from taxon object scientific_name - will
+           be used to set the scientific name of the genome and link to a
+           taxon generate_missing_genes - If the file has CDS or mRNA with no
+           corresponding gene, generate a spoofed gene. use_existing_assembly
+           - Supply an existing assembly reference) -> structure: parameter
+           "file" of type "File" -> structure: parameter "path" of String,
+           parameter "shock_id" of String, parameter "ftp_url" of String,
+           parameter "genome_name" of String, parameter "workspace_name" of
+           String, parameter "source" of String, parameter "taxon_wsname" of
+           String, parameter "taxon_id" of String, parameter "release" of
+           String, parameter "generate_ids_if_needed" of String, parameter
+           "genetic_code" of Long, parameter "scientific_name" of String,
+           parameter "metadata" of type "usermeta" -> mapping from String to
+           String, parameter "generate_missing_genes" of type "boolean" (A
+           boolean - 0 for false, 1 for true. @range (0, 1)), parameter
+           "use_existing_assembly" of String
         :returns: instance of type "GenomeSaveResult" -> structure: parameter
            "genome_ref" of String
         """
@@ -90,6 +91,23 @@ class GenomeFileUtil(object):
            for false, 1 for true. @range (0, 1))
         """
         return self._client.run_job('GenomeFileUtil.genome_to_gff',
+                                    [params], self._service_ver, context)
+
+    def metagenome_to_gff(self, params, context=None):
+        """
+        :param params: instance of type "MetagenomeToGFFParams" (is_gtf -
+           optional flag switching export to GTF format (default is 0, which
+           means GFF) target_dir - optional target directory to create file
+           in (default is temporary folder with name 'gff_<timestamp>'
+           created in scratch)) -> structure: parameter "metagenome_ref" of
+           String, parameter "ref_path_to_genome" of list of String,
+           parameter "is_gtf" of type "boolean" (A boolean - 0 for false, 1
+           for true. @range (0, 1)), parameter "target_dir" of String
+        :returns: instance of type "MetagenomeToGFFResult" -> structure:
+           parameter "file_path" of String, parameter "from_cache" of type
+           "boolean" (A boolean - 0 for false, 1 for true. @range (0, 1))
+        """
+        return self._client.run_job('GenomeFileUtil.metagenome_to_gff',
                                     [params], self._service_ver, context)
 
     def genome_to_genbank(self, params, context=None):
@@ -183,32 +201,47 @@ class GenomeFileUtil(object):
         return self._client.run_job('GenomeFileUtil.export_genome_features_protein_to_fasta',
                                     [params], self._service_ver, context)
 
+    def export_metagenome_as_gff(self, params, context=None):
+        """
+        :param params: instance of type "ExportParams" (input and output
+           structure functions for standard downloaders) -> structure:
+           parameter "input_ref" of String
+        :returns: instance of type "ExportOutput" -> structure: parameter
+           "shock_id" of String
+        """
+        return self._client.run_job('GenomeFileUtil.export_metagenome_as_gff',
+                                    [params], self._service_ver, context)
+
     def fasta_gff_to_genome(self, params, context=None):
         """
         :param params: instance of type "FastaGFFToGenomeParams" (genome_name
            - becomes the name of the object workspace_name - the name of the
            workspace it gets saved to. source - Source of the file typically
            something like RefSeq or Ensembl taxon_ws_name - where the
-           reference taxons are : ReferenceTaxons taxon_reference - if
-           defined, will try to link the Genome to the specified taxonomy
-           object insteas of performing the lookup during upload release -
-           Release or version number of the data per example Ensembl has
-           numbered releases of all their data: Release 31 genetic_code -
-           Genetic code of organism. Overwrites determined GC from taxon
-           object generate_missing_genes - If the file has CDS or mRNA with
-           no corresponding gene, generate a spoofed gene. Off by default) ->
-           structure: parameter "fasta_file" of type "File" -> structure:
-           parameter "path" of String, parameter "shock_id" of String,
-           parameter "ftp_url" of String, parameter "gff_file" of type "File"
-           -> structure: parameter "path" of String, parameter "shock_id" of
-           String, parameter "ftp_url" of String, parameter "genome_name" of
-           String, parameter "workspace_name" of String, parameter "source"
-           of String, parameter "taxon_wsname" of String, parameter
-           "taxon_reference" of String, parameter "release" of String,
+           reference taxons are : ReferenceTaxons taxon_id - if defined, will
+           try to link the Genome to the specified taxonomy id in lieu of
+           performing the lookup during upload release - Release or version
+           number of the data per example Ensembl has numbered releases of
+           all their data: Release 31 genetic_code - Genetic code of
+           organism. Overwrites determined GC from taxon object
+           scientific_name - will be used to set the scientific name of the
+           genome and link to a taxon generate_missing_genes - If the file
+           has CDS or mRNA with no corresponding gene, generate a spoofed
+           gene. Off by default existing_assembly_ref - a KBase assembly upa,
+           to associate the genome with. Avoids saving a new assembly when
+           specified.) -> structure: parameter "fasta_file" of type "File" ->
+           structure: parameter "path" of String, parameter "shock_id" of
+           String, parameter "ftp_url" of String, parameter "gff_file" of
+           type "File" -> structure: parameter "path" of String, parameter
+           "shock_id" of String, parameter "ftp_url" of String, parameter
+           "genome_name" of String, parameter "workspace_name" of String,
+           parameter "source" of String, parameter "taxon_wsname" of String,
+           parameter "taxon_id" of String, parameter "release" of String,
            parameter "genetic_code" of Long, parameter "scientific_name" of
            String, parameter "metadata" of type "usermeta" -> mapping from
            String to String, parameter "generate_missing_genes" of type
-           "boolean" (A boolean - 0 for false, 1 for true. @range (0, 1))
+           "boolean" (A boolean - 0 for false, 1 for true. @range (0, 1)),
+           parameter "existing_assembly_ref" of String
         :returns: instance of type "GenomeSaveResult" -> structure: parameter
            "genome_ref" of String
         """
@@ -222,100 +255,197 @@ class GenomeFileUtil(object):
            - becomes the name of the object workspace_name - the name of the
            workspace it gets saved to. source - Source of the file typically
            something like RefSeq or Ensembl taxon_ws_name - where the
-           reference taxons are : ReferenceTaxons taxon_reference - if
-           defined, will try to link the Genome to the specified taxonomy
-           object insteas of performing the lookup during upload release -
-           Release or version number of the data per example Ensembl has
-           numbered releases of all their data: Release 31 genetic_code -
-           Genetic code of organism. Overwrites determined GC from taxon
-           object generate_missing_genes - If the file has CDS or mRNA with
-           no corresponding gene, generate a spoofed gene. Off by default) ->
-           structure: parameter "fasta_file" of type "File" -> structure:
-           parameter "path" of String, parameter "shock_id" of String,
-           parameter "ftp_url" of String, parameter "gff_file" of type "File"
-           -> structure: parameter "path" of String, parameter "shock_id" of
-           String, parameter "ftp_url" of String, parameter "genome_name" of
-           String, parameter "workspace_name" of String, parameter "source"
-           of String, parameter "taxon_wsname" of String, parameter
-           "taxon_reference" of String, parameter "release" of String,
+           reference taxons are : ReferenceTaxons taxon_id - if defined, will
+           try to link the Genome to the specified taxonomy id in lieu of
+           performing the lookup during upload release - Release or version
+           number of the data per example Ensembl has numbered releases of
+           all their data: Release 31 genetic_code - Genetic code of
+           organism. Overwrites determined GC from taxon object
+           scientific_name - will be used to set the scientific name of the
+           genome and link to a taxon generate_missing_genes - If the file
+           has CDS or mRNA with no corresponding gene, generate a spoofed
+           gene. Off by default existing_assembly_ref - a KBase assembly upa,
+           to associate the genome with. Avoids saving a new assembly when
+           specified.) -> structure: parameter "fasta_file" of type "File" ->
+           structure: parameter "path" of String, parameter "shock_id" of
+           String, parameter "ftp_url" of String, parameter "gff_file" of
+           type "File" -> structure: parameter "path" of String, parameter
+           "shock_id" of String, parameter "ftp_url" of String, parameter
+           "genome_name" of String, parameter "workspace_name" of String,
+           parameter "source" of String, parameter "taxon_wsname" of String,
+           parameter "taxon_id" of String, parameter "release" of String,
            parameter "genetic_code" of Long, parameter "scientific_name" of
            String, parameter "metadata" of type "usermeta" -> mapping from
            String to String, parameter "generate_missing_genes" of type
-           "boolean" (A boolean - 0 for false, 1 for true. @range (0, 1))
+           "boolean" (A boolean - 0 for false, 1 for true. @range (0, 1)),
+           parameter "existing_assembly_ref" of String
         :returns: instance of unspecified object
         """
         return self._client.run_job('GenomeFileUtil.fasta_gff_to_genome_json',
+                                    [params], self._service_ver, context)
+
+    def fasta_gff_to_metagenome(self, params, context=None):
+        """
+        :param params: instance of type "FastaGFFToMetagenomeParams"
+           (genome_name - becomes the name of the object workspace_name - the
+           name of the workspace it gets saved to. source - Source of the
+           file typically something like RefSeq or Ensembl taxon_ws_name -
+           where the reference taxons are : ReferenceTaxons taxon_id - if
+           defined, will try to link the Genome to the specified taxonomy id
+           in lieu of performing the lookup during upload release - Release
+           or version number of the data per example Ensembl has numbered
+           releases of all their data: Release 31 genetic_code - Genetic code
+           of organism. Overwrites determined GC from taxon object
+           scientific_name - will be used to set the scientific name of the
+           genome and link to a taxon generate_missing_genes - If the file
+           has CDS or mRNA with no corresponding gene, generate a spoofed
+           gene. Off by default existing_assembly_ref - a KBase assembly upa,
+           to associate the metagenome with. Avoids saving a new assembly
+           when specified.) -> structure: parameter "fasta_file" of type
+           "File" -> structure: parameter "path" of String, parameter
+           "shock_id" of String, parameter "ftp_url" of String, parameter
+           "gff_file" of type "File" -> structure: parameter "path" of
+           String, parameter "shock_id" of String, parameter "ftp_url" of
+           String, parameter "genome_name" of String, parameter
+           "workspace_name" of String, parameter "source" of String,
+           parameter "metadata" of type "usermeta" -> mapping from String to
+           String, parameter "generate_missing_genes" of type "boolean" (A
+           boolean - 0 for false, 1 for true. @range (0, 1)), parameter
+           "existing_assembly_ref" of String
+        :returns: instance of type "MetagenomeSaveResult" -> structure:
+           parameter "metagenome_ref" of String
+        """
+        return self._client.run_job('GenomeFileUtil.fasta_gff_to_metagenome',
                                     [params], self._service_ver, context)
 
     def save_one_genome(self, params, context=None):
         """
         :param params: instance of type "SaveOneGenomeParams" -> structure:
            parameter "workspace" of String, parameter "name" of String,
-           parameter "data" of type "Genome" (Genome object holds much of the
-           data relevant for a genome in KBase Genome publications should be
-           papers about the genome Should the Genome object contain a list of
-           contig_ids too? Source: allowed entries RefSeq, Ensembl,
-           Phytozome, RAST, Prokka, User_upload #allowed entries RefSeq,
-           Ensembl, Phytozome, RAST, Prokka, User_upload controlled
-           vocabulary managed by API Domain is a controlled vocabulary
-           Warnings : mostly controlled vocab but also allow for unstructured
-           Genome_tiers : controlled vocabulary (based on ap input and API
-           checked) Allowed values: #Representative, Reference, ExternalDB,
-           User Examples Tiers: All phytozome - Representative and ExternalDB
-           Phytozome flagship genomes - Reference, Representative and
-           ExternalDB Ensembl - Representative and ExternalDB RefSeq
-           Reference - Reference, Representative and ExternalDB RefSeq
-           Representative - Representative and ExternalDB RefSeq Latest or
-           All Assemblies folder - ExternalDB User Data - User tagged Example
-           Sources: RefSeq, Ensembl, Phytozome, Microcosm, User, RAST,
-           Prokka, (other annotators) @optional warnings contig_lengths
-           contig_ids source_id taxonomy publications @optional
-           ontology_events ontologies_present non_coding_features mrnas
-           @optional genbank_handle_ref gff_handle_ref
+           parameter "data" of type "Genome" (Genome type -- annotated and
+           assembled genome data. Field descriptions: id - string - KBase
+           legacy data ID scientific_name - string - human readable species
+           name domain - string - human readable phylogenetic domain name
+           (eg. "Bacteria") warnings - list of string - genome-level warnings
+           generated in the annotation process genome_tiers - list of string
+           - controlled vocabulary (based on app input and checked by
+           GenomeFileUtil) A list of labels describing the data source for
+           this genome. Allowed values - Representative, Reference,
+           ExternalDB, User Tier assignments based on genome source: * All
+           phytozome - Representative and ExternalDB * Phytozome flagship
+           genomes - Reference, Representative and ExternalDB * Ensembl -
+           Representative and ExternalDB * RefSeq Reference - Reference,
+           Representative and ExternalDB * RefSeq Representative -
+           Representative and ExternalDB * RefSeq Latest or All Assemblies
+           folder - ExternalDB * User Data - User tagged feature_counts - map
+           of string to integer - total counts of each type of feature keys
+           are a controlled vocabulary of - "CDS", "gene", "misc_feature",
+           "misc_recomb", "mobile_element", "ncRNA" - 72,
+           "non_coding_features", "non_coding_genes",
+           "protein_encoding_gene", "rRNA", "rep_origin", "repeat_region",
+           "tRNA" genetic_code - int - An NCBI-assigned taxonomic category
+           for the organism See here -
+           https://www.ncbi.nlm.nih.gov/Taxonomy/Utils/wprintgc.cgi dna_size
+           - integer - total number of nucleotides num_contigs - integer -
+           total number of contigs in the genome molecule_type - string -
+           controlled vocab - the type of molecule sequenced Possible values
+           are "Unknown", "DNA", "RNA", "genomic DNA", "genomic RNA", "mRNA",
+           "tRNA", "rRNA", "other RNA", "other DNA", "transcribed RNA",
+           "viral cRNA", "unassigned DNA", "unassigned RNA" contig_lengths -
+           list of int - nucleotide length of each contig in the genome
+           Indexes in this list correspond to indexes in the `contig_ids`
+           list. contig_ids - list of str - external database identifiers for
+           each contig (eg. "NC_000913.3") source - str - controlled vocab -
+           descriptor of where this data came from (eg. "RefSeq") Allowed
+           entries RefSeq, Ensembl, Phytozome, RAST, Prokka, User_upload
+           source_id - string - identifier of this genome from the source
+           database (eg. the RefSeq ID such as "NC_000913") md5 - string -
+           checksum of the underlying assembly sequence taxonomy - string -
+           semicolon-delimited taxonomy lineage, in order of parent to child
+           taxon_assignments - mapping of taxonomy namespace to taxon ID.
+           example - {"ncbi": "286", "gtdb": "s__staphylococcus_devriesei"}
+           gc_content - float - ratio of GC count to AT in the genome
+           publications - tuple of (pubmedid, source, title, web_addr, year,
+           authors, journal). See typedef above. ontology_events - A record
+           of the service and method used for a set of ontology assignments
+           on the genome. ontologies_present - a mapping of ontology source
+           id (eg. "GO") to a mapping of term IDs (eg "GO:16209") to term
+           names (eg. "histidine biosynthetic process"). features - array of
+           Feature - protein coding genes (see the separate Feature spec)
+           cdss - array of protein-coding sequences mrnas - array of
+           transcribed messenger RNA sequences (equal to cdss plus 5' and 3'
+           UTRs) non_coding_features - array of features that does not
+           include mRNA, CDS, and protein-encoding genes assembly_ref -
+           workspace reference to an assembly object from which this
+           annotated genome was derived. taxon_ref - workspace reference to a
+           taxon object that classifies the species or strain of this genome.
+           genbank_handle_ref - file server handle reference to the source
+           genbank file for this genome. gff_handle_ref - file server handle
+           reference to the source GFF file for this genome.
+           external_source_origination_date - TODO look at GFU for this
+           release - string - User-supplied release or version of the source
+           data. This most likely will come from an input field in the import
+           app. original_source_file_name - filename from which this genome
+           was derived (eg. genbank or gff filename). notes - TODO
+           quality_scores - TODO suspect - bool - flag of whether this
+           annotation is problematic due to some warning genome_type - string
+           - controlled vocab - One of "draft isolate", "finished isolate",
+           "mag", "sag", "virus", "plasmid", "construct" Features vs. coding
+           sequences: a feature is a sequence in the DNA that codes for a
+           protein, including non-transcribed introns. A coding sequence
+           (stored as `cdss`) includes **only** the sections of the feature
+           that codes for a protein, minus introns and UTRs. @optional
+           warnings contig_lengths contig_ids source_id taxonomy publications
+           @optional ontology_events ontologies_present non_coding_features
+           mrnas genome_type @optional genbank_handle_ref gff_handle_ref
            external_source_origination_date @optional release
            original_source_file_name notes quality_scores suspect
-           assembly_ref @metadata ws gc_content as GC content @metadata ws
-           taxonomy as Taxonomy @metadata ws md5 as MD5 @metadata ws dna_size
-           as Size @metadata ws genetic_code as Genetic code @metadata ws
-           domain as Domain @metadata ws source_id as Source ID @metadata ws
-           source as Source @metadata ws scientific_name as Name @metadata ws
-           length(features) as Number of Protein Encoding Genes @metadata ws
-           length(cdss) as Number of CDS @metadata ws assembly_ref as
-           Assembly Object @metadata ws num_contigs as Number contigs
-           @metadata ws length(warnings) as Number of Genome Level Warnings
-           @metadata ws suspect as Suspect Genome) -> structure: parameter
-           "id" of type "Genome_id" (KBase genome ID @id kb), parameter
-           "scientific_name" of String, parameter "domain" of String,
-           parameter "warnings" of list of String, parameter "genome_tiers"
-           of list of String, parameter "feature_counts" of mapping from
-           String to Long, parameter "genetic_code" of Long, parameter
-           "dna_size" of Long, parameter "num_contigs" of Long, parameter
-           "molecule_type" of String, parameter "contig_lengths" of list of
-           Long, parameter "contig_ids" of list of String, parameter "source"
-           of String, parameter "source_id" of type "source_id" (Reference to
-           a source_id @id external), parameter "md5" of String, parameter
-           "taxonomy" of String, parameter "gc_content" of Double, parameter
-           "publications" of list of type "publication" (Structure for a
-           publication (float pubmedid string source (ex. Pubmed) string
-           title string web address string  publication year string authors
-           string journal)) -> tuple of size 7: parameter "pubmedid" of
-           Double, parameter "source" of String, parameter "title" of String,
-           parameter "url" of String, parameter "year" of String, parameter
-           "authors" of String, parameter "journal" of String, parameter
-           "ontology_events" of list of type "Ontology_event" (@optional
-           ontology_ref method_version eco) -> structure: parameter "id" of
-           String, parameter "ontology_ref" of type "Ontology_ref" (Reference
-           to a ontology object @id ws KBaseOntology.OntologyDictionary),
-           parameter "method" of String, parameter "method_version" of
-           String, parameter "timestamp" of String, parameter "eco" of
-           String, parameter "ontologies_present" of mapping from String to
-           mapping from String to String, parameter "features" of list of
-           type "Feature" (Structure for a single CDS encoding ?gene? of a
-           genome ONLY PUT GENES THAT HAVE A CORRESPONDING CDS IN THIS ARRAY
-           NOTE: Sequence is optional. Ideally we can keep it in here, but
-           Recognize due to space constraints another solution may be needed.
-           We may want to add additional fields for other CDM functions
-           (e.g., atomic regulons, coexpressed fids, co_occurring fids,...)
+           assembly_ref @optional taxon_ref taxon_assignments @metadata ws
+           gc_content as GC content @metadata ws taxonomy as Taxonomy
+           @metadata ws md5 as MD5 @metadata ws dna_size as Size @metadata ws
+           genetic_code as Genetic code @metadata ws domain as Domain
+           @metadata ws source_id as Source ID @metadata ws source as Source
+           @metadata ws scientific_name as Name @metadata ws genome_type as
+           Type @metadata ws length(features) as Number of Protein Encoding
+           Genes @metadata ws length(cdss) as Number of CDS @metadata ws
+           assembly_ref as Assembly Object @metadata ws num_contigs as Number
+           contigs @metadata ws length(warnings) as Number of Genome Level
+           Warnings @metadata ws suspect as Suspect Genome) -> structure:
+           parameter "id" of type "Genome_id" (KBase legacy data ID @id kb),
+           parameter "scientific_name" of String, parameter "domain" of
+           String, parameter "warnings" of list of String, parameter
+           "genome_tiers" of list of String, parameter "feature_counts" of
+           mapping from String to Long, parameter "genetic_code" of Long,
+           parameter "dna_size" of Long, parameter "num_contigs" of Long,
+           parameter "molecule_type" of String, parameter "contig_lengths" of
+           list of Long, parameter "contig_ids" of list of String, parameter
+           "source" of String, parameter "source_id" of type "source_id"
+           (Reference to a source_id @id external), parameter "md5" of
+           String, parameter "taxonomy" of String, parameter
+           "taxon_assignments" of mapping from String to String, parameter
+           "gc_content" of Double, parameter "publications" of list of type
+           "publication" (Structure for a publication Elements: (0) pubmedid
+           - float (1) source - string - (ex. Pubmed) (2) title - string (3)
+           string web address - string (4) publication year - string (5)
+           authors - string (6) journal - string) -> tuple of size 7:
+           parameter "pubmedid" of Double, parameter "source" of String,
+           parameter "title" of String, parameter "url" of String, parameter
+           "year" of String, parameter "authors" of String, parameter
+           "journal" of String, parameter "ontology_events" of list of type
+           "Ontology_event" (@optional ontology_ref method_version eco) ->
+           structure: parameter "id" of String, parameter "ontology_ref" of
+           type "Ontology_ref" (Reference to a ontology object @id ws
+           KBaseOntology.OntologyDictionary), parameter "method" of String,
+           parameter "method_version" of String, parameter "timestamp" of
+           String, parameter "eco" of String, parameter "ontologies_present"
+           of mapping from String to mapping from String to String, parameter
+           "features" of list of type "Feature" (Structure for a single CDS
+           encoding “gene” of a genome ONLY PUT GENES THAT HAVE A
+           CORRESPONDING CDS IN THIS ARRAY NOTE: Sequence is optional.
+           Ideally we can keep it in here, but Recognize due to space
+           constraints another solution may be needed. We may want to add
+           additional fields for other CDM functions (e.g., atomic regulons,
+           coexpressed fids, co_occurring fids,...)
            protein_translation_length and protein_translation are for longest
            coded protein (representative protein for splice variants) NOTE:
            New Aliases field definitely breaks compatibility. As Does
@@ -337,18 +467,20 @@ class GenomeFileUtil(object):
            String, parameter "mrnas" of list of String, parameter "children"
            of list of String, parameter "flags" of list of String, parameter
            "warnings" of list of String, parameter "inference_data" of list
-           of type "InferenceInfo" (category;#Maybe a controlled vocabulary
-           type;#Maybe a controlled vocabulary) -> structure: parameter
-           "category" of String, parameter "type" of String, parameter
-           "evidence" of String, parameter "dna_sequence" of String,
-           parameter "dna_sequence_length" of Long, parameter "aliases" of
-           list of tuple of size 2: parameter "fieldname" of String,
-           parameter "alias" of String, parameter "db_xrefs" of list of tuple
-           of size 2: parameter "db_source" of String, parameter
-           "db_identifier" of String, parameter "non_coding_features" of list
-           of type "NonCodingFeature" (Structure for a single feature that is
-           NOT one of the following: Protein encoding gene (gene that has a
-           corresponding CDS) mRNA CDS Note pseudo-genes and Non protein
+           of type "InferenceInfo" (Type spec for the "InferenceInfo" object.
+           TODO docs Found in the `inference_data` fields in mRNAs and CDSs
+           Fields: category - string - TODO type - string - TODO evidence -
+           string - TODO) -> structure: parameter "category" of String,
+           parameter "type" of String, parameter "evidence" of String,
+           parameter "dna_sequence" of String, parameter
+           "dna_sequence_length" of Long, parameter "aliases" of list of
+           tuple of size 2: parameter "fieldname" of String, parameter
+           "alias" of String, parameter "db_xrefs" of list of tuple of size
+           2: parameter "db_source" of String, parameter "db_identifier" of
+           String, parameter "non_coding_features" of list of type
+           "NonCodingFeature" (Structure for a single feature that is NOT one
+           of the following: - Protein encoding gene (gene that has a
+           corresponding CDS) - mRNA - CDS Note pseudo-genes and Non protein
            encoding genes are put into this flags are flag fields in GenBank
            format. This will be a controlled vocabulary. Initially Acceptable
            values are pseudo, ribosomal_slippage, and trans_splicing Md5 is
@@ -365,24 +497,78 @@ class GenomeFileUtil(object):
            "md5" of String, parameter "parent_gene" of String, parameter
            "children" of list of String, parameter "flags" of list of String,
            parameter "warnings" of list of String, parameter "inference_data"
-           of list of type "InferenceInfo" (category;#Maybe a controlled
-           vocabulary type;#Maybe a controlled vocabulary) -> structure:
-           parameter "category" of String, parameter "type" of String,
-           parameter "evidence" of String, parameter "dna_sequence" of
-           String, parameter "dna_sequence_length" of Long, parameter
-           "aliases" of list of tuple of size 2: parameter "fieldname" of
-           String, parameter "alias" of String, parameter "db_xrefs" of list
-           of tuple of size 2: parameter "db_source" of String, parameter
-           "db_identifier" of String, parameter "cdss" of list of type "CDS"
-           (Structure for a single feature CDS flags are flag fields in
-           GenBank format. This will be a controlled vocabulary. Initially
-           Acceptable values are pseudo, ribosomal_slippage, and
-           trans_splicing Md5 is the md5 of dna_sequence. @optional
-           parent_gene parent_mrna functions ontology_terms note flags
-           warnings @optional inference_data dna_sequence aliases db_xrefs
-           functional_descriptions) -> structure: parameter "id" of type
-           "cds_id" (KBase CDS ID @id external), parameter "location" of list
-           of tuple of size 4: type "Contig_id" (ContigSet contig ID @id
+           of list of type "InferenceInfo" (Type spec for the "InferenceInfo"
+           object. TODO docs Found in the `inference_data` fields in mRNAs
+           and CDSs Fields: category - string - TODO type - string - TODO
+           evidence - string - TODO) -> structure: parameter "category" of
+           String, parameter "type" of String, parameter "evidence" of
+           String, parameter "dna_sequence" of String, parameter
+           "dna_sequence_length" of Long, parameter "aliases" of list of
+           tuple of size 2: parameter "fieldname" of String, parameter
+           "alias" of String, parameter "db_xrefs" of list of tuple of size
+           2: parameter "db_source" of String, parameter "db_identifier" of
+           String, parameter "cdss" of list of type "CDS" (Structure for a
+           single coding sequence. Coding sequences are the sections of a
+           feature's sequence that are translated to a protein (minus introns
+           and UTRs). Fields: id - string - identifier of the coding
+           sequence, such as "b0001_CDS_1" location - list<tuple<string, int,
+           string, int>> - list of locations from where this sequence
+           originates in the original assembly. Each sub-sequence in the list
+           constitutes a section of the resulting CDS. The first element in
+           the tuple corresponds to the "contig_id", such as "NC_000913.3".
+           The second element in the tuple is an index in the contig of where
+           the sequence starts. The third element is either a plus or minus
+           sign indicating whether it is on the 5' to 3' leading strand ("+")
+           or on the 3' to 5' lagging strand ("-"). The last element is the
+           length of the sub-sequence. For a location on the leading strand
+           (denoted by "+"), the index is of the leftmost base, and the
+           sequence extends to the right. For a location on the lagging
+           strand (denoted by "-"), the index is of the rightmost base, and
+           the sequence extends to the left. NOTE: the last element in each
+           tuple is the *length* of each sub-sequence. If you have a location
+           such as ("xyz", 100, "+", 50), then your sequence will go from
+           index 100 to index 149 (this has a length of 50). It *does not* go
+           from index 100 to index 150, as that would have a length of 51.
+           Likewise, if you have the location ("xyz", 100, "-", 50), then the
+           sequence extends from 100 down to 51, which has a length of 50
+           bases. It does not go from index 100 to 50, as that would have a
+           length of 51. md5 - string - md5 of the dna sequence - TODO
+           clarification protein_md5 - string - hash of the protein sequence
+           that this CDS encodes parent_gene - string - gene (feature) from
+           which this CDS comes from, including introns and UTRs that have
+           been removed to create this CDS. parent_mrna - string - mRNA
+           sequence from which this sequence is derived, including UTRs but
+           not introns. note - string - TODO functions - list<string> - list
+           of protein products or chemical processes that this sequence
+           creates, facilitates, or influences. functional_descriptions -
+           list<string> - TODO list of protein products or chemical processes
+           that sequence creates, facilitates, or influences. ontology_terms
+           - mapping<string, mapping<string, list<int>>> - a mapping of
+           ontology source id (eg. "GO") to a mapping of term IDs (eg
+           "GO:16209") to a list of indexes into the ontology_events data
+           (found in the top level of the genome object). The index into an
+           ontology event indicates what service and method created this term
+           assignment. flags - list<string>  - (controlled vocab) fields from
+           the genbank source. A common example is "pseudo" for pseudo-genes
+           that do not encode proteins, which shows up as "/pseudo" in the
+           genbank. Values can be: "pseudo", "ribosomal_slippage",
+           "trans_splicing" warnings - list<string> - TODO inference_data -
+           list<InferenceInfo> - TODO protein_translation - string - amino
+           acid sequence that this CDS gets translated into.
+           protein_translation_length - int - length of the above aliases -
+           list<(string, string)> - alternative list of names or identifiers
+           eg: [["gene", "thrA"], ["locus_tag", "b0002"]] db_xrefs -
+           list<(string, string)> - Identifiers from other databases
+           (database cross-references) The first string is the database name,
+           the second is the database identifier. eg: [["ASAP",
+           "ABE-0000006"], ["EcoGene", "EG11277"]] dna_sequence - string -
+           sequence of exons from the genome that constitute this protein
+           encoding sequence. dna_sequence_length - int - length of the above
+           @optional parent_gene parent_mrna functions ontology_terms note
+           flags warnings @optional inference_data dna_sequence aliases
+           db_xrefs functional_descriptions) -> structure: parameter "id" of
+           type "cds_id" (KBase CDS ID @id external), parameter "location" of
+           list of tuple of size 4: type "Contig_id" (ContigSet contig ID @id
            external), Long, String, Long, parameter "md5" of String,
            parameter "protein_md5" of String, parameter "parent_gene" of type
            "Feature_id" (KBase Feature ID @id external), parameter
@@ -392,20 +578,69 @@ class GenomeFileUtil(object):
            parameter "ontology_terms" of mapping from String to mapping from
            String to list of Long, parameter "flags" of list of String,
            parameter "warnings" of list of String, parameter "inference_data"
-           of list of type "InferenceInfo" (category;#Maybe a controlled
-           vocabulary type;#Maybe a controlled vocabulary) -> structure:
-           parameter "category" of String, parameter "type" of String,
-           parameter "evidence" of String, parameter "protein_translation" of
-           String, parameter "protein_translation_length" of Long, parameter
-           "aliases" of list of tuple of size 2: parameter "fieldname" of
-           String, parameter "alias" of String, parameter "db_xrefs" of list
-           of tuple of size 2: parameter "db_source" of String, parameter
-           "db_identifier" of String, parameter "dna_sequence" of String,
-           parameter "dna_sequence_length" of Long, parameter "mrnas" of list
-           of type "mRNA" (Structure for a single feature mRNA flags are flag
-           fields in GenBank format. This will be a controlled vocabulary.
-           Initially Acceptable values are pseudo, ribosomal_slippage, and
-           trans_splicing Md5 is the md5 of dna_sequence. @optional
+           of list of type "InferenceInfo" (Type spec for the "InferenceInfo"
+           object. TODO docs Found in the `inference_data` fields in mRNAs
+           and CDSs Fields: category - string - TODO type - string - TODO
+           evidence - string - TODO) -> structure: parameter "category" of
+           String, parameter "type" of String, parameter "evidence" of
+           String, parameter "protein_translation" of String, parameter
+           "protein_translation_length" of Long, parameter "aliases" of list
+           of tuple of size 2: parameter "fieldname" of String, parameter
+           "alias" of String, parameter "db_xrefs" of list of tuple of size
+           2: parameter "db_source" of String, parameter "db_identifier" of
+           String, parameter "dna_sequence" of String, parameter
+           "dna_sequence_length" of Long, parameter "mrnas" of list of type
+           "mRNA" (The mRNA is the transcribed sequence from the original
+           feature, minus the introns, but including the UTRs. Fields: id -
+           string - identifying string for the mRNA location -
+           list<tuple<string, int, string, int>> - list of locations from
+           where this sequence originates in the original assembly. Each
+           sub-sequence in the list constitutes a section of the resulting
+           CDS. The first element in the tuple corresponds to the
+           "contig_id", such as "NC_000913.3". The second element in the
+           tuple is an index in the contig of where the sequence starts. The
+           third element is either a plus or minus sign indicating whether it
+           is on the 5' to 3' leading strand ("+") or on the 3' to 5' lagging
+           strand ("-"). The last element is the length of the sub-sequence.
+           For a location on the leading strand (denoted by "+"), the index
+           is of the leftmost base, and the sequence extends to the right.
+           For a location on the lagging strand (denoted by "-"), the index
+           is of the rightmost base, and the sequence extends to the left.
+           NOTE: the last element in each tuple is the *length* of each
+           sub-sequence. If you have a location such as ("xyz", 100, "+",
+           50), then your sequence will go from index 100 to index 149 (this
+           has a length of 50). It *does not* go from index 100 to index 150,
+           as that would have a length of 51. Likewise, if you have the
+           location ("xyz", 100, "-", 50), then the sequence extends from 100
+           down to 51, which has a length of 50 bases. It does not go from
+           index 100 to 50, as that would have a length of 51. md5 - string -
+           md5 of the dna sequence - TODO clarification parent_gene -
+           Feature_id - corresponding feature for this sequence, including
+           introns and UTRs cds - string - corresponding coding sequence for
+           this mRNA (the sequence minus UTRs) dna_sequence - string -
+           sequence of UTRs and exons from the genome that constitute this
+           mRNA dna_sequence_length - int - length of the above note - string
+           - TODO functions - list<string> - TODO list of protein products or
+           chemical processes that sequence creates, facilitates, or
+           influences. functional_descriptions - list<string> - TODO list of
+           protein products or chemical processes that sequence creates,
+           facilitates, or influences. ontology_terms - mapping<string,
+           mapping<string, list<int>>> - a mapping of ontology source id (eg.
+           "GO") to a mapping of term IDs (eg "GO:16209") to a list of
+           indexes into the ontology_events data (found in the top level of
+           the genome object). The index into an ontology event indicates
+           what service and method created this term assignment. flags -
+           list<string> - controlled vocab - fields from the genbank source.
+           A common example is "pseudo" for pseudo-genes that do not encode
+           proteins, which shows up as "/pseudo" in the genbank. Values can
+           be: "pseudo", "ribosomal_slippage", "trans_splicing" warnings -
+           list<string> - TODO inference_data - list<InferenceInfo> - TODO
+           aliases - list<(string, string)> - alternative list of names or
+           identifiers eg: [["gene", "thrA"], ["locus_tag", "b0002"]]
+           db_xrefs - list<(string, string)> - Identifiers from other
+           databases (database cross-references). The first string is the
+           database name, the second is the database identifier. eg:
+           [["ASAP", "ABE-0000006"], ["EcoGene", "EG11277"]] @optional
            parent_gene cds functions ontology_terms note flags warnings
            @optional inference_data dna_sequence aliases db_xrefs
            functional_descriptions) -> structure: parameter "id" of type
@@ -421,33 +656,38 @@ class GenomeFileUtil(object):
            "ontology_terms" of mapping from String to mapping from String to
            list of Long, parameter "flags" of list of String, parameter
            "warnings" of list of String, parameter "inference_data" of list
-           of type "InferenceInfo" (category;#Maybe a controlled vocabulary
-           type;#Maybe a controlled vocabulary) -> structure: parameter
-           "category" of String, parameter "type" of String, parameter
-           "evidence" of String, parameter "aliases" of list of tuple of size
-           2: parameter "fieldname" of String, parameter "alias" of String,
-           parameter "db_xrefs" of list of tuple of size 2: parameter
-           "db_source" of String, parameter "db_identifier" of String,
-           parameter "assembly_ref" of type "Assembly_ref" (Reference to an
-           Assembly object in the workspace @id ws
-           KBaseGenomeAnnotations.Assembly), parameter "taxon_ref" of type
-           "Taxon_ref" (Reference to a taxon object @id ws
-           KBaseGenomeAnnotations.Taxon), parameter "genbank_handle_ref" of
-           type "genbank_handle_ref" (Reference to a handle to the Genbank
-           file on shock @id handle), parameter "gff_handle_ref" of type
-           "gff_handle_ref" (Reference to a handle to the GFF file on shock
-           @id handle), parameter "external_source_origination_date" of
-           String, parameter "release" of String, parameter
-           "original_source_file_name" of String, parameter "notes" of
-           String, parameter "quality_scores" of list of type
-           "GenomeQualityScore" (Score_interpretation : fraction_complete -
-           controlled vocabulary managed by API @optional method_report_ref
-           method_version) -> structure: parameter "method" of String,
-           parameter "method_report_ref" of type "Method_report_ref"
-           (Reference to a report object @id ws KBaseReport.Report),
-           parameter "method_version" of String, parameter "score" of String,
-           parameter "score_interpretation" of String, parameter "timestamp"
-           of String, parameter "suspect" of type "Bool", parameter "hidden"
+           of type "InferenceInfo" (Type spec for the "InferenceInfo" object.
+           TODO docs Found in the `inference_data` fields in mRNAs and CDSs
+           Fields: category - string - TODO type - string - TODO evidence -
+           string - TODO) -> structure: parameter "category" of String,
+           parameter "type" of String, parameter "evidence" of String,
+           parameter "aliases" of list of tuple of size 2: parameter
+           "fieldname" of String, parameter "alias" of String, parameter
+           "db_xrefs" of list of tuple of size 2: parameter "db_source" of
+           String, parameter "db_identifier" of String, parameter
+           "assembly_ref" of type "Assembly_ref" (Reference to an Assembly
+           object in the workspace @id ws KBaseGenomeAnnotations.Assembly),
+           parameter "taxon_ref" of type "Taxon_ref" (Reference to a taxon
+           object @id ws KBaseGenomeAnnotations.Taxon), parameter
+           "genbank_handle_ref" of type "genbank_handle_ref" (Reference to a
+           handle to the Genbank file on shock @id handle), parameter
+           "gff_handle_ref" of type "gff_handle_ref" (Reference to a handle
+           to the GFF file on shock @id handle), parameter
+           "external_source_origination_date" of String, parameter "release"
+           of String, parameter "original_source_file_name" of String,
+           parameter "notes" of String, parameter "quality_scores" of list of
+           type "GenomeQualityScore" (Genome quality score Fields: method -
+           string - TODO method_report_ref - string - TODO method_version -
+           string - TODO score: string - TODO score_interpretation - string -
+           TODO timestamp - string - TODO Score_interpretation -
+           fraction_complete - controlled vocabulary managed by API @optional
+           method_report_ref method_version) -> structure: parameter "method"
+           of String, parameter "method_report_ref" of type
+           "Method_report_ref" (Reference to a report object @id ws
+           KBaseReport.Report), parameter "method_version" of String,
+           parameter "score" of String, parameter "score_interpretation" of
+           String, parameter "timestamp" of String, parameter "suspect" of
+           type "Bool", parameter "genome_type" of String, parameter "hidden"
            of type "boolean" (A boolean - 0 for false, 1 for true. @range (0,
            1)), parameter "upgrade" of type "boolean" (A boolean - 0 for
            false, 1 for true. @range (0, 1))
@@ -498,6 +738,89 @@ class GenomeFileUtil(object):
            the user.) -> mapping from String to String
         """
         return self._client.run_job('GenomeFileUtil.save_one_genome',
+                                    [params], self._service_ver, context)
+
+    def ws_obj_gff_to_genome(self, params, context=None):
+        """
+        This function takes in a workspace object of type KBaseGenomes.Genome or KBaseGenomeAnnotations.Assembly and a gff file and produces a KBaseGenomes.Genome reanotated according to the the input gff file.
+        :param params: instance of type "WsObjGFFToGenomeParams" (gff_file -
+           object containing path to gff_file ws_ref - input Assembly or
+           Genome reference genome_name - becomes the name of the object
+           workspace_name - the name of the workspace it gets saved to.
+           source - Source of the file typically something like RefSeq or
+           Ensembl taxon_ws_name - where the reference taxons are :
+           ReferenceTaxons taxon_id - if defined, will try to link the Genome
+           to the specified taxonomy id in lieu of performing the lookup
+           during upload release - Release or version number of the data per
+           example Ensembl has numbered releases of all their data: Release
+           31 genetic_code - Genetic code of organism. Overwrites determined
+           GC from taxon object scientific_name - will be used to set the
+           scientific name of the genome and link to a taxon metadata - any
+           user input metadata generate_missing_genes - If the file has CDS
+           or mRNA with no corresponding gene, generate a spoofed gene. Off
+           by default) -> structure: parameter "ws_ref" of String, parameter
+           "gff_file" of type "File" -> structure: parameter "path" of
+           String, parameter "shock_id" of String, parameter "ftp_url" of
+           String, parameter "genome_name" of String, parameter
+           "workspace_name" of String, parameter "source" of String,
+           parameter "taxon_wsname" of String, parameter "taxon_id" of
+           String, parameter "release" of String, parameter "genetic_code" of
+           Long, parameter "scientific_name" of String, parameter "metadata"
+           of type "usermeta" -> mapping from String to String, parameter
+           "generate_missing_genes" of type "boolean" (A boolean - 0 for
+           false, 1 for true. @range (0, 1))
+        :returns: instance of type "GenomeSaveResult" -> structure: parameter
+           "genome_ref" of String
+        """
+        return self._client.run_job('GenomeFileUtil.ws_obj_gff_to_genome',
+                                    [params], self._service_ver, context)
+
+    def ws_obj_gff_to_metagenome(self, params, context=None):
+        """
+        This function takes in a workspace object of type KBaseMetagenomes.AnnotatedMetagenomeAssembly or KBaseGenomeAnnotations.Assembly and a gff file and produces a KBaseMetagenomes.AnnotatedMetagenomeAssembly reanotated according to the the input gff file.
+        :param params: instance of type "WsObjGFFToMetagenomeParams"
+           (gff_file - object containing path to gff_file ws_ref - input
+           Assembly or AnnotatedMetagenomeAssembly reference genome_name -
+           becomes the name of the object workspace_name - the name of the
+           workspace it gets saved to. source - Source of the file typically
+           something like RefSeq or Ensembl genetic_code - Genetic code of
+           organism. Overwrites determined GC from taxon object metadata -
+           any user input metadata generate_missing_genes - If the file has
+           CDS or mRNA with no corresponding gene, generate a spoofed gene.
+           Off by default) -> structure: parameter "ws_ref" of String,
+           parameter "gff_file" of type "File" -> structure: parameter "path"
+           of String, parameter "shock_id" of String, parameter "ftp_url" of
+           String, parameter "genome_name" of String, parameter
+           "workspace_name" of String, parameter "source" of String,
+           parameter "metadata" of type "usermeta" -> mapping from String to
+           String, parameter "generate_missing_genes" of type "boolean" (A
+           boolean - 0 for false, 1 for true. @range (0, 1))
+        :returns: instance of type "MetagenomeSaveResult" -> structure:
+           parameter "metagenome_ref" of String
+        """
+        return self._client.run_job('GenomeFileUtil.ws_obj_gff_to_metagenome',
+                                    [params], self._service_ver, context)
+
+    def update_taxon_assignments(self, params, context=None):
+        """
+        Add, replace, or remove taxon assignments for a Genome object.
+        :param params: instance of type "UpdateTaxonAssignmentsParams"
+           (Parameters for the update_taxon_assignments function. Fields:
+           workspace_id: a workspace UPA of a Genome object
+           taxon_assignments: an optional mapping of assignments to add or
+           replace. This will perform a merge on the existing assignments.
+           Any new assignments are added, while any existing assignments are
+           replaced. remove_assignments: an optional list of assignment names
+           to remove. @optional taxon_assignments remove_assignments) ->
+           structure: parameter "workspace_id" of Long, parameter "object_id"
+           of Long, parameter "taxon_assignments" of mapping from String to
+           String, parameter "remove_assignments" of list of String
+        :returns: instance of type "UpdateTaxonAssignmentsResult" (Result of
+           the update_taxon_assignments function. Fields: ws_obj_ref: a
+           workspace UPA of a Genome object) -> structure: parameter
+           "ws_obj_ref" of String
+        """
+        return self._client.run_job('GenomeFileUtil.update_taxon_assignments',
                                     [params], self._service_ver, context)
 
     def status(self, context=None):

--- a/lib/installed_clients/ReadsUtilsClient.py
+++ b/lib/installed_clients/ReadsUtilsClient.py
@@ -43,7 +43,7 @@ class ReadsUtils(object):
         """
         Validate a FASTQ file. The file extensions .fq, .fnq, and .fastq
         are accepted. Note that prior to validation the file will be altered in
-        place to remove blank lines if any exist.
+        place to remove blank lines and CRLF characters if any exist.
         :param params: instance of list of type "ValidateFASTQParams" (Input
            to the validateFASTQ function. Required parameters: file_path -
            the path to the file to validate. Optional parameters: interleaved

--- a/test/DifferentialExpressionMatrixSet_basic_test.py
+++ b/test/DifferentialExpressionMatrixSet_basic_test.py
@@ -1,26 +1,27 @@
 """Basic DifferentialExpressionMatrixSet tests."""
-from test.util import info_to_ref, make_fake_diff_exp_matrix
+from test.util import make_fake_diff_exp_matrix
 from typing import Any
 
 import pytest
 from installed_clients.baseclient import ServerError
 from SetAPI.SetAPIImpl import SetAPI
+from SetAPI.util import info_to_ref
 
 N_MATRICES = 3
 
 
 @pytest.fixture(scope="class")
-def test_data(ws_name: str, clients: dict[str, Any], genome_refs: list[str]) -> dict:
+def test_data(ws_id: int, clients: dict[str, Any], genome_refs: list[str]) -> dict:
     # Make fake diff exp matrices
     diff_exps_no_genome = [
-        make_fake_diff_exp_matrix(f"fake_mat_no_genome_{i}", ws_name, clients["ws"])
+        make_fake_diff_exp_matrix(f"fake_mat_no_genome_{i}", ws_id, clients["ws"])
         for i in range(N_MATRICES)
     ]
 
     diff_exps_genome = [
         make_fake_diff_exp_matrix(
             f"fake_mat_genome_{i}",
-            ws_name,
+            ws_id,
             clients["ws"],
             genome_ref=genome_refs[0],
         )
@@ -35,7 +36,7 @@ def test_data(ws_name: str, clients: dict[str, Any], genome_refs: list[str]) -> 
 
 
 def test_save_diff_exp_matrix_set(
-    test_data: dict, set_api_client: SetAPI, context: dict[str, str | list], ws_name: str
+    test_data: dict, set_api_client: SetAPI, context: dict[str, str | list], ws_id: int
 ) -> None:
     set_name = "test_diff_exp_matrix_set"
     set_items = [{"label": "foo", "ref": ref} for ref in test_data["diff_exps_genome"]]
@@ -43,7 +44,7 @@ def test_save_diff_exp_matrix_set(
     result = set_api_client.save_differential_expression_matrix_set_v1(
         context,
         {
-            "workspace": ws_name,
+            "workspace_id": ws_id,
             "output_object_name": set_name,
             "data": matrix_set,
         },
@@ -57,7 +58,7 @@ def test_save_diff_exp_matrix_set(
 
 
 def test_save_diff_exp_matrix_set_no_genome(
-    test_data: dict, set_api_client: SetAPI, context: dict[str, str | list], ws_name: str
+    test_data: dict, set_api_client: SetAPI, context: dict[str, str | list], ws_id: int
 ) -> None:
     set_name = "test_de_matrix_set_no_genome"
     set_items = [
@@ -67,7 +68,7 @@ def test_save_diff_exp_matrix_set_no_genome(
     result = set_api_client.save_differential_expression_matrix_set_v1(
         context,
         {
-            "workspace": ws_name,
+            "workspace_id": ws_id,
             "output_object_name": set_name,
             "data": matrix_set,
         },
@@ -85,7 +86,7 @@ def test_save_dem_set_mismatched_genomes(
     set_api_client: SetAPI,
     context: dict[str, str | list],
     clients: dict[str, Any],
-    ws_name: str,
+    ws_id: int,
 ) -> None:
     set_name = "dem_set_bad_genomes"
     dem_set = {
@@ -94,7 +95,7 @@ def test_save_dem_set_mismatched_genomes(
             {
                 "ref": make_fake_diff_exp_matrix(
                     "odd_dem",
-                    ws_name,
+                    ws_id,
                     clients["ws"],
                     genome_ref=test_data["genome_refs"][1],
                 ),
@@ -110,7 +111,7 @@ def test_save_dem_set_mismatched_genomes(
         set_api_client.save_differential_expression_matrix_set_v1(
             context,
             {
-                "workspace": ws_name,
+                "workspace_id": ws_id,
                 "output_object_name": set_name,
                 "data": dem_set,
             },
@@ -118,7 +119,7 @@ def test_save_dem_set_mismatched_genomes(
 
 
 def test_save_dem_set_no_data(
-    set_api_client: SetAPI, context: dict[str, str | list], ws_name: str
+    set_api_client: SetAPI, context: dict[str, str | list], ws_id: int
 ) -> None:
     with pytest.raises(
         ValueError,
@@ -127,7 +128,7 @@ def test_save_dem_set_no_data(
         set_api_client.save_differential_expression_matrix_set_v1(
             context,
             {
-                "workspace": ws_name,
+                "workspace_id": ws_id,
                 "output_object_name": "foo",
                 "data": None,
             },
@@ -135,7 +136,7 @@ def test_save_dem_set_no_data(
 
 
 def test_save_dem_set_no_dem(
-    set_api_client: SetAPI, context: dict[str, str | list], ws_name: str
+    set_api_client: SetAPI, context: dict[str, str | list], ws_id: int
 ) -> None:
     with pytest.raises(
         ValueError,
@@ -144,7 +145,7 @@ def test_save_dem_set_no_dem(
         set_api_client.save_differential_expression_matrix_set_v1(
             context,
             {
-                "workspace": ws_name,
+                "workspace_id": ws_id,
                 "output_object_name": "foo",
                 "data": {"items": []},
             },
@@ -152,7 +153,7 @@ def test_save_dem_set_no_dem(
 
 
 def test_get_dem_set(
-    test_data: dict, set_api_client: SetAPI, context: dict[str, str | list], ws_name: str
+    test_data: dict, set_api_client: SetAPI, context: dict[str, str | list], ws_id: int
 ) -> None:
     set_name = "test_expression_set"
     set_items = [
@@ -162,7 +163,7 @@ def test_get_dem_set(
     dem_set_ref = set_api_client.save_differential_expression_matrix_set_v1(
         context,
         {
-            "workspace": ws_name,
+            "workspace_id": ws_id,
             "output_object_name": set_name,
             "data": dem_set,
         },
@@ -194,7 +195,7 @@ def test_get_dem_set(
 
 
 def test_get_dem_set_ref_path(
-    test_data: dict, set_api_client: SetAPI, context: dict[str, str | list], ws_name: str
+    test_data: dict, set_api_client: SetAPI, context: dict[str, str | list], ws_id: int
 ) -> None:
     set_name = "test_diff_expression_set_ref_path"
     set_items = [
@@ -204,7 +205,7 @@ def test_get_dem_set_ref_path(
     dem_set_ref = set_api_client.save_differential_expression_matrix_set_v1(
         context,
         {
-            "workspace": ws_name,
+            "workspace_id": ws_id,
             "output_object_name": set_name,
             "data": dem_set,
         },
@@ -255,7 +256,9 @@ def test_get_dem_set_bad_path(
         )
 
 
-def test_get_dem_set_no_ref(set_api_client: SetAPI, context: dict[str, str | list]) -> None:
+def test_get_dem_set_no_ref(
+    set_api_client: SetAPI, context: dict[str, str | list]
+) -> None:
     with pytest.raises(
         ValueError,
         match='"ref" parameter field specifiying the DifferentialExpressionMatrix set is required',

--- a/test/FeatureSetSet_test.py
+++ b/test/FeatureSetSet_test.py
@@ -1,23 +1,22 @@
 """Basic FeatureSet tests."""
-from test.util import info_to_ref, make_fake_feature_set
+from test.util import make_fake_feature_set
 from typing import Any
 
 import pytest
 from installed_clients.baseclient import ServerError
 from SetAPI.SetAPIImpl import SetAPI
+from SetAPI.util import info_to_ref
 
 N_FEATURESET_REFS = 3
 
 
 @pytest.fixture(scope="module")
 def featureset_refs(
-    genome_refs: list[str], ws_name: str, clients: dict[str, Any]
+    genome_refs: list[str], ws_id: int, clients: dict[str, Any]
 ) -> list:
     # Make some fake feature sets
     return [
-        make_fake_feature_set(
-            f"feature_set_{i}", genome_refs[0], ws_name, clients["ws"]
-        )
+        make_fake_feature_set(f"feature_set_{i}", genome_refs[0], ws_id, clients["ws"])
         for i in range(N_FEATURESET_REFS)
     ]
 
@@ -26,7 +25,7 @@ def test_save_feature_set_set(
     featureset_refs: list,
     set_api_client: SetAPI,
     context: dict[str, str | list],
-    ws_name: str,
+    ws_id: int,
 ) -> None:
     set_name = "test_feature_set_set"
     set_items = [{"label": "foo", "ref": ref} for ref in featureset_refs]
@@ -34,7 +33,7 @@ def test_save_feature_set_set(
     result = set_api_client.save_feature_set_set_v1(
         context,
         {
-            "workspace": ws_name,
+            "workspace_id": ws_id,
             "output_object_name": set_name,
             "data": expression_set,
         },
@@ -48,7 +47,7 @@ def test_save_feature_set_set(
 
 
 def test_save_feature_set_set_no_data(
-    set_api_client: SetAPI, context: dict[str, str | list], ws_name: str
+    set_api_client: SetAPI, context: dict[str, str | list], ws_id: int
 ) -> None:
     with pytest.raises(
         ValueError, match='"data" parameter field required to save a FeatureSetSet'
@@ -56,7 +55,7 @@ def test_save_feature_set_set_no_data(
         set_api_client.save_feature_set_set_v1(
             context,
             {
-                "workspace": ws_name,
+                "workspace_id": ws_id,
                 "output_object_name": "foo",
                 "data": None,
             },
@@ -65,7 +64,7 @@ def test_save_feature_set_set_no_data(
 
 @pytest.mark.skip("Currently allow empty FeatureSetSets")
 def test_save_feature_set_set_empty(
-    set_api_client: SetAPI, context: dict[str, str | list], ws_name: str
+    set_api_client: SetAPI, context: dict[str, str | list], ws_id: int
 ) -> None:
     with pytest.raises(
         ValueError,
@@ -74,7 +73,7 @@ def test_save_feature_set_set_empty(
         set_api_client.save_feature_set_set_v1(
             context,
             {
-                "workspace": ws_name,
+                "workspace_id": ws_id,
                 "output_object_name": "foo",
                 "data": {"description": "empty_set", "items": []},
             },
@@ -82,7 +81,10 @@ def test_save_feature_set_set_empty(
 
 
 def test_get_feature_set_set(
-    featureset_refs: list, set_api_client: SetAPI, context: dict[str, str | list], ws_name: str
+    featureset_refs: list,
+    set_api_client: SetAPI,
+    context: dict[str, str | list],
+    ws_id: int,
 ) -> None:
     set_name = "test_featureset_set2"
     set_items = [{"label": "wt", "ref": ref} for ref in featureset_refs]
@@ -90,7 +92,7 @@ def test_get_feature_set_set(
     featureset_set_ref = set_api_client.save_feature_set_set_v1(
         context,
         {
-            "workspace": ws_name,
+            "workspace_id": ws_id,
             "output_object_name": set_name,
             "data": featureset_set,
         },

--- a/test/GenomeSet_basic_test.py
+++ b/test/GenomeSet_basic_test.py
@@ -1,5 +1,5 @@
 """Basic GenomeSet tests."""
-from test.conftest import INFO_LENGTH
+from test.util import INFO_LENGTH
 
 from SetAPI.SetAPIImpl import SetAPI
 
@@ -10,7 +10,7 @@ def test_basic_save_and_get(
     genome_refs: list[str],
     set_api_client: SetAPI,
     context: dict[str, str | list],
-    ws_name: str,
+    ws_id: int,
 ) -> None:
     set_name = "set_of_genomes"
     set_description = "my first genome set"
@@ -30,7 +30,7 @@ def test_basic_save_and_get(
         {
             "data": set_data,
             "output_object_name": set_name,
-            "workspace": ws_name,
+            "workspace_id": ws_id,
         },
     )[0]
     assert "set_ref" in res
@@ -42,7 +42,7 @@ def test_basic_save_and_get(
     assert res["set_info"][10]["item_count"] == str(N_GENOME_REFS)
 
     # test get of that object
-    d1 = set_api_client.get_genome_set_v1(context, {"ref": ws_name + "/" + set_name})[0]
+    d1 = set_api_client.get_genome_set_v1(context, {"ref": res["set_ref"]})[0]
     assert "data" in d1
     assert "info" in d1
     assert len(d1["info"]) == INFO_LENGTH
@@ -91,7 +91,7 @@ def test_save_and_get_kbasesearch_genome(
     genome_refs: list[str],
     set_api_client: SetAPI,
     context: dict[str, str | list],
-    ws_name: str,
+    ws_id: int,
 ) -> None:
     set_name = "set_of_kbasesearch_genomes"
 
@@ -116,7 +116,7 @@ def test_save_and_get_kbasesearch_genome(
         {
             "data": set_data,
             "output_object_name": set_name,
-            "workspace": ws_name,
+            "workspace_id": ws_id,
             "save_search_set": True,
         },
     )[0]
@@ -129,7 +129,7 @@ def test_save_and_get_kbasesearch_genome(
     assert "KBaseSearch.GenomeSet" in res["set_info"][2]
 
     # test get of that object
-    d1 = set_api_client.get_genome_set_v1(context, {"ref": ws_name + "/" + set_name})[0]
+    d1 = set_api_client.get_genome_set_v1(context, {"ref": res["set_ref"]})[0]
     assert "data" in d1
     assert "info" in d1
     assert len(d1["info"]) == INFO_LENGTH
@@ -149,7 +149,7 @@ def test_save_and_get_kbasesearch_genome(
 
 
 def test_save_and_get_of_empty_set(
-    set_api_client: SetAPI, context: dict[str, str | list], ws_name: str
+    set_api_client: SetAPI, context: dict[str, str | list], ws_id: int
 ) -> None:
     set_name = "nada_set"
     set_description = "nothing to see here"
@@ -162,7 +162,7 @@ def test_save_and_get_of_empty_set(
         {
             "data": set_data,
             "output_object_name": set_name,
-            "workspace": ws_name,
+            "workspace_id": ws_id,
         },
     )[0]
     assert "set_ref" in res
@@ -174,7 +174,7 @@ def test_save_and_get_of_empty_set(
     assert res["set_info"][10]["item_count"] == "0"
 
     # test get of that object
-    d1 = set_api_client.get_genome_set_v1(context, {"ref": ws_name + "/" + set_name})[0]
+    d1 = set_api_client.get_genome_set_v1(context, {"ref": res["set_ref"]})[0]
     assert "data" in d1
     assert "info" in d1
     assert len(d1["info"]) == INFO_LENGTH

--- a/test/ReadsSet_basic_test.py
+++ b/test/ReadsSet_basic_test.py
@@ -1,6 +1,5 @@
 """Basic ReadsSet tests."""
-from test.conftest import INFO_LENGTH
-from test.util import make_fake_sampleset
+from test.util import make_fake_sampleset, INFO_LENGTH
 from typing import Any
 
 import pytest
@@ -8,12 +7,12 @@ from SetAPI.SetAPIImpl import SetAPI
 
 
 @pytest.fixture(scope="module")
-def sampleset_ref(reads_refs: list[str], ws_name: str, clients: dict[str, Any]) -> str:
+def sampleset_ref(reads_refs: list[str], ws_id: int, clients: dict[str, Any]) -> str:
     return make_fake_sampleset(
         "test_sampleset",
         reads_refs,
         ["wt", "cond1", "cond2"],
-        ws_name,
+        ws_id,
         clients["ws"],
     )
 
@@ -22,7 +21,7 @@ def test_basic_save_and_get(
     reads_refs: list[str],
     set_api_client: SetAPI,
     context: dict[str, str | list],
-    ws_name: str,
+    ws_id: int,
 ) -> None:
     set_name = "set_o_reads"
     set_description = "my first reads"
@@ -43,7 +42,7 @@ def test_basic_save_and_get(
         {
             "data": set_data,
             "output_object_name": set_name,
-            "workspace": ws_name,
+            "workspace_id": ws_id,
         },
     )[0]
     assert "set_ref" in res
@@ -55,7 +54,7 @@ def test_basic_save_and_get(
     assert res["set_info"][10]["item_count"] == str(n_items_in_set)
 
     # test get of that object
-    d1 = set_api_client.get_reads_set_v1(context, {"ref": ws_name + "/" + set_name})[0]
+    d1 = set_api_client.get_reads_set_v1(context, {"ref": res["set_ref"]})[0]
     assert "data" in d1
     assert "info" in d1
     assert len(d1["info"]) == INFO_LENGTH
@@ -108,7 +107,7 @@ def test_basic_save_and_get(
 
 
 def test_save_and_get_of_empty_set(
-    set_api_client: SetAPI, context: dict[str, str | list], ws_name: str
+    set_api_client: SetAPI, context: dict[str, str | list], ws_id: int
 ) -> None:
     set_name = "nada_set"
     set_description = "nothing to see here"
@@ -123,7 +122,7 @@ def test_save_and_get_of_empty_set(
         {
             "data": set_data,
             "output_object_name": set_name,
-            "workspace": ws_name,
+            "workspace_id": ws_id,
         },
     )[0]
     assert "set_ref" in res
@@ -135,7 +134,7 @@ def test_save_and_get_of_empty_set(
     assert res["set_info"][10]["item_count"] == str(n_items_in_set)
 
     # test get of that object
-    d1 = set_api_client.get_reads_set_v1(context, {"ref": ws_name + "/" + set_name})[0]
+    d1 = set_api_client.get_reads_set_v1(context, {"ref": res["set_ref"]})[0]
     assert "data" in d1
     assert "info" in d1
     assert len(d1["info"]) == INFO_LENGTH

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -23,7 +23,6 @@ CONFIG_FILE = os.environ.get(
 
 TOKEN = os.environ.get("KB_AUTH_TOKEN", None)
 SDK_CALLBACK_URL = os.environ["SDK_CALLBACK_URL"]
-INFO_LENGTH = 11
 
 
 @pytest.fixture(scope="session")
@@ -105,7 +104,12 @@ def test_workspace(
     log_this(
         config,
         "ws_results",
-        {"ws_create": result, "config": config, "context": context, "ws_delete": deletion},
+        {
+            "ws_create": result,
+            "config": config,
+            "context": context,
+            "ws_delete": deletion,
+        },
     )
 
 
@@ -146,20 +150,22 @@ def clients(test_workspace: dict[str, Any]) -> dict[str, Any]:
 
 
 @pytest.fixture(scope="session")
-def reads_refs(clients: dict[str, Any], ws_name: str) -> list[str]:
-    return make_reads_refs(clients["foft"], ws_name)
-
-
-@pytest.fixture(scope="session")
 def scratch_dir(config: dict[str, str]) -> str:
     scratch_dir = config["scratch"]
-    shutil.copytree(os.path.join(TEST_BASE_DIR, "data"), scratch_dir, dirs_exist_ok=True)
+    shutil.copytree(
+        os.path.join(TEST_BASE_DIR, "data"), scratch_dir, dirs_exist_ok=True
+    )
     return scratch_dir
 
 
 @pytest.fixture(scope="session")
-def genome_refs(clients: dict[str, Any], ws_name: str) -> list[str]:
-    return make_genome_refs(clients["foft"], ws_name)
+def genome_refs(clients: dict[str, Any], ws_id: str) -> list[str]:
+    return make_genome_refs(clients["foft"], ws_id)
+
+
+@pytest.fixture(scope="session")
+def reads_refs(clients: dict[str, Any], ws_id: str) -> list[str]:
+    return make_reads_refs(clients["foft"], ws_id)
 
 
 @pytest.fixture(scope="session")

--- a/test/generic_set_access_test.py
+++ b/test/generic_set_access_test.py
@@ -1,7 +1,6 @@
 """Generic set functionality tests."""
 import time
-from test.conftest import INFO_LENGTH
-from test.util import log_this
+from test.util import log_this, INFO_LENGTH
 from typing import Any
 
 import pytest
@@ -15,7 +14,7 @@ def create_sets(
     reads_refs: list[str],
     set_api_client: SetAPI,
     context: dict[str, str | list],
-    ws_name: str,
+    ws_id: int,
 ) -> dict:
     set_names = ["set_o_reads1", "set_o_reads2", "set_o_reads3"]
     set_refs = []
@@ -31,7 +30,7 @@ def create_sets(
         # test a save - makes a new ReadsSet object in the workspace.
         res = set_api_client.save_reads_set_v1(
             context,
-            {"data": set_data, "output_object_name": s, "workspace": ws_name},
+            {"data": set_data, "output_object_name": s, "workspace_id": ws_id},
         )[0]
         set_refs.append(res["set_ref"])
 
@@ -64,21 +63,26 @@ def test_list_sets(
     clients: dict[str, Any],
 ) -> None:
     list_sets_ws_name = f"{ws_name}_list_sets"
-    clients["ws"].create_workspace({"workspace": list_sets_ws_name})
+    result = clients["ws"].create_workspace({"workspace": list_sets_ws_name})
+    list_sets_ws_id = result[0]
 
     # make sure we can see an empty list of sets before WS has any
     res = set_api_client.list_sets(
-        context, {"workspace": list_sets_ws_name, "include_set_item_info": 1}
+        context, {"workspace": list_sets_ws_id, "include_set_item_info": 1}
     )[0]
     assert len(res["sets"]) == 0
 
     # create the test sets, adds a ReadsSet object in the workspace
-    set_data = create_sets(reads_refs, set_api_client, context, list_sets_ws_name)
+    set_data = create_sets(reads_refs, set_api_client, context, list_sets_ws_id)
 
     # Get the sets in the workspace along with their item info.
     res = set_api_client.list_sets(
+        context, {"workspace": list_sets_ws_id, "include_set_item_info": 1}
+    )[0]
+    res_name = set_api_client.list_sets(
         context, {"workspace": list_sets_ws_name, "include_set_item_info": 1}
     )[0]
+    assert res == res_name
     assert "sets" in res
     assert len(res["sets"]) == len(set_data["set_names"])
     for s in res["sets"]:
@@ -93,7 +97,7 @@ def test_list_sets(
             assert len(item["info"]) == INFO_LENGTH
 
     # Get the sets in a workspace without their item info (just the refs)
-    res2 = set_api_client.list_sets(context, {"workspace": list_sets_ws_name})[0]
+    res2 = set_api_client.list_sets(context, {"workspace": list_sets_ws_id})[0]
     assert "sets" in res2
     assert len(res2["sets"]) == len(set_data["set_names"])
     for s in res2["sets"]:
@@ -132,7 +136,10 @@ def test_list_sets(
 
 
 def test_bulk_list_sets(
-    config: dict[str, str], clients: dict[str, Any], set_api_client: SetAPI, context: dict[str, str | list]
+    config: dict[str, str],
+    clients: dict[str, Any],
+    set_api_client: SetAPI,
+    context: dict[str, str | list],
 ) -> None:
     magic_number = 1000
     try:
@@ -144,7 +151,9 @@ def test_bulk_list_sets(
             if ws_info[4] < magic_number:
                 ids.append(str(ws_info[0]))
             else:
-                debug_lines.append(f"Workspace: {ws_info[1]}, size={ws_info[4]} skipped")
+                debug_lines.append(
+                    f"Workspace: {ws_info[1]}, size={ws_info[4]} skipped"
+                )
 
         debug_lines.append("Number of workspaces for bulk list_sets: " + str(len(ids)))
         if len(ids) > 0:
@@ -158,7 +167,9 @@ def test_bulk_list_sets(
             context, {"workspaces": ids, "include_set_item_info": 1}
         )[0]
 
-        debug_lines.append(f"Objects found: {len(ret['sets'])}, time={time.time() - t1}")
+        debug_lines.append(
+            f"Objects found: {len(ret['sets'])}, time={time.time() - t1}"
+        )
         if DEBUG:
             log_this(config, "test_bulk_list_sets", debug_lines)
 
@@ -167,7 +178,10 @@ def test_bulk_list_sets(
 
 
 def unit_test_get_set_items(
-    set_data: dict, config: dict[str, str], set_api_client: SetAPI, context: dict[str, str | list]
+    set_data: dict,
+    config: dict[str, str],
+    set_api_client: SetAPI,
+    context: dict[str, str | list],
 ) -> None:
     res = set_api_client.get_set_items(
         context,


### PR DESCRIPTION
While doing some updates to the tests, I noticed that `create_sample_set` has a string parameter named `ws_id` but the code actually uses the workspace name. Doh! I didn't want to change the API so I've just put in a fix that allows either the workspace name or ID to be entered and the code will work out which form of identifier it is dealing with and thus use the correct params when calling the workspace.

Also in this PR:
- updated the installed clients
- copied `info_to_ref` over to the main util functions methods
- fixed un-pythonic camelCase names
- shifted to using `ws_id`s in the tests since they are more reliable