### PR TITLE
List all sets: standardised test methods for any SetAPI class

### DIFF
--- a/lib/SetAPI/assembly/AssemblySetInterfaceV1.py
+++ b/lib/SetAPI/assembly/AssemblySetInterfaceV1.py
@@ -1,7 +1,12 @@
+"""An interface for handling sets of Assemblies."""
+from typing import Any
+
+from installed_clients.WorkspaceClient import Workspace
+
 from SetAPI.error_messages import (
     data_required,
     include_params_valid,
-    items_list_required,
+    list_required,
     ref_must_be_valid,
     ref_path_must_be_valid,
     ref_required,
@@ -12,24 +17,26 @@ from SetAPI.util import (
     check_reference,
     info_to_ref,
 )
-from typing import Any
 
 
 class AssemblySetInterfaceV1:
-    def __init__(self: "AssemblySetInterfaceV1", workspace_client):
+    def __init__(self: "AssemblySetInterfaceV1", workspace_client: Workspace):
         self.ws = workspace_client
         self.set_interface = SetInterfaceV1(workspace_client)
 
     @staticmethod
     def set_type() -> str:
+        """The set type saved by this class."""
         return "KBaseSets.AssemblySet"
 
     @staticmethod
     def set_items_type() -> str:
+        """The type of object in the sets."""
         return "Assembly"
 
     @staticmethod
     def allows_empty_set() -> bool:
+        """Whether or not the class allows the creation of empty sets."""
         return True
 
     def save_assembly_set(
@@ -73,10 +80,10 @@ class AssemblySetInterfaceV1:
             err_msg = data_required(self.set_items_type())
             raise ValueError(err_msg)
 
-        # N.b. AssemblySets allow an empty items list so we don't check that
-        # params["data"]["items"] is populated
+        # N.b. AssemblySets allow an empty items list so we don't
+        # need to check that params["data"]["items"] is populated
         if "items" not in params["data"]:
-            raise ValueError(items_list_required(self.set_items_type()))
+            raise ValueError(list_required(self.set_items_type()))
 
         # add 'description' and item 'label' fields if not present:
         if "description" not in params["data"]:
@@ -108,7 +115,9 @@ class AssemblySetInterfaceV1:
     ) -> dict[str, str | bool | list[str]]:
         """Perform basic validation on the get_set parameters.
 
-        :param params: this class
+        :param self: this class
+        :type self: AssemblySetInterfaceV1
+        :param params: parameters to the get_set function
         :type params: dict[str, Any]
         :return: validated parameters
         :rtype: dict[str, str | bool | list[str]]
@@ -130,9 +139,7 @@ class AssemblySetInterfaceV1:
 
         return {
             "ref": params["ref"],
-            INC_ITEM_INFO: True if params.get(INC_ITEM_INFO, 0) == 1 else False,
-            INC_ITEM_REF_PATHS: True
-            if params.get(INC_ITEM_REF_PATHS, 0) == 1
-            else False,
+            INC_ITEM_INFO: params.get(INC_ITEM_INFO, 0) == 1,
+            INC_ITEM_REF_PATHS: params.get(INC_ITEM_REF_PATHS, 0) == 1,
             REF_PATH_TO_SET: ref_path_to_set,
         }

--- a/lib/SetAPI/differentialexpressionmatrix/DifferentialExpressionMatrixSetInterfaceV1.py
+++ b/lib/SetAPI/differentialexpressionmatrix/DifferentialExpressionMatrixSetInterfaceV1.py
@@ -3,6 +3,7 @@ An interface for handling sets of Expression objects.
 """
 from SetAPI.generic.SetInterfaceV1 import SetInterfaceV1
 from SetAPI.util import check_reference, info_to_ref
+from SetAPI.generic.constants import INC_ITEM_INFO, INC_ITEM_REF_PATHS, REF_PATH_TO_SET
 
 
 class DifferentialExpressionMatrixSetInterfaceV1:
@@ -63,19 +64,13 @@ class DifferentialExpressionMatrixSetInterfaceV1:
     def get_differential_expression_matrix_set(self, ctx, params):
         self._check_get_differential_expression_matrix_set_params(params)
 
-        include_item_info = False
-        if "include_item_info" in params:
-            if params["include_item_info"] == 1:
-                include_item_info = True
+        include_item_info = True if params.get(INC_ITEM_INFO, 0) == 1 else False
 
-        include_set_item_ref_paths = False
-        if "include_set_item_ref_paths" in params:
-            if params["include_set_item_ref_paths"] == 1:
-                include_set_item_ref_paths = True
+        include_set_item_ref_paths = (
+            True if params.get(INC_ITEM_REF_PATHS, 0) == 1 else False
+        )
 
-        ref_path_to_set = []
-        if "ref_path_to_set" in params:
-            ref_path_to_set = params["ref_path_to_set"]
+        ref_path_to_set = params.get(REF_PATH_TO_SET, [])
 
         set_data = self.set_interface.get_set(
             params["ref"],
@@ -88,11 +83,11 @@ class DifferentialExpressionMatrixSetInterfaceV1:
     def _check_get_differential_expression_matrix_set_params(self, params):
         if "ref" not in params or params["ref"] is None:
             raise ValueError(
-                '"ref" parameter field specifiying the DifferentialExpressionMatrix set is required'
+                '"ref" parameter field specifying the DifferentialExpressionMatrix set is required'
             )
         if not check_reference(params["ref"]):
             raise ValueError('"ref" parameter must be a valid workspace reference')
-        if "include_item_info" in params and params["include_item_info"] not in [0, 1]:
+        if INC_ITEM_INFO in params and params[INC_ITEM_INFO] not in [0, 1]:
             raise ValueError(
                 '"include_item_info" parameter field can only be set to 0 or 1'
             )

--- a/lib/SetAPI/error_messages.py
+++ b/lib/SetAPI/error_messages.py
@@ -9,8 +9,8 @@ def include_params_valid(param_name) -> str:
     return f'The "{param_name}" parameter can only be set to 0 or 1'
 
 
-def items_list_required(set_items_type: str) -> str:
-    return f'An "items" list must be defined in the "data" parameter to save {set_items_type}Sets'
+def list_required(set_items_type: str, list_type: str = "items") -> str:
+    return f'An "{list_type}" list must be defined in the "data" parameter to save {set_items_type}Sets'
 
 
 def no_items(set_items_type: str) -> str:

--- a/lib/SetAPI/error_messages.py
+++ b/lib/SetAPI/error_messages.py
@@ -1,0 +1,35 @@
+"""Functions to construct common error messages."""
+
+
+def data_required(set_items_type: str) -> str:
+    return f'The "data" parameter is required to save {set_items_type}Sets'
+
+
+def include_params_valid(param_name) -> str:
+    return f'The "{param_name}" parameter can only be set to 0 or 1'
+
+
+def items_list_required(set_items_type: str) -> str:
+    return f'An "items" list must be defined in the "data" parameter to save {set_items_type}Sets'
+
+
+def no_items(set_items_type: str) -> str:
+    return f"{set_items_type}Sets must contain at least one {set_items_type} object reference."
+
+
+def ref_required(set_items_type: str) -> str:
+    return f'The "ref" parameter specifying the {set_items_type}Set is required'
+
+
+def ref_must_be_valid() -> str:
+    return 'The "ref" parameter must be a valid workspace reference'
+
+
+def ref_path_must_be_valid() -> str:
+    return 'The "ref_path" parameter must contain valid workspace references'
+
+
+def same_ref(set_items_type: str) -> str:
+    return (
+        f"All {set_items_type} objects in the set must use the same genome reference."
+    )

--- a/lib/SetAPI/expression/ExpressionSetInterfaceV1.py
+++ b/lib/SetAPI/expression/ExpressionSetInterfaceV1.py
@@ -4,6 +4,7 @@ An interface for handling sets of Expression objects.
 from SetAPI import util
 from SetAPI.generic.SetInterfaceV1 import SetInterfaceV1
 from SetAPI.util import info_to_ref
+from SetAPI.generic.constants import INC_ITEM_INFO, INC_ITEM_REF_PATHS, REF_PATH_TO_SET
 
 
 class ExpressionSetInterfaceV1:
@@ -62,19 +63,13 @@ class ExpressionSetInterfaceV1:
     def get_expression_set(self, ctx, params):
         set_type, obj_spec = self._check_get_expression_set_params(params)
 
-        include_item_info = False
-        if "include_item_info" in params:
-            if params["include_item_info"] == 1:
-                include_item_info = True
+        include_item_info = True if params.get(INC_ITEM_INFO, 0) == 1 else False
 
-        include_set_item_ref_paths = False
-        if "include_set_item_ref_paths" in params:
-            if params["include_set_item_ref_paths"] == 1:
-                include_set_item_ref_paths = True
+        include_set_item_ref_paths = (
+            True if params.get(INC_ITEM_REF_PATHS, 0) == 1 else False
+        )
 
-        ref_path_to_set = []
-        if "ref_path_to_set" in params:
-            ref_path_to_set = params["ref_path_to_set"]
+        ref_path_to_set = params.get(REF_PATH_TO_SET, [])
 
         if "KBaseSets" in set_type:
             # If it's a KBaseSets type, then we know the usual interface will work...
@@ -130,16 +125,16 @@ class ExpressionSetInterfaceV1:
     def _check_get_expression_set_params(self, params):
         if "ref" not in params or params["ref"] is None:
             raise ValueError(
-                '"ref" parameter field specifiying the expression set is required'
+                '"ref" parameter field specifying the expression set is required'
             )
         if not util.check_reference(params["ref"]):
             raise ValueError('"ref" parameter must be a valid workspace reference')
-        if "include_item_info" in params and params["include_item_info"] not in [0, 1]:
+        if INC_ITEM_INFO in params and params[INC_ITEM_INFO] not in [0, 1]:
             raise ValueError(
                 '"include_item_info" parameter field can only be set to 0 or 1'
             )
         obj_spec = util.build_ws_obj_selector(
-            params.get("ref"), params.get("ref_path_to_set", [])
+            params.get("ref"), params.get(REF_PATH_TO_SET, [])
         )
         info = self.workspace_client.get_object_info3({"objects": [obj_spec]})
 

--- a/lib/SetAPI/featureset/FeatureSetSetInterfaceV1.py
+++ b/lib/SetAPI/featureset/FeatureSetSetInterfaceV1.py
@@ -3,6 +3,7 @@ An interface for saving and retrieving Sets of FeatureSets.
 """
 from SetAPI.generic.SetInterfaceV1 import SetInterfaceV1
 from SetAPI.util import check_reference, info_to_ref
+from SetAPI.generic.constants import INC_ITEM_INFO, INC_ITEM_REF_PATHS, REF_PATH_TO_SET
 
 
 class FeatureSetSetInterfaceV1:
@@ -41,19 +42,13 @@ class FeatureSetSetInterfaceV1:
     def get_feature_set_set(self, ctx, params):
         self._check_get_feature_set_set_params(params)
 
-        include_item_info = False
-        if "include_item_info" in params:
-            if params["include_item_info"] == 1:
-                include_item_info = True
+        include_item_info = True if params.get(INC_ITEM_INFO, 0) == 1 else False
 
-        include_set_item_ref_paths = False
-        if "include_set_item_ref_paths" in params:
-            if params["include_set_item_ref_paths"] == 1:
-                include_set_item_ref_paths = True
+        include_set_item_ref_paths = (
+            True if params.get(INC_ITEM_REF_PATHS, 0) == 1 else False
+        )
 
-        ref_path_to_set = []
-        if "ref_path_to_set" in params:
-            ref_path_to_set = params["ref_path_to_set"]
+        ref_path_to_set = params.get(REF_PATH_TO_SET, [])
 
         set_data = self.set_interface.get_set(
             params["ref"],
@@ -68,11 +63,11 @@ class FeatureSetSetInterfaceV1:
     def _check_get_feature_set_set_params(self, params):
         if "ref" not in params or params["ref"] is None:
             raise ValueError(
-                '"ref" parameter field specifiying the FeatureSet set is required'
+                '"ref" parameter field specifying the FeatureSet set is required'
             )
         if not check_reference(params["ref"]):
             raise ValueError('"ref" parameter must be a valid workspace reference')
-        if "include_item_info" in params and params["include_item_info"] not in [0, 1]:
+        if INC_ITEM_INFO in params and params[INC_ITEM_INFO] not in [0, 1]:
             raise ValueError(
                 '"include_item_info" parameter field can only be set to 0 or 1'
             )

--- a/lib/SetAPI/generic/GenericSetNavigator.py
+++ b/lib/SetAPI/generic/GenericSetNavigator.py
@@ -8,6 +8,7 @@ from SetAPI.util import (
     build_ws_obj_selector,
     populate_item_object_ref_paths,
 )
+from SetAPI.generic.constants import INC_ITEM_REF_PATHS, REF_PATH_TO_SET
 
 
 class GenericSetNavigator:
@@ -55,7 +56,7 @@ class GenericSetNavigator:
         if params.get("include_set_item_info", 0) == 1:
             top_level_sets = self._populate_set_item_info(top_level_sets)
 
-        if params.get("include_set_item_ref_paths", 0) == 1:
+        if params.get(INC_ITEM_REF_PATHS, 0) == 1:
             top_level_sets = self._populate_set_item_ref_path(top_level_sets)
 
         if self.DEBUG:
@@ -222,7 +223,7 @@ class GenericSetNavigator:
 
     def _populate_set_item_ref_path(self, set_list):
         for s in set_list:
-            obj_spec = build_ws_obj_selector(s["ref"], s.get("ref_path_to_set", []))
+            obj_spec = build_ws_obj_selector(s["ref"], s.get(REF_PATH_TO_SET, []))
             populate_item_object_ref_paths(s["items"], obj_spec)
 
         return set_list
@@ -265,10 +266,7 @@ class GenericSetNavigator:
         # add the info for each set item in the list
         set_list = self._populate_set_item_info(set_list)
 
-        if (
-            "include_set_item_ref_paths" in params
-            and params["include_set_item_ref_paths"] == 1
-        ):
+        if INC_ITEM_REF_PATHS in params and params[INC_ITEM_REF_PATHS] == 1:
             set_list = self._populate_set_item_ref_path(set_list)
 
         return {"sets": set_list}

--- a/lib/SetAPI/generic/SetInterfaceV1.py
+++ b/lib/SetAPI/generic/SetInterfaceV1.py
@@ -16,7 +16,7 @@ class SetInterfaceV1:
 
     def _check_save_set_params(self, params):
         if "data" not in params:
-            raise ValueError('"data" parameter field specifiying the set is required')
+            raise ValueError('"data" parameter field specifying the set is required')
         if (
             "workspace" not in params
             and "workspace_id" not in params

--- a/lib/SetAPI/generic/constants.py
+++ b/lib/SetAPI/generic/constants.py
@@ -1,0 +1,3 @@
+INC_ITEM_INFO = "include_item_info"
+INC_ITEM_REF_PATHS = "include_set_item_ref_paths"
+REF_PATH_TO_SET = "ref_path_to_set"

--- a/lib/SetAPI/genome/GenomeSetInterfaceV1.py
+++ b/lib/SetAPI/genome/GenomeSetInterfaceV1.py
@@ -1,5 +1,6 @@
 from SetAPI.generic.SetInterfaceV1 import SetInterfaceV1
 from SetAPI.util import info_to_ref
+from SetAPI.generic.constants import INC_ITEM_INFO, INC_ITEM_REF_PATHS, REF_PATH_TO_SET
 
 
 class GenomeSetInterfaceV1:
@@ -58,19 +59,13 @@ class GenomeSetInterfaceV1:
     def get_genome_set(self, ctx, params):
         self._check_get_genome_set_params(params)
 
-        include_item_info = False
-        if "include_item_info" in params:
-            if params["include_item_info"] == 1:
-                include_item_info = True
+        include_item_info = True if params.get(INC_ITEM_INFO, 0) == 1 else False
 
-        include_set_item_ref_paths = False
-        if "include_set_item_ref_paths" in params:
-            if params["include_set_item_ref_paths"] == 1:
-                include_set_item_ref_paths = True
+        include_set_item_ref_paths = (
+            True if params.get(INC_ITEM_REF_PATHS, 0) == 1 else False
+        )
 
-        ref_path_to_set = []
-        if "ref_path_to_set" in params:
-            ref_path_to_set = params["ref_path_to_set"]
+        ref_path_to_set = params.get(REF_PATH_TO_SET, [])
 
         set_data = self.set_interface.get_set(
             params["ref"],
@@ -85,13 +80,12 @@ class GenomeSetInterfaceV1:
     def _check_get_genome_set_params(self, params):
         if "ref" not in params:
             raise ValueError(
-                '"ref" parameter field specifiying the genome  set is required'
+                '"ref" parameter field specifying the genome  set is required'
             )
-        if "include_item_info" in params:
-            if params["include_item_info"] not in [0, 1]:
-                raise ValueError(
-                    '"include_item_info" parameter field can only be set to 0 or 1'
-                )
+        if INC_ITEM_INFO in params and params[INC_ITEM_INFO] not in [0, 1]:
+            raise ValueError(
+                '"include_item_info" parameter field can only be set to 0 or 1'
+            )
 
     def _normalize_genome_set_data(self, set_data):
         # make sure that optional/missing fields are filled in or are defined

--- a/lib/SetAPI/reads/ReadsSetInterfaceV1.py
+++ b/lib/SetAPI/reads/ReadsSetInterfaceV1.py
@@ -5,6 +5,7 @@ from SetAPI.util import (
     build_ws_obj_selector,
     info_to_ref,
 )
+from SetAPI.generic.constants import INC_ITEM_INFO, INC_ITEM_REF_PATHS, REF_PATH_TO_SET
 
 
 class ReadsSetInterfaceV1:
@@ -44,18 +45,13 @@ class ReadsSetInterfaceV1:
     def get_reads_set(self, ctx, params):
         set_type, obj_spec = self._check_get_reads_set_params(params)
 
-        include_item_info = False
-        if params.get("include_item_info", 0) == 1:
-            include_item_info = True
+        include_item_info = True if params.get(INC_ITEM_INFO, 0) == 1 else False
 
-        include_set_item_ref_paths = False
-        if "include_set_item_ref_paths" in params:
-            if params["include_set_item_ref_paths"] == 1:
-                include_set_item_ref_paths = True
+        include_set_item_ref_paths = (
+            True if params.get(INC_ITEM_REF_PATHS, 0) == 1 else False
+        )
 
-        ref_path_to_set = []
-        if "ref_path_to_set" in params and len(params["ref_path_to_set"]) > 0:
-            ref_path_to_set = params["ref_path_to_set"]
+        ref_path_to_set = params.get(REF_PATH_TO_SET, [])
 
         # If this is a KBaseSets.ReadsSet, do as normal.
         if "KBaseSets" in set_type:
@@ -113,18 +109,18 @@ class ReadsSetInterfaceV1:
     def _check_get_reads_set_params(self, params):
         if "ref" not in params:
             raise ValueError(
-                '"ref" parameter field specifiying the reads set is required'
+                '"ref" parameter field specifying the reads set is required'
             )
         if not check_reference(params["ref"]):
             raise ValueError('"ref" parameter must be a valid workspace reference')
-        if "include_item_info" in params:
-            if params["include_item_info"] not in [0, 1]:
+        if INC_ITEM_INFO in params:
+            if params[INC_ITEM_INFO] not in [0, 1]:
                 raise ValueError(
                     '"include_item_info" parameter field can only be set to 0 or 1'
                 )
 
         obj_spec = build_ws_obj_selector(
-            params.get("ref"), params.get("ref_path_to_set", [])
+            params.get("ref"), params.get(REF_PATH_TO_SET, [])
         )
 
         info = self.ws.get_object_info3({"objects": [obj_spec]})

--- a/lib/SetAPI/util.py
+++ b/lib/SetAPI/util.py
@@ -31,9 +31,6 @@ def check_reference(ref: str | None) -> bool:
         return False
 
     parts = ref.split("/")
-    if len(parts) < 2 or len(parts) > 3 or any(len(item) == 0 for item in parts):
-        return False
-
     # do we have a KBase UPA (\d+/\d+ or \d+/\d+/\d+)?
     could_be_ints = sum(1 for item in parts if item.isdigit())
     if could_be_ints == len(parts):
@@ -42,10 +39,6 @@ def check_reference(ref: str | None) -> bool:
     # otherwise, we have a ws name and object name, so there should only be two parts
     # none of the remaining parts should be integers
     if len(parts) == 3 or could_be_ints != 0:
-        return False
-
-    # check whether there's a ":" present
-    if ":" in parts[1]:
         return False
 
     # make sure that if there's a ":" in the first part, the stuff on either side isn't an int

--- a/lib/SetAPI/util.py
+++ b/lib/SetAPI/util.py
@@ -1,20 +1,59 @@
-"""
-This module contains some utility functions for the SetAPI.
-"""
+"""This module contains some utility functions for the SetAPI."""
 import os
 import re
+from typing import Any
+
 from installed_clients.DataFileUtilClient import DataFileUtil
 
+KBASE_UPA_REGEX = re.compile(r"^\d+/\d+(/\d+)?$")
+WS_NAME_OBJ_NAME_REGEX = re.compile(r"^([\w\.\-\|]+:)?[\w\.\-\|]+/[\w\.\-\|]+$")
 
-def check_reference(ref):
+
+def check_reference(ref: str | None) -> bool:
+    r"""Check whether a string looks like an object reference.
+
+    Valid object references may be of the form
+
+    \d+/\d+/\d+  classic KBase UPA
+    \d+/\d+      ws ID and obj ID, no version
+    \w+/\w+      ws name, object name (|, -, and . are also valid characters, but are omitted here for brevity)
+    \w+:\w+/\w+  user ID, ws name, object name
+
+    :param ref: a KBase object reference
+    :type ref: str | None
+    :return: True if ref looks like an object reference; False otherwise.
+    :rtype: bool
     """
-    Returns True if ref looks like an actual object reference: xx/yy/zz or xx/yy
-    Returns False otherwise.
-    """
-    obj_ref_regex = re.compile(r"^((\d+)|[A-Za-z].*)\/((\d+)|[A-Za-z].*)(\/\d+)?$")
-    # obj_ref_regex = re.compile("^(?P<wsid>\d+)\/(?P<objid>\d+)(\/(?P<ver>\d+))?$")
-    if ref is None or not obj_ref_regex.match(ref):
+    if not ref:
         return False
+
+    if not (WS_NAME_OBJ_NAME_REGEX.match(ref) or KBASE_UPA_REGEX.match(ref)):
+        return False
+
+    parts = ref.split("/")
+    if len(parts) < 2 or len(parts) > 3 or any(len(item) == 0 for item in parts):
+        return False
+
+    # do we have a KBase UPA (\d+/\d+ or \d+/\d+/\d+)?
+    could_be_ints = sum(1 for item in parts if item.isdigit())
+    if could_be_ints == len(parts):
+        return True
+
+    # otherwise, we have a ws name and object name, so there should only be two parts
+    # none of the remaining parts should be integers
+    if len(parts) == 3 or could_be_ints != 0:
+        return False
+
+    # check whether there's a ":" present
+    if ":" in parts[1]:
+        return False
+
+    # make sure that if there's a ":" in the first part, the stuff on either side isn't an int
+    if ":" in parts[0]:
+        name_parts = parts[0].split(":")
+        if any(item.isdigit() or len(item) == 0 for item in name_parts):
+            return False
+
     return True
 
 
@@ -37,37 +76,56 @@ def convert_workspace_param(params: dict[str, int | str]) -> dict[str, int | str
     :return: the key and value to be used in the WS request
     :rtype: dict[str, str]
     """
-    if "workspace" in params:
-        if str(params["workspace"]).isdigit():
-            return {"id": int(params["workspace"])}
-        return {"workspace": params["workspace"]}
+    if params:
+        # check the workspace_id, ws_id, and workspace fields for potential IDs or names
+        ws_id_like = params.get(
+            "workspace_id", params.get("ws_id", params.get("workspace", None))
+        )
+        if ws_id_like:
+            if str(ws_id_like).isdigit():
+                return {"id": int(ws_id_like)}
+            # otherwise, we probably have a workspace name posing as a workspace ID
+            return {"workspace": ws_id_like}
 
-    if "workspace_id" in params:
-        return {"id": params["workspace_id"]}
-    if "ws_id" in params:
-        return {"id": params["ws_id"]}
-
-    if "workspace_name" in params:
-        return {"workspace": params["workspace_name"]}
-    if "ws_name" in params:
-        return {"workspace": params["ws_name"]}
+        ws_name_like = params.get("workspace_name", params.get("ws_name", None))
+        if ws_name_like:
+            return {"workspace": str(ws_name_like)}
 
     raise ValueError("No appropriate key found for workspace name or ID")
 
 
-def build_ws_obj_selector(ref, ref_path_to_set):
+def build_ws_obj_selector(
+    ref: str, ref_path_to_set: None | list[str]
+) -> dict[str, str]:
+    """Build the appropriate workspace object selector.
+
+    :param ref: a workspace object reference
+    :type ref: str
+    :param ref_path_to_set: a list of WS refs to the set
+    :type ref_path_to_set: None | list[str]
+    :return: the appropriate WS object ref
+    :rtype: dict[str, str]
+    """
     if ref_path_to_set and len(ref_path_to_set) > 0:
         return {"ref": ";".join(ref_path_to_set)}
     return {"ref": ref}
 
 
-def populate_item_object_ref_paths(set_items, obj_selector):
-    """
-    Called when include_set_item_ref_paths is set.
-    Add a field ref_path to each item in set
+def populate_item_object_ref_paths(
+    set_items: list[dict[str, Any]], obj_selector: dict[str, Any]
+) -> list[dict[str, Any]]:
+    """Add a field ref_path to each item in set; called when include_set_item_ref_paths is set.
+
+    :param set_items: list of items in a set
+    :type set_items: list[dict[str, Any]]
+    :param obj_selector:
+    :type obj_selector: dict[str, Any]
+
+    :return: set items with "ref_path" field added
+    :rtype: list[dict[str, Any]]
     """
     for set_item in set_items:
-        set_item["ref_path"] = obj_selector["ref"] + ";" + set_item["ref"]
+        set_item["ref_path"] = f"{obj_selector['ref']};{set_item['ref']}"
     return set_items
 
 

--- a/test/AssemblySet_basic_test.py
+++ b/test/AssemblySet_basic_test.py
@@ -1,21 +1,19 @@
 """Basic tests for the AssemblySet class."""
-from SetAPI.SetAPIImpl import SetAPI
-from SetAPI.assembly.AssemblySetInterfaceV1 import AssemblySetInterfaceV1
-from SetAPI.generic.constants import INC_ITEM_INFO, INC_ITEM_REF_PATHS, REF_PATH_TO_SET
-from typing import Any
-
-from test.util import log_this
-import pytest
 from test.common_checks import (
-    check_get_set_output,
-    check_save_set_output,
     check_get_set_bad_path,
-    check_get_set_no_ref,
     check_get_set_bad_ref,
+    check_get_set_no_ref,
+    check_get_set_output,
     check_save_set_no_data,
     check_save_set_no_items_list,
+    check_save_set_output,
 )
+from typing import Any
 
+import pytest
+from SetAPI.assembly.AssemblySetInterfaceV1 import AssemblySetInterfaceV1
+from SetAPI.generic.constants import INC_ITEM_INFO, INC_ITEM_REF_PATHS, REF_PATH_TO_SET
+from SetAPI.SetAPIImpl import SetAPI
 
 API_CLASS = AssemblySetInterfaceV1
 

--- a/test/DifferentialExpressionMatrixSet_basic_test.py
+++ b/test/DifferentialExpressionMatrixSet_basic_test.py
@@ -3,6 +3,7 @@ import pytest
 from installed_clients.baseclient import ServerError
 from SetAPI.SetAPIImpl import SetAPI
 from SetAPI.util import info_to_ref
+from SetAPI.generic.constants import INC_ITEM_INFO, INC_ITEM_REF_PATHS
 
 
 def test_save_diff_exp_matrix_set(
@@ -137,7 +138,7 @@ def test_get_dem_set(
     )[0]["set_ref"]
 
     fetched_set = set_api_client.get_differential_expression_matrix_set_v1(
-        context, {"ref": dem_set_ref, "include_item_info": 0}
+        context, {"ref": dem_set_ref, INC_ITEM_INFO: 0}
     )[0]
     assert fetched_set is not None
     assert "data" in fetched_set
@@ -151,7 +152,7 @@ def test_get_dem_set(
         assert "label" in item
 
     fetched_set_with_info = set_api_client.get_differential_expression_matrix_set_v1(
-        context, {"ref": dem_set_ref, "include_item_info": 1}
+        context, {"ref": dem_set_ref, INC_ITEM_INFO: 1}
     )[0]
     assert fetched_set_with_info is not None
     assert "data" in fetched_set_with_info
@@ -184,8 +185,8 @@ def test_get_dem_set_ref_path(
             context,
             {
                 "ref": dem_set_ref,
-                "include_item_info": 0,
-                "include_set_item_ref_paths": 1,
+                INC_ITEM_INFO: 0,
+                INC_ITEM_REF_PATHS: 1,
             },
         )[0]
     )
@@ -231,6 +232,6 @@ def test_get_dem_set_no_ref(
 ) -> None:
     with pytest.raises(
         ValueError,
-        match='"ref" parameter field specifiying the DifferentialExpressionMatrix set is required',
+        match='"ref" parameter field specifying the DifferentialExpressionMatrix set is required',
     ):
         set_api_client.get_differential_expression_matrix_set_v1(context, {"ref": None})

--- a/test/ExpressionSet_basic_test.py
+++ b/test/ExpressionSet_basic_test.py
@@ -5,6 +5,7 @@ import pytest
 from installed_clients.baseclient import ServerError
 from SetAPI.SetAPIImpl import SetAPI
 from SetAPI.util import info_to_ref
+from SetAPI.generic.constants import INC_ITEM_INFO, INC_ITEM_REF_PATHS
 
 DEBUG = False
 
@@ -117,7 +118,7 @@ def test_get_expression_set(
     )[0]["set_ref"]
 
     fetched_set = set_api_client.get_expression_set_v1(
-        context, {"ref": expression_set_ref, "include_item_info": 0}
+        context, {"ref": expression_set_ref, INC_ITEM_INFO: 0}
     )[0]
     assert fetched_set is not None
     assert "data" in fetched_set
@@ -131,7 +132,7 @@ def test_get_expression_set(
         assert "label" in item
 
     fetched_set_with_info = set_api_client.get_expression_set_v1(
-        context, {"ref": expression_set_ref, "include_item_info": 1}
+        context, {"ref": expression_set_ref, INC_ITEM_INFO: 1}
     )[0]
     assert fetched_set_with_info is not None
     assert "data" in fetched_set_with_info
@@ -164,8 +165,8 @@ def test_get_expression_set_ref_path(
         context,
         {
             "ref": expression_set_ref,
-            "include_item_info": 1,
-            "include_set_item_ref_paths": 1,
+            INC_ITEM_INFO: 1,
+            INC_ITEM_REF_PATHS: 1,
         },
     )[0]
     assert fetched_set_with_info is not None
@@ -189,8 +190,8 @@ def test_get_created_rnaseq_expression_set_ref_path(
         context,
         {
             "ref": rnaseq_expression_set,
-            "include_item_info": 0,
-            "include_set_item_ref_paths": 1,
+            INC_ITEM_INFO: 0,
+            INC_ITEM_REF_PATHS: 1,
         },
     )[0]
 
@@ -232,6 +233,6 @@ def test_get_expression_set_no_ref(
 ) -> None:
     with pytest.raises(
         ValueError,
-        match='"ref" parameter field specifiying the expression set is required',
+        match='"ref" parameter field specifying the expression set is required',
     ):
         set_api_client.get_expression_set_v1(context, {"ref": None})

--- a/test/FeatureSetSet_test.py
+++ b/test/FeatureSetSet_test.py
@@ -3,6 +3,7 @@ import pytest
 from installed_clients.baseclient import ServerError
 from SetAPI.SetAPIImpl import SetAPI
 from SetAPI.util import info_to_ref
+from SetAPI.generic.constants import INC_ITEM_INFO, INC_ITEM_REF_PATHS
 
 
 def test_save_feature_set_set(
@@ -84,7 +85,7 @@ def test_get_feature_set_set(
     )[0]["set_ref"]
 
     fetched_set = set_api_client.get_feature_set_set_v1(
-        context, {"ref": featureset_set_ref, "include_item_info": 0}
+        context, {"ref": featureset_set_ref, INC_ITEM_INFO: 0}
     )[0]
     assert fetched_set is not None
     assert "data" in fetched_set
@@ -101,8 +102,8 @@ def test_get_feature_set_set(
         context,
         {
             "ref": featureset_set_ref,
-            "include_item_info": 1,
-            "include_set_item_ref_paths": 1,
+            INC_ITEM_INFO: 1,
+            INC_ITEM_REF_PATHS: 1,
         },
     )[0]
     assert fetched_set_with_info is not None
@@ -140,6 +141,6 @@ def test_get_feature_set_set_no_ref(
 ) -> None:
     with pytest.raises(
         ValueError,
-        match='"ref" parameter field specifiying the FeatureSet set is required',
+        match='"ref" parameter field specifying the FeatureSet set is required',
     ):
         set_api_client.get_feature_set_set_v1(context, {"ref": None})

--- a/test/GenomeSet_basic_test.py
+++ b/test/GenomeSet_basic_test.py
@@ -2,6 +2,7 @@
 from test.util import INFO_LENGTH
 
 from SetAPI.SetAPIImpl import SetAPI
+from SetAPI.generic.constants import INC_ITEM_INFO, INC_ITEM_REF_PATHS
 
 
 def test_basic_save_and_get(
@@ -63,8 +64,8 @@ def test_basic_save_and_get(
         context,
         {
             "ref": res["set_ref"],
-            "include_item_info": 1,
-            "include_set_item_ref_paths": 1,
+            INC_ITEM_INFO: 1,
+            INC_ITEM_REF_PATHS: 1,
         },
     )[0]
     assert "data" in d2
@@ -186,7 +187,7 @@ def test_save_and_get_of_empty_set(
     assert len(d1["data"]["items"]) == 0
 
     d2 = set_api_client.get_genome_set_v1(
-        context, {"ref": res["set_ref"], "include_item_info": 1}
+        context, {"ref": res["set_ref"], INC_ITEM_INFO: 1}
     )[0]
 
     assert "data" in d2

--- a/test/ReadsAlignmentSet_basic_test.py
+++ b/test/ReadsAlignmentSet_basic_test.py
@@ -1,290 +1,288 @@
 """Basic ReadsAlignmentSet tests."""
-from test.util import log_this
-
-import pytest
-from installed_clients.baseclient import ServerError
+from typing import Any
+from SetAPI.generic.constants import INC_ITEM_INFO, INC_ITEM_REF_PATHS, REF_PATH_TO_SET
+from SetAPI.readsalignment.ReadsAlignmentSetInterfaceV1 import (
+    ReadsAlignmentSetInterfaceV1,
+)
 from SetAPI.SetAPIImpl import SetAPI
-from SetAPI.util import info_to_ref
+from test.common_checks import (
+    check_get_set_bad_path,
+    check_get_set_bad_ref,
+    check_get_set_no_ref,
+    check_get_set_output,
+    check_save_set_mismatched_genomes,
+    check_save_set_no_data,
+    check_save_set_no_items_list,
+    check_save_set_no_objects,
+    check_save_set_output,
+)
+import pytest
 
-DEBUG = False
-SET_TYPE = "KBaseSets.ReadsAlignmentSet"
+API_CLASS = ReadsAlignmentSetInterfaceV1
 
 
-def test_save_alignment_set(
+@pytest.fixture(scope="module")
+def alignment_set(
     alignment_refs: list[str],
     set_api_client: SetAPI,
     context: dict[str, str | list],
     ws_id: int,
-) -> None:
-    alignment_set_name = "test_alignment_set"
-    alignment_set_description = "test_alignments"
-    alignment_items = [{"label": "wt", "ref": ref} for ref in alignment_refs]
-    alignment_set = {"description": alignment_set_description, "items": alignment_items}
+) -> dict[str, int | str | dict[str, Any]]:
+    set_name = "test_alignment_set"
+    set_description = "test_alignments"
+    set_items = [{"label": "some_label", "ref": ref} for ref in alignment_refs]
+    set_data = {
+        "description": set_description,
+        "items": set_items,
+    }
+
     result = set_api_client.save_reads_alignment_set_v1(
         context,
         {
             "workspace_id": ws_id,
-            "output_object_name": alignment_set_name,
-            "data": alignment_set,
+            "output_object_name": set_name,
+            "data": set_data,
         },
     )[0]
-    assert result is not None
-    assert "set_ref" in result
-    assert "set_info" in result
-    assert result["set_ref"] == info_to_ref(result["set_info"])
-    assert result["set_info"][1] == alignment_set_name
-    assert "KBaseSets.ReadsAlignmentSet" in result["set_info"][2]
+    return {
+        "obj": result,
+        "set_name": set_name,
+        "set_type": API_CLASS.set_type(),
+        "set_description": set_description,
+        "n_items": len(alignment_refs),
+        "second_set_item": set_items[1],
+    }
 
 
-def test_save_alignment_set_mismatched_genomes(
+def test_save_reads_alignment_set(
+    alignment_set,
+) -> None:
+    check_save_set_output(**alignment_set)
+
+
+def test_save_reads_alignment_set_mismatched_genomes(
     set_api_client: SetAPI,
     context: dict[str, str | list],
     ws_id: int,
     alignment_mismatched_genome_refs: list[str],
 ) -> None:
-    set_name = "alignment_set_mismatched_genomes"
-    set_description = "this_better_fail"
-    set_items = [
-        {"label": "al", "ref": ref} for ref in alignment_mismatched_genome_refs
+    alignment_set_items = [
+        {"label": "some_label", "ref": ref} for ref in alignment_mismatched_genome_refs
     ]
-    alignment_set = {
-        "description": set_description,
-        "items": set_items,
-    }
-
-    with pytest.raises(
-        ValueError,
-        match="All ReadsAlignments in the set must be aligned against "
-        "the same genome reference",
-    ):
-        set_api_client.save_reads_alignment_set_v1(
-            context,
-            {
-                "workspace_id": ws_id,
-                "output_object_name": set_name,
-                "data": alignment_set,
-            },
-        )
+    check_save_set_mismatched_genomes(
+        context=context,
+        save_method=set_api_client.save_reads_alignment_set_v1,
+        set_items=alignment_set_items,
+        set_items_type=API_CLASS.set_items_type(),
+    )
 
 
-def test_save_alignment_set_no_data(
+def test_save_reads_alignment_set_no_data(
     set_api_client: SetAPI, context: dict[str, str | list], ws_id: int
 ) -> None:
-    with pytest.raises(
-        ValueError,
-        match='"data" parameter field required to save a ReadsAlignmentSet',
-    ):
-        set_api_client.save_reads_alignment_set_v1(
-            context,
-            {
-                "workspace_id": ws_id,
-                "output_object_name": "foo",
-                "data": None,
-            },
-        )
+    check_save_set_no_data(
+        context,
+        set_api_client.save_reads_alignment_set_v1,
+        API_CLASS.set_items_type(),
+    )
 
 
-def test_save_alignment_set_no_alignments(
+def test_save_reads_alignment_set_no_items_list(
     set_api_client: SetAPI, context: dict[str, str | list], ws_id: int
 ) -> None:
-    with pytest.raises(
-        ValueError,
-        match="A ReadsAlignmentSet must contain at least one ReadsAlignment reference.",
-    ):
-        set_api_client.save_reads_alignment_set_v1(
-            context,
+    check_save_set_no_items_list(
+        context,
+        set_api_client.save_reads_alignment_set_v1,
+        API_CLASS.set_items_type(),
+    )
+
+
+def test_save_reads_alignment_set_no_alignments(
+    set_api_client: SetAPI, context: dict[str, str | list], ws_id: int
+) -> None:
+    check_save_set_no_objects(
+        context,
+        set_api_client.save_reads_alignment_set_v1,
+        API_CLASS.set_items_type(),
+    )
+
+
+@pytest.mark.parametrize(
+    "ref_args",
+    [
+        pytest.param("__SET_REF__", id="set_ref"),
+        pytest.param("__WS_NAME__SET_NAME__", id="ws_name_set_name"),
+    ],
+)
+@pytest.mark.parametrize(
+    "get_method_args",
+    [
+        pytest.param({}, id="empty"),
+        pytest.param({INC_ITEM_INFO: 1}, id="inc_item_info"),
+        pytest.param(
+            {INC_ITEM_REF_PATHS: 1},
+            id="inc_ref_path",
+        ),
+        pytest.param(
             {
-                "workspace_id": ws_id,
-                "output_object_name": "foo",
-                "data": {"items": []},
+                INC_ITEM_INFO: 1,
+                INC_ITEM_REF_PATHS: 1,
             },
-        )
-
-
-def test_get_old_alignment_set(
-    rnaseq_alignment_sets: list[str],
+            id="inc_item_info_ref_path",
+        ),
+        pytest.param(
+            {INC_ITEM_INFO: 1, INC_ITEM_REF_PATHS: 1, REF_PATH_TO_SET: []},
+            id="inc_item_info_ref_path_empty_ref_path",
+        ),
+        pytest.param(
+            {INC_ITEM_INFO: 1, INC_ITEM_REF_PATHS: 1, REF_PATH_TO_SET: ["YES"]},
+            id="inc_item_info_ref_path_w_ref_path",
+        ),
+        pytest.param(
+            {
+                INC_ITEM_INFO: 0,
+                INC_ITEM_REF_PATHS: 0,
+            },
+            id="no_incs",
+        ),
+    ],
+)
+def test_get_reads_alignment_set(
+    alignment_set: dict[str, Any],
     set_api_client: SetAPI,
     context: dict[str, str | list],
+    ws_name: str,
     reads_refs: list[str],
+    ref_args: str,
+    get_method_args: dict[str, str | int],
+    config,
 ) -> None:
-    n_items = len(reads_refs)
-    for ref in rnaseq_alignment_sets:
-        fetched_set = set_api_client.get_reads_alignment_set_v1(
-            context, {"ref": ref, "include_item_info": 0}
-        )[0]
-        assert fetched_set is not None
-        assert "data" in fetched_set
-        assert "info" in fetched_set
-        assert len(fetched_set["data"]["items"]) == n_items
-        assert ref == info_to_ref(fetched_set["info"])
-        for item in fetched_set["data"]["items"]:
-            assert "info" not in item
-            assert "ref" in item
-            assert "label" in item
+    alignment_set_ref = alignment_set["obj"]["set_ref"]
+    params = {}
+    if ref_args == "__SET_REF__":
+        params["ref"] = alignment_set_ref
+    else:
+        params["ref"] = f"{ws_name}/{alignment_set['set_name']}"
 
-        fetched_set_with_info = set_api_client.get_reads_alignment_set_v1(
-            context,
+    for param in [INC_ITEM_INFO, INC_ITEM_REF_PATHS, REF_PATH_TO_SET]:
+        if param in get_method_args:
+            params[param] = get_method_args[param]
+
+    if params.get(REF_PATH_TO_SET, []) != []:
+        # add in a value to check REF_PATH_TO_SET
+        params[REF_PATH_TO_SET] = [alignment_set["obj"]["set_ref"]]
+
+    fetched_set = set_api_client.get_reads_alignment_set_v1(context, params)[0]
+
+    args_to_check_get_set_output = {
+        **{arg: alignment_set[arg] for arg in alignment_set if arg != "obj"},
+        **params,
+        "obj": fetched_set,
+    }
+    check_get_set_output(**args_to_check_get_set_output)
+
+
+@pytest.mark.parametrize(
+    "ref_args",
+    [
+        pytest.param("__SET_REF__", id="set_ref"),
+        pytest.param("__WS_NAME__SET_NAME__", id="ws_name_set_name"),
+    ],
+)
+@pytest.mark.parametrize(
+    "get_method_args",
+    [
+        pytest.param({}, id="empty"),
+        pytest.param({INC_ITEM_INFO: 1}, id="inc_item_info"),
+        pytest.param(
+            {INC_ITEM_REF_PATHS: 1},
+            id="inc_ref_path",
+        ),
+        pytest.param(
             {
-                "ref": ref,
-                "include_item_info": 1,
-                "include_set_item_ref_paths": 1,
+                INC_ITEM_INFO: 1,
+                INC_ITEM_REF_PATHS: 1,
             },
-        )[0]
-        assert fetched_set_with_info is not None
-        assert "data" in fetched_set_with_info
-        for item in fetched_set_with_info["data"]["items"]:
-            assert "info" in item
-            assert "ref" in item
-            assert "label" in item
-            assert "ref_path" in item
-            assert item["ref_path"] == ref + ";" + item["ref"]
-
-
-def test_get_old_alignment_set_ref_path_to_set(
-    config: dict[str, str],
-    set_api_client: SetAPI,
-    context: dict[str, str | list],
+            id="inc_item_info_ref_path",
+        ),
+        pytest.param(
+            {INC_ITEM_INFO: 1, INC_ITEM_REF_PATHS: 1, REF_PATH_TO_SET: ["YES"]},
+            id="inc_item_info_ref_path_w_ref_path",
+        ),
+        pytest.param(
+            {INC_ITEM_INFO: 1, INC_ITEM_REF_PATHS: 1, REF_PATH_TO_SET: []},
+            id="inc_item_info_ref_path_empty_ref_path",
+        ),
+        pytest.param(
+            {
+                INC_ITEM_INFO: 0,
+                INC_ITEM_REF_PATHS: 0,
+            },
+            id="no_incs",
+        ),
+    ],
+)
+def test_get_rnaseq_alignment_set(
     rnaseq_alignment_sets: list[str],
     rnaseq_expression_set: str,
+    set_api_client: SetAPI,
+    context: dict[str, str | list],
+    ws_name: str,
     reads_refs: list[str],
+    ref_args: str,
+    get_method_args: dict[str, str | int],
+    config,
 ) -> None:
-    alignment_ref = rnaseq_alignment_sets[0]
-    ref_path_to_set = [rnaseq_expression_set, alignment_ref]
+    params = {}
+    for param in [INC_ITEM_INFO, INC_ITEM_REF_PATHS, REF_PATH_TO_SET]:
+        if param in get_method_args:
+            params[param] = get_method_args[param]
+
     n_items = len(reads_refs)
+    idx = -1
+    for ref in rnaseq_alignment_sets:
+        idx += 1
+        set_name = f"fake_rnaseq_alignment_set_{idx}"
+        if ref_args == "__SET_REF__":
+            params["ref"] = ref
+        else:
+            params["ref"] = f"{ws_name}/{set_name}"
 
-    fetched_set = set_api_client.get_reads_alignment_set_v1(
-        context,
-        {
-            "ref": alignment_ref,
-            "ref_path_to_set": ref_path_to_set,
-            "include_item_info": 0,
-            "include_set_item_ref_paths": 1,
-        },
-    )[0]
-    assert fetched_set is not None
-    assert "data" in fetched_set
-    assert "info" in fetched_set
-    assert len(fetched_set["data"]["items"]) == n_items
-    assert alignment_ref == info_to_ref(fetched_set["info"])
-    for item in fetched_set["data"]["items"]:
-        assert "info" not in item
-        assert "ref" in item
-        assert "label" in item
-        assert "ref_path" in item
-        assert item["ref_path"] == ";".join(ref_path_to_set) + ";" + item["ref"]
+        if params.get(REF_PATH_TO_SET, []) != []:
+            # add in some values for the REF_PATH_TO_SET
+            params[REF_PATH_TO_SET] = [
+                rnaseq_alignment_sets[idx],
+            ]
 
-    if DEBUG:
-        log_this(config, "RNASeq_Alignment_with_ref_path_to_set", fetched_set)
+        fetched_set = set_api_client.get_reads_alignment_set_v1(context, params)[0]
 
-
-def test_get_alignment_set(
-    set_api_client: SetAPI,
-    context: dict[str, str | list],
-    ws_id: int,
-    alignment_refs: list[str],
-) -> None:
-    alignment_set_name = "test_alignment_set"
-    alignment_items = [{"label": "wt", "ref": ref} for ref in alignment_refs]
-    n_items = len(alignment_refs)
-    alignment_set = {"description": "test_alignments", "items": alignment_items}
-    alignment_set_ref = set_api_client.save_reads_alignment_set_v1(
-        context,
-        {
-            "workspace_id": ws_id,
-            "output_object_name": alignment_set_name,
-            "data": alignment_set,
-        },
-    )[0]["set_ref"]
-
-    fetched_set = set_api_client.get_reads_alignment_set_v1(
-        context, {"ref": alignment_set_ref, "include_item_info": 0}
-    )[0]
-    assert fetched_set is not None
-    assert "data" in fetched_set
-    assert "info" in fetched_set
-    assert len(fetched_set["data"]["items"]) == n_items
-    assert alignment_set_ref == info_to_ref(fetched_set["info"])
-    for item in fetched_set["data"]["items"]:
-        assert "info" not in item
-        assert "ref" in item
-        assert "label" in item
-
-    fetched_set_with_info = set_api_client.get_reads_alignment_set_v1(
-        context, {"ref": alignment_set_ref, "include_item_info": 1}
-    )[0]
-    assert fetched_set_with_info is not None
-    assert "data" in fetched_set_with_info
-    for item in fetched_set_with_info["data"]["items"]:
-        assert "info" in item
-        assert "ref" in item
-        assert "label" in item
-
-
-def test_get_alignment_set_ref_path(
-    alignment_refs: list[str],
-    set_api_client: SetAPI,
-    context: dict[str, str | list],
-    ws_id: int,
-) -> None:
-    alignment_set_name = "test_alignment_set_ref_path"
-    alignment_items = [{"label": "wt", "ref": ref} for ref in alignment_refs]
-    n_items = len(alignment_refs)
-    alignment_set = {"description": "test_alignments", "items": alignment_items}
-    alignment_set_ref = set_api_client.save_reads_alignment_set_v1(
-        context,
-        {
-            "workspace_id": ws_id,
-            "output_object_name": alignment_set_name,
-            "data": alignment_set,
-        },
-    )[0]["set_ref"]
-
-    fetched_set = set_api_client.get_reads_alignment_set_v1(
-        context,
-        {
-            "ref": alignment_set_ref,
-            "include_item_info": 0,
-            "include_set_item_ref_paths": 1,
-        },
-    )[0]
-    assert fetched_set is not None
-    assert "data" in fetched_set
-    assert "info" in fetched_set
-    assert len(fetched_set["data"]["items"]) == n_items
-    assert alignment_set_ref == info_to_ref(fetched_set["info"])
-    for item in fetched_set["data"]["items"]:
-        assert "info" not in item
-        assert "ref" in item
-        assert "label" in item
-        assert "ref_path" in item
-        assert item["ref_path"] == alignment_set_ref + ";" + item["ref"]
-
-
-def test_get_alignment_set_bad_ref(
-    set_api_client: SetAPI, context: dict[str, str | list]
-) -> None:
-    with pytest.raises(
-        ValueError, match='"ref" parameter must be a valid workspace reference'
-    ):
-        set_api_client.get_reads_alignment_set_v1(context, {"ref": "not_a_ref"})
-
-
-def test_get_alignment_set_bad_path(
-    set_api_client: SetAPI, context: dict[str, str | list]
-) -> None:
-    with pytest.raises(
-        ServerError, match="JSONRPCError: -32500. Object 2 cannot be accessed:"
-    ):
-        set_api_client.get_reads_alignment_set_v1(
-            context, {"ref": "1/2/3", "path_to_set": ["foo", "bar"]}
+        # set items are not returned in order so can't check the second set item
+        check_get_set_output(
+            fetched_set,
+            set_name=set_name,
+            set_type="KBaseRNASeq.RNASeqAlignmentSet",
+            set_description="",
+            n_items=n_items,
+            **params,
+            is_fake_set=True,
         )
 
 
-def test_get_alignment_set_no_ref(
+def test_get_reads_alignment_set_bad_ref(
     set_api_client: SetAPI, context: dict[str, str | list]
 ) -> None:
-    with pytest.raises(
-        ValueError,
-        match='"ref" parameter field specifiying the reads alignment set is required',
-    ):
-        set_api_client.get_reads_alignment_set_v1(context, {"ref": None})
+    check_get_set_bad_ref(context, set_api_client.get_reads_alignment_set_v1)
+
+
+def test_get_reads_alignment_set_bad_path(
+    set_api_client: SetAPI, context: dict[str, str | list]
+) -> None:
+    check_get_set_bad_path(context, set_api_client.get_reads_alignment_set_v1)
+
+
+def test_get_reads_alignment_set_no_ref(
+    set_api_client: SetAPI, context: dict[str, str | list]
+) -> None:
+    check_get_set_no_ref(
+        context, set_api_client.get_reads_alignment_set_v1, API_CLASS.set_items_type()
+    )

--- a/test/ReadsAlignmentSet_basic_test.py
+++ b/test/ReadsAlignmentSet_basic_test.py
@@ -1,10 +1,4 @@
 """Basic ReadsAlignmentSet tests."""
-from typing import Any
-from SetAPI.generic.constants import INC_ITEM_INFO, INC_ITEM_REF_PATHS, REF_PATH_TO_SET
-from SetAPI.readsalignment.ReadsAlignmentSetInterfaceV1 import (
-    ReadsAlignmentSetInterfaceV1,
-)
-from SetAPI.SetAPIImpl import SetAPI
 from test.common_checks import (
     check_get_set_bad_path,
     check_get_set_bad_ref,
@@ -16,7 +10,14 @@ from test.common_checks import (
     check_save_set_no_objects,
     check_save_set_output,
 )
+from typing import Any
+
 import pytest
+from SetAPI.generic.constants import INC_ITEM_INFO, INC_ITEM_REF_PATHS, REF_PATH_TO_SET
+from SetAPI.readsalignment.ReadsAlignmentSetInterfaceV1 import (
+    ReadsAlignmentSetInterfaceV1,
+)
+from SetAPI.SetAPIImpl import SetAPI
 
 API_CLASS = ReadsAlignmentSetInterfaceV1
 
@@ -152,10 +153,8 @@ def test_get_reads_alignment_set(
     set_api_client: SetAPI,
     context: dict[str, str | list],
     ws_name: str,
-    reads_refs: list[str],
     ref_args: str,
     get_method_args: dict[str, str | int],
-    config,
 ) -> None:
     alignment_set_ref = alignment_set["obj"]["set_ref"]
     params = {}
@@ -224,14 +223,12 @@ def test_get_reads_alignment_set(
 )
 def test_get_rnaseq_alignment_set(
     rnaseq_alignment_sets: list[str],
-    rnaseq_expression_set: str,
     set_api_client: SetAPI,
     context: dict[str, str | list],
     ws_name: str,
     reads_refs: list[str],
     ref_args: str,
     get_method_args: dict[str, str | int],
-    config,
 ) -> None:
     params = {}
     for param in [INC_ITEM_INFO, INC_ITEM_REF_PATHS, REF_PATH_TO_SET]:

--- a/test/ReadsSet_basic_test.py
+++ b/test/ReadsSet_basic_test.py
@@ -3,6 +3,7 @@ from test.util import INFO_LENGTH
 
 import pytest
 from SetAPI.SetAPIImpl import SetAPI
+from SetAPI.generic.constants import INC_ITEM_INFO, INC_ITEM_REF_PATHS
 
 
 def test_basic_save_and_get(
@@ -71,8 +72,8 @@ def test_basic_save_and_get(
         context,
         {
             "ref": res["set_ref"],
-            "include_item_info": 1,
-            "include_set_item_ref_paths": 1,
+            INC_ITEM_INFO: 1,
+            INC_ITEM_REF_PATHS: 1,
         },
     )[0]
     assert "data" in d2
@@ -133,7 +134,7 @@ def test_save_and_get_of_empty_set(
     assert len(d1["data"]["items"]) == 0
 
     d2 = set_api_client.get_reads_set_v1(
-        context, {"ref": res["set_ref"], "include_item_info": 1}
+        context, {"ref": res["set_ref"], INC_ITEM_INFO: 1}
     )[0]
 
     assert "data" in d2
@@ -154,8 +155,8 @@ def test_get_sampleset_as_readsset(
 ) -> None:
     param_set = [
         {"ref": sampleset_ref},
-        {"ref": sampleset_ref, "include_item_info": 0},
-        {"ref": sampleset_ref, "include_item_info": 1},
+        {"ref": sampleset_ref, INC_ITEM_INFO: 0},
+        {"ref": sampleset_ref, INC_ITEM_INFO: 1},
     ]
     n_items_in_set = len(
         reads_refs
@@ -170,7 +171,7 @@ def test_get_sampleset_as_readsset(
         assert res["info"][10]["item_count"] == n_items_in_set
         for item in res["data"]["items"]:
             assert "ref" in item
-            if params.get("include_item_info", 0) == 1:
+            if params.get(INC_ITEM_INFO, 0) == 1:
                 assert "info" in item
                 assert len(item["info"]) == INFO_LENGTH
             else:

--- a/test/SampleSet_basic_test.py
+++ b/test/SampleSet_basic_test.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 
 import pytest
 from SetAPI.SetAPIImpl import SetAPI
+from SetAPI.generic.constants import INC_ITEM_INFO, INC_ITEM_REF_PATHS
 
 DESCRIPTION = "first pass at testing something or other"
 DEBUG = False
@@ -97,8 +98,8 @@ def test_basic_save_and_get(
         context,
         {
             "ref": res["set_ref"],
-            "include_item_info": 1,
-            "include_set_item_ref_paths": 1,
+            INC_ITEM_INFO: 1,
+            INC_ITEM_REF_PATHS: 1,
         },
     )[0]
     assert "data" in d2
@@ -243,8 +244,8 @@ def test_basic_save_and_get_condition_in_list(
         context,
         {
             "ref": res["set_ref"],
-            "include_item_info": 1,
-            "include_set_item_ref_paths": 1,
+            INC_ITEM_INFO: 1,
+            INC_ITEM_REF_PATHS: 1,
         },
     )[0]
     assert "data" in d2

--- a/test/common_checks.py
+++ b/test/common_checks.py
@@ -1,0 +1,334 @@
+import pytest
+from typing import Callable, Any
+from test.util import (
+    INFO_LENGTH,
+    info_to_name,
+    info_to_ref,
+    info_to_type,
+    info_to_usermeta,
+)
+
+
+def is_info_object(
+    obj: list[str | int | dict[str, str]],
+    obj_name: str | None = None,
+    obj_type: str | None = None,
+    obj_description: str | None = None,
+    n_items: int | None = None,
+    is_fake_set: bool = False,
+) -> None:
+    """Checks whether a mysterious data structure is a KBase info list.
+
+    If the set was not created by the SetAPI (is_fake_set = True), some of the
+    fields will be filled out differently, so the checks reflect this.
+
+    info list structure:
+    obj_id objid - the numerical id of the object.
+    obj_name name - the name of the object.
+    type_string type - the type of the object.
+    timestamp save_date - the save date of the object.
+    obj_ver ver - the version of the object.
+    username saved_by - the user that saved or copied the object.
+    ws_id wsid - the workspace containing the object.
+    ws_name workspace - the workspace containing the object.
+    string chsum - the md5 checksum of the object.
+    int size - the size of the object in bytes.
+    usermeta meta - arbitrary user-supplied metadata about
+        the object.
+
+    :param obj: the mysterious data structure
+    :type info: list[str|int|dict[str, str]]
+    :param obj_name: expected object name, defaults to None
+    :type obj_name: str | None, optional
+    :param obj_type: expected object type, defaults to None
+    :type obj_type: str | None, optional
+    :param obj_description: expected description in the user metadata, defaults to None
+    :type obj_description: str | None, optional
+    :param n_items: how many items are expected in the user metadata, defaults to None
+    :type n_items: int | None, optional
+    :param is_fake_set: whether or not the current set was created by the SetAPI, defaults to False
+    :type is_fake_set: bool, optional
+    """
+    assert isinstance(obj, list)
+    assert len(obj) == INFO_LENGTH
+    for ix in [0, 4, 6, 9]:
+        assert isinstance(obj[ix], int)
+    for ix in [1, 2, 3, 5, 7, 8]:
+        assert isinstance(obj[ix], str)
+    # usermeta field
+    if obj[10]:
+        assert isinstance(obj[10], dict)
+
+    # some of these can be "falsy" values (0, empty string), so check explicitly against None
+    if obj_name is not None:
+        assert info_to_name(obj) == obj_name
+    if obj_type:
+        assert obj_type in info_to_type(obj)
+    if obj_description is not None and not is_fake_set:
+        assert "description" in info_to_usermeta(obj)
+        assert info_to_usermeta(obj)["description"] == obj_description
+    if n_items is not None and not is_fake_set:
+        assert "item_count" in info_to_usermeta(obj)
+        assert info_to_usermeta(obj)["item_count"] == str(n_items)
+
+
+def check_save_set_output(
+    obj: dict[str, Any],
+    set_name: str,
+    set_type: str | None = None,
+    set_description: str | None = None,
+    n_items: int | None = None,
+    **kwargs,
+) -> None:
+    """Check the output of a save_set command.
+
+    The output should be of the form
+    { "set_ref": <upa>, "set_info": <kbase info list> }
+
+    :param obj: API output to check
+    :type obj: dict[str, Any]
+    :param set_name: the set name
+    :type set_name: str
+    :param set_type: the type of the set, defaults to None
+    :type set_type: str | None, optional
+    :param set_description: user-entered description of the set, defaults to None
+    :type set_description: str | None, optional
+    :param n_items: number of items in the set, defaults to None
+    :type n_items: int | None, optional
+    :param kwargs: leftover params - not used
+    :type kwargs: dict[str, Any], optional
+    """
+    assert obj is not None
+    assert "set_ref" in obj
+    assert "set_info" in obj
+    assert obj["set_ref"] == info_to_ref(obj["set_info"])
+    is_info_object(obj["set_info"], set_name, set_type, set_description, n_items)
+
+
+def check_second_item(
+    obj: dict[str, Any],
+    expected_item_data: dict[str, str],
+) -> None:
+    """Check the second item in a set.
+
+    :param obj: API output to check, with items stored in obj["data"]["items"]
+    :type obj: dict[str, Any]
+    :param expected_item_data: expected item data (should have ref and label)
+    :type expected_item_data: dict[str, str]
+    """
+    second_item = obj["data"]["items"][1]
+    assert second_item.get("ref", None) == expected_item_data["ref"]
+    assert second_item.get("label", None) == expected_item_data["label"]
+
+
+def check_get_set_output(
+    obj: dict[str, Any],
+    ref: str,
+    set_name: str,
+    set_type: str | None = None,
+    set_description: str | None = None,
+    n_items: int | None = None,
+    second_set_item: dict[str, str] | None = None,
+    include_item_info: int = 0,
+    include_set_item_ref_paths: int = 0,
+    ref_path_to_set: list[str] | None = None,
+    is_fake_set: bool = False,
+) -> None:
+    """Checks the output of a get_set command.
+
+    :param obj: API output to check
+    :type obj: dict[str, Any]
+    :param ref: reference used to access the set
+    :type ref: str
+    :param set_name: set name
+    :type set_name: str
+    :param set_type: set type, defaults to None
+    :type set_type: str | None, optional
+    :param set_description: set description, defaults to None
+    :type set_description: str | None, optional
+    :param n_items: how many items are expected in the set, defaults to None
+    :type n_items: int | None, optional
+    :param second_set_item: dict containing label and ref for the second item in the set, defaults to None
+    :type second_set_item: dict[str, str] | None, optional
+    :param include_item_info: whether set items are expected to have item info, defaults to 0 (false)
+    :type include_item_info: int, optional
+    :param include_set_item_ref_paths: whether set items are expected to have a ref path, defaults to 0 (false)
+    :type include_set_item_ref_paths: int, optional
+    :param ref_path_to_set: list of references for the set, defaults to None
+    :type ref_path_to_set: list[str], optional
+    :param is_fake_set: whether or not the current set was created by the SetAPI, defaults to False
+    :type is_fake_set: bool, optional
+    :param kwargs: leftover params - not used
+    :type kwargs: dict[str, Any], optional
+    """
+    assert obj is not None
+    assert "data" in obj
+    assert "info" in obj
+    is_info_object(
+        obj["info"], set_name, set_type, set_description, n_items, is_fake_set
+    )
+
+    assert obj["data"]["description"] == set_description
+    assert len(obj["data"]["items"]) == n_items
+
+    for item in obj["data"]["items"]:
+        if include_item_info == 1:
+            assert "info" in item
+            is_info_object(item["info"])
+        else:
+            assert "info" not in item
+
+        if include_set_item_ref_paths == 1:
+            ref_path = item.get("ref_path", "NOT_FOUND")
+            if ref_path_to_set:
+                assert ref_path == ";".join(ref_path_to_set) + ";" + item["ref"]
+            else:
+                assert item.get("ref_path", "NOT_FOUND") == f"{ref};{item['ref']}"
+        else:
+            assert "ref_path" not in item
+
+    if n_items and second_set_item:
+        check_second_item(obj, second_set_item)
+
+
+FAKE_WS_ID = 123456789
+
+
+def check_save_set_mismatched_genomes(
+    context: dict[str, str | list],
+    save_method: Callable,
+    set_items: list[dict[str, str]],
+    set_items_type: str,
+) -> None:
+    with pytest.raises(
+        ValueError,
+        match=f"All {set_items_type} objects in the set must use the same genome reference.",
+    ):
+        save_method(
+            context,
+            {
+                "workspace_id": FAKE_WS_ID,
+                "output_object_name": "foo",
+                "data": {
+                    "description": "mismatched genome alert!",
+                    "items": set_items,
+                },
+            },
+        )
+
+
+def check_save_set_no_data(
+    context: dict[str, str | list],
+    save_method: Callable,
+    set_items_type: str,
+) -> None:
+    """Check that a set cannot be created without a "data" parameter.
+
+    :param context: KBase context
+    :type context: dict[str, str  |  list]
+    :param save_method: which method we're using
+    :type save_method: Callable
+    :param set_items_type: type of item in the set
+    :type set_items_type: str
+    """
+    with pytest.raises(
+        ValueError,
+        match=f'The "data" parameter is required to save {set_items_type}Sets',
+    ):
+        save_method(
+            context,
+            {
+                "workspace_id": FAKE_WS_ID,
+                "output_object_name": "foo",
+                "data": None,
+            },
+        )
+
+
+def check_save_set_no_items_list(
+    context: dict[str, str | list],
+    save_method: Callable,
+    set_items_type: str,
+) -> None:
+    """Check that a set cannot be created without an "items" key under the "data" parameter.
+
+    :param context: context
+    :type context: dict[str, str  |  list]
+    :param save_method: SetAPI save method being tested
+    :type save_method: Callable
+    :param set_items_type: string with the item type
+    :type set_items_type: str
+    """
+    with pytest.raises(
+        ValueError,
+        match=f'An "items" list must be defined in the "data" parameter to save {set_items_type}Sets',
+    ):
+        save_method(
+            context,
+            {
+                "workspace_id": FAKE_WS_ID,
+                "output_object_name": "foo",
+                "data": {},
+            },
+        )
+
+
+def check_save_set_no_objects(
+    context: dict[str, str | list],
+    save_method: Callable,
+    set_items_type: str,
+) -> None:
+    """For classes that don't allow empty sets to be created.
+
+    :param context: context
+    :type context: dict[str, str  |  list]
+    :param save_method: SetAPI save method being tested
+    :type save_method: Callable
+    :param set_items_type: string with the item type
+    :type set_items_type: str
+    """
+    with pytest.raises(
+        ValueError,
+        match=f"{set_items_type}Sets must contain at least one {set_items_type} object reference.",
+    ):
+        save_method(
+            context,
+            {
+                "workspace_id": FAKE_WS_ID,
+                "output_object_name": "foo",
+                "data": {"items": []},
+            },
+        )
+
+
+def check_get_set_bad_ref(
+    context: dict[str, str | list],
+    get_method: Callable,
+) -> None:
+    with pytest.raises(
+        ValueError, match='The "ref" parameter must be a valid workspace reference'
+    ):
+        get_method(context, {"ref": "not_a_ref"})
+
+
+def check_get_set_bad_path(
+    context: dict[str, str | list],
+    get_method: Callable,
+) -> None:
+    with pytest.raises(
+        ValueError,
+        match='The "ref_path" parameter must contain valid workspace references',
+    ):
+        get_method(context, {"ref": "1/2/3", "ref_path_to_set": ["foo", "bar"]})
+
+
+def check_get_set_no_ref(
+    context: dict[str, str | list],
+    get_method: Callable,
+    set_items_type: str,
+) -> None:
+    with pytest.raises(
+        ValueError,
+        match=f'The "ref" parameter specifying the {set_items_type}Set is required',
+    ):
+        get_method(context, {"ref": None})

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -10,8 +10,8 @@ from test.util import (
     make_fake_alignment,
     make_fake_annotation,
     make_fake_expression,
-    make_fake_old_alignment_set,
-    make_fake_old_expression_set,
+    make_fake_rnaseq_alignment_set,
+    make_fake_rnaseq_expression_set,
     make_fake_sampleset,
     make_fake_feature_set,
     make_fake_diff_exp_matrix,
@@ -126,7 +126,7 @@ def test_workspaces(
     }
 
     # check what is in the workspaces
-    all_objs_default = ws_client.list_objects({"ids": [ws_id]})
+    all_objs_default = ws_client.list_objects({"ids": [ws_id], "includeMetadata": 1})
     all_objs_list_all_sets = ws_client.list_objects({"ids": [list_all_sets_ws_id]})
 
     # delete the test workspaces
@@ -401,11 +401,7 @@ def condition_set_ref(
         "unit_ont_ref": "KbaseOntologies/Custom",
     }
     condition_set_data = {
-        "conditions": {
-            conditions[0]: ["0", "0"],
-            conditions[1]: ["0", "0"],
-            conditions[2]: ["0", "0"],
-        },
+        "conditions": {conditions[ix]: ["0", "0"] for ix in range(2)},
         "factors": [
             {"factor": "Time series design", "unit": "Hour", **common_factor_data},
             {
@@ -416,19 +412,20 @@ def condition_set_ref(
         ],
         "ontology_mapping_method": "User Curation",
     }
-    save_object_params = {
-        "id": ws_id,
-        "objects": [
-            {
-                "type": "KBaseExperiments.ConditionSet",
-                "data": condition_set_data,
-                "name": condition_set_object_name,
-            }
-        ],
-    }
 
-    dfu_oi = clients["dfu"].save_objects(save_object_params)[0]
-    return info_to_ref(dfu_oi)
+    saved_condition_set_info = clients["dfu"].save_objects(
+        {
+            "id": ws_id,
+            "objects": [
+                {
+                    "type": "KBaseExperiments.ConditionSet",
+                    "data": condition_set_data,
+                    "name": condition_set_object_name,
+                }
+            ],
+        }
+    )[0]
+    return info_to_ref(saved_condition_set_info)
 
 
 @pytest.fixture(scope="session")
@@ -662,7 +659,7 @@ def rnaseq_alignment_sets(
     :rtype: list[str]
     """
     return [
-        make_fake_old_alignment_set(
+        make_fake_rnaseq_alignment_set(
             f"fake_rnaseq_alignment_set_{i}",
             reads_refs,
             genome_refs[0],
@@ -704,8 +701,7 @@ def rnaseq_expression_set(
     :return: KBase UPA
     :rtype: str
     """
-    # Make a fake RNASeq Expression Set object
-    return make_fake_old_expression_set(
+    return make_fake_rnaseq_expression_set(
         "fake_rnaseq_expression_set",
         genome_refs[0],
         sampleset_ref,

--- a/test/generic_set_access_test.py
+++ b/test/generic_set_access_test.py
@@ -6,6 +6,7 @@ from typing import Any
 import pytest
 from SetAPI.generic.GenericSetNavigator import GenericSetNavigator
 from SetAPI.SetAPIImpl import SetAPI
+from SetAPI.generic.constants import INC_ITEM_INFO, INC_ITEM_REF_PATHS, REF_PATH_TO_SET
 
 DEBUG = False
 
@@ -108,7 +109,7 @@ def test_list_sets(
 
     # Get the sets with their reference paths
     res3 = set_api_client.list_sets(
-        context, {"workspace": list_all_sets_ws_name, "include_set_item_ref_paths": 1}
+        context, {"workspace": list_all_sets_ws_name, INC_ITEM_REF_PATHS: 1}
     )[0]
 
     if DEBUG:
@@ -187,7 +188,7 @@ def unit_test_get_set_items(
                 {"ref": set_data["set_refs"][1]},
                 {"ref": set_data["set_refs"][2]},
             ],
-            "include_set_item_ref_paths": 1,
+            INC_ITEM_REF_PATHS: 1,
         },
     )[0]
     if DEBUG:

--- a/test/util.py
+++ b/test/util.py
@@ -1,10 +1,8 @@
-"""
-Some utility functions to help with testing. These mainly add fake objects to use in making sets.
-"""
+"""Some utility functions to help with testing. These mainly add fake objects to use in making sets."""
 import json
+from typing import Any
 
 from installed_clients.WorkspaceClient import Workspace
-
 from SetAPI.util import info_to_ref
 
 INFO_LENGTH = 11
@@ -53,7 +51,7 @@ def info_to_usermeta(info: list[int | str | dict[str, str]]) -> dict[str, str]:
     :param info: info list
     :type info: list[int | str | dict[str, str]]
     :return: the metadata (if it exists)
-    :rtype: None | dict[str, Any]
+    :rtype: dict[str, Any]
     """
     return info[10]
 
@@ -61,20 +59,19 @@ def info_to_usermeta(info: list[int | str | dict[str, str]]) -> dict[str, str]:
 def make_fake_alignment(
     dummy_file_shock_handle: str,
     name: str,
-    reads_ref,
-    genome_ref,
+    reads_ref: str,
+    genome_ref: str,
     ws_id: int,
     ws_client: Workspace,
-):
-    """
-    Makes a Fake KBaseRNASeq.RNASeqAlignment object and returns a ref to it.
-    dfu: DataFileUtil client
+) -> str:
+    """Makes a Fake KBaseRNASeq.RNASeqAlignment object and returns a ref to it.
+
     dummy_file_shock_handle: shock handle for a dummy file
     name: the name of the object
     reads_ref: a reference to a valid (probably fake) reads library
     genome_ref: a reference to a valid (also probably fake) genome
-    workspace_name: the name of the workspace to save this object
-    workspace_client: a Workspace client tuned to the server of your choice
+    ws_id: the ID of the workspace to save this object
+    ws_client: a Workspace client tuned to the server of your choice.
     """
     alignment = {
         "file": dummy_file_shock_handle,
@@ -93,7 +90,7 @@ def make_fake_annotation(
     name: str,
     ws_id: int,
     ws_client: Workspace,
-):
+) -> str:
     annotation = {
         "handle": dummy_file_shock_handle,
         "size": 0,
@@ -106,8 +103,8 @@ def make_fake_annotation(
 
 
 def make_fake_diff_exp_matrix(
-    name: str, ws_id: int, ws_client: Workspace, genome_ref=None
-):
+    name: str, ws_id: int, ws_client: Workspace, genome_ref: None | str = None
+) -> str:
     """
     Makes a fake KBaseFeatureValues.DifferentialExpressionMatrix object and returns a ref ot it.
     * = optional (so, left out of this fake stuff)
@@ -153,14 +150,15 @@ def make_fake_diff_exp_matrix(
 def make_fake_expression(
     dummy_file_shock_handle: str,
     name: str,
-    genome_ref,
-    annotation_ref,
-    alignment_ref,
+    genome_ref: str,
+    annotation_ref: str,
+    alignment_ref: str,
     ws_id: int,
     ws_client: Workspace,
-):
+) -> str:
     """
     Makes a Fake KBaseRNASeq.RNASeqExpression object and returns a ref to it.
+
     genome_ref: reference to a genome object
     annotation_ref: reference to a KBaseRNASeq.GFFAnnotation
     alignment_ref: reference to a KBaseRNASeq.RNASeqAlignment
@@ -181,9 +179,12 @@ def make_fake_expression(
     return make_fake_object(exp, "KBaseRNASeq.RNASeqExpression", name, ws_id, ws_client)
 
 
-def make_fake_feature_set(name: str, genome_ref, ws_id: int, ws_client: Workspace):
+def make_fake_feature_set(
+    name: str, genome_ref: str, ws_id: int, ws_client: Workspace
+) -> str:
     """
     Makes a fake KBaseCollections.FeatureSet object and returns a ref to it.
+
     KBaseCollections.FeatureSet type:
     typedef structure {
         string description;
@@ -205,16 +206,16 @@ def make_fake_feature_set(name: str, genome_ref, ws_id: int, ws_client: Workspac
     )
 
 
-def make_fake_old_alignment_set(
+def make_fake_rnaseq_alignment_set(
     name: str,
-    reads_refs,
-    genome_ref,
-    sampleset_ref,
-    alignments_refs,
+    reads_refs: list[str],
+    genome_ref: str,
+    sampleset_ref: str,
+    alignments_refs: list[str],
     ws_id: int,
     ws_client: Workspace,
-    include_sample_alignments=False,
-):
+    include_sample_alignments: bool = False,
+) -> str:
     """
     Make a fake set object for KBaseRNASeq.RNASeqAlignmentSet objects
     Needs a whole bunch of stuff:
@@ -247,17 +248,17 @@ def make_fake_old_alignment_set(
     )
 
 
-def make_fake_old_expression_set(
+def make_fake_rnaseq_expression_set(
     name: str,
-    genome_ref,
-    sampleset_ref,
-    alignments_refs,
-    alignmentset_ref,
-    expressions_refs,
+    genome_ref: str,
+    sampleset_ref: str,
+    alignments_refs: list[str],
+    alignmentset_ref: str,
+    expressions_refs: list[str],
     ws_id: int,
     ws_client: Workspace,
-    include_sample_expressions=False,
-):
+    include_sample_expressions: bool = False,
+) -> str:
     """
     Make a fake set object for KBaseRNASeq.RNASeqAlignmentSet objects
     Needs a whole bunch of stuff:
@@ -291,8 +292,12 @@ def make_fake_old_expression_set(
 
 
 def make_fake_sampleset(
-    name: str, reads_refs, conditions, ws_id: int, ws_client: Workspace
-):
+    name: str,
+    reads_refs: list[str],
+    conditions: list[str],
+    ws_id: int,
+    ws_client: Workspace,
+) -> str:
     """
     Make a fake KBaseRNASeq.RNASeqSampleSet object.
     reads_refs and conditions are expected to be the same length, and that length can be 0.
@@ -314,8 +319,12 @@ def make_fake_sampleset(
 
 
 def make_fake_object(
-    obj, obj_type: str, name: str, ws_id: int, workspace_client: Workspace
-):
+    obj: dict[str, Any],
+    obj_type: str,
+    name: str,
+    ws_id: int,
+    workspace_client: Workspace,
+) -> str:
     """
     Saves a dummy object (obj) of given type obj_type and name to the given workspace ID using the
     provided workspace client.

--- a/test/util_test.py
+++ b/test/util_test.py
@@ -1,0 +1,258 @@
+from typing import Any
+import pytest
+from SetAPI.util import (
+    check_reference,
+    build_ws_obj_selector,
+    populate_item_object_ref_paths,
+    convert_workspace_param,
+)
+
+bad_upas = [
+    None,
+    "",
+    "//",
+    "://",
+    " / / ",
+    "1",
+    "1/",
+    "1//3",
+    "1/2/",
+    "1/2/3/",
+    "1/2/3;",
+    "1/2/3;4/5/",
+    "1/2/foo",
+    "1/bar",
+    "1/bar/3",
+    "1:this/that",
+    "1;2;3",
+    "://",
+    ":this/that",
+    "foo",
+    "foo/2",
+    "foo/2/3",
+    "foo/bar/3",
+    "foo/bar;baz/frobozz",
+    "foo:1/2",
+    "http://",
+    "myws/myobj/myver",
+    "myws/myobj/myver;otherws/otherobj/otherver",
+    "no,commas,allowed",
+    "some whitespace",
+    "this:/that",
+    "this:1/that",
+    "ws:obj:ver",
+    "x/y/z",
+]
+
+
+@pytest.mark.parametrize("upa", [pytest.param(upa) for upa in bad_upas])
+def test_check_reference_fail(upa):
+    assert check_reference(upa) is False
+
+
+good_upas = [
+    "1/2",
+    "1/2/3",
+    "bar/baz",
+    "barb13/baz17710n",
+    "foo:bar/baz",
+    "user-name:_ws_.name/obj-name",
+    "some-text:some_more.text/other-text_here.",
+]
+
+
+@pytest.mark.parametrize("upa", [pytest.param(upa) for upa in good_upas])
+def test_check_reference_good_refs(upa) -> None:
+    assert check_reference(upa) is True
+
+
+GOOD_UPA = "123/45/6"
+WS_ID_INT = 12345
+WS_ID_STR = "12345"
+WS_NAME = "some_string"
+
+
+@pytest.mark.parametrize(
+    "params_key",
+    [
+        pytest.param("workspace", id="workspace"),
+        pytest.param("workspace_id", id="workspace_id"),
+        pytest.param("ws_id", id="ws_id"),
+    ],
+)
+@pytest.mark.parametrize(
+    "args",
+    [
+        pytest.param(
+            {
+                "value": WS_ID_INT,
+                "expected": {"id": WS_ID_INT},
+            },
+            id="ws_id_int",
+        ),
+        pytest.param(
+            {
+                "value": WS_ID_STR,
+                "expected": {"id": WS_ID_INT},
+            },
+            id="ws_id_str",
+        ),
+        pytest.param(
+            {
+                "value": WS_NAME,
+                "expected": {"workspace": WS_NAME},
+            },
+            id="ws_name",
+        ),
+    ],
+)
+def test_convert_workspace_param(
+    params_key: str, args: dict[str, dict[str, int | str]]
+) -> None:
+    assert convert_workspace_param({params_key: args["value"]}) == args["expected"]
+
+
+@pytest.mark.parametrize(
+    "params_key",
+    [
+        pytest.param("workspace_name", id="workspace_name"),
+        pytest.param("ws_name", id="ws_name"),
+    ],
+)
+@pytest.mark.parametrize(
+    "args",
+    [
+        pytest.param(
+            {
+                "value": WS_ID_INT,
+                "expected": {"workspace": WS_ID_STR},
+            },
+            id="ws_id_int",
+        ),
+        pytest.param(
+            {
+                "value": WS_ID_STR,
+                "expected": {"workspace": WS_ID_STR},
+            },
+            id="ws_id_str",
+        ),
+        pytest.param(
+            {
+                "value": WS_NAME,
+                "expected": {"workspace": WS_NAME},
+            },
+            id="ws_name",
+        ),
+    ],
+)
+def test_convert_workspace_param_ws_name(
+    params_key: str, args: dict[str, str | int | dict[str, int | str]]
+) -> None:
+    assert convert_workspace_param({params_key: args["value"]}) == args["expected"]
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        pytest.param({}, id="empty_dict"),
+        pytest.param(None, id="dict is None"),
+        pytest.param({"this": "that"}, id="missing_param"),
+    ],
+)
+def test_convert_workspace_param_fail(args: None | dict[str, str]) -> None:
+    with pytest.raises(
+        ValueError, match="No appropriate key found for workspace name or ID"
+    ):
+        convert_workspace_param(args)
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        pytest.param(
+            {
+                "ref": GOOD_UPA,
+                "ref_path_to_set": None,
+                "expected": GOOD_UPA,
+            },
+            id="ref_path_to_set_none",
+        ),
+        pytest.param(
+            {
+                "ref": GOOD_UPA,
+                "ref_path_to_set": [],
+                "expected": GOOD_UPA,
+            },
+            id="ref_path_to_set_empty",
+        ),
+        pytest.param(
+            {
+                "ref": None,
+                "ref_path_to_set": None,
+                "expected": None,
+            },
+            id="ref_and_ref_path_none",
+        ),
+        pytest.param(
+            {
+                "ref": None,
+                "ref_path_to_set": ["a/b/c"],
+                "expected": "a/b/c",
+            },
+            id="ref_path_single_item",
+        ),
+        pytest.param(
+            {
+                "ref": "whatever",
+                "ref_path_to_set": ["a/b/c", "d/e/f", "g/h/i"],
+                "expected": "a/b/c;d/e/f;g/h/i",
+            },
+            id="ref_path_three_items",
+        ),
+    ],
+)
+def test_build_ws_obj_selector(args: dict[str, Any]) -> None:
+    """Test that the correct workspace object selector is built.
+
+    :param args: dict containing the arguments and expected result.
+    :type args: dict[str, Any]
+    """
+    assert build_ws_obj_selector(args["ref"], args["ref_path_to_set"]) == {
+        "ref": args["expected"]
+    }
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        pytest.param(
+            {
+                "set_items": [],
+                "obj_selector": {"ref": "whatever"},
+                "expected": [],
+            },
+            id="empty_list",
+        ),
+        pytest.param(
+            {
+                "set_items": [{"ref": "some_ref"}, {"ref": "some_other_ref"}],
+                "obj_selector": {"ref": "whatever"},
+                "expected": [
+                    {"ref": "some_ref", "ref_path": "whatever;some_ref"},
+                    {"ref": "some_other_ref", "ref_path": "whatever;some_other_ref"},
+                ],
+            },
+            id="populated_list",
+        ),
+    ],
+)
+def test_populate_item_object_ref_paths(args: dict[str, Any]) -> None:
+    """Test that the correct ref path is added to items in a list.
+
+    :param args: dict containing arguments and expected result.
+    :type args: dict[str, Any]
+    """
+    assert (
+        populate_item_object_ref_paths(args["set_items"], args["obj_selector"])
+        == args["expected"]
+    )


### PR DESCRIPTION
Sorry this got a lot longer than expected... I had forgotten there were some simple search-n-replace changes in addition to the more complex changes I made!

changes:

- fix "specifiying" typo in error messages
- create constants for the strings `include_item_info`, `include_set_item_ref_paths`, and `ref_path_to_set`
- improve the `util` module and add tests
- for two specific modules, `AssemblySetInterface` and `ReadsAlignmentSetInterface`, standardise the methods and param validation, etc.
- standardise the tests used by the two modules above
- add in functions that run all the custom assertions used in verifying that the SetAPI returns what we think it should

Codecov upload failed.

Planned next steps:
- convert the tests for the other classes over to this format.
- convert the other classes over to the format used by AssemblySet and ReadAlignmentSet.
- add ability to return info as dicts (thanks to new workspace `get_object_info3` param).
- change `list_all_sets` so it actually lists all sets, instead of just reads sets.
- try my best to forget about the SetAPI... it was all just a horrible dream.