### PR TITLE
List all sets: Switch to standard error tests

### DIFF
--- a/lib/SetAPI/assembly/AssemblySetInterfaceV1.py
+++ b/lib/SetAPI/assembly/AssemblySetInterfaceV1.py
@@ -74,7 +74,7 @@ class AssemblySetInterfaceV1:
         :param params: parameters to the save_set function
         :type params: dict[str, Any]
         """
-        if params.get("data", None) is None:
+        if params.get("data") is None:
             err_msg = param_required("data")
             raise ValueError(err_msg)
 
@@ -124,7 +124,7 @@ class AssemblySetInterfaceV1:
         :return: validated parameters
         :rtype: dict[str, str | bool | list[str]]
         """
-        if not params.get("ref", None):
+        if not params.get("ref"):
             raise ValueError(param_required("ref"))
 
         if not check_reference(params["ref"]):

--- a/lib/SetAPI/assembly/AssemblySetInterfaceV1.py
+++ b/lib/SetAPI/assembly/AssemblySetInterfaceV1.py
@@ -4,12 +4,12 @@ from typing import Any
 from installed_clients.WorkspaceClient import Workspace
 
 from SetAPI.error_messages import (
-    data_required,
     include_params_valid,
     list_required,
+    no_dupes,
+    param_required,
     ref_must_be_valid,
     ref_path_must_be_valid,
-    ref_required,
 )
 from SetAPI.generic.constants import INC_ITEM_INFO, INC_ITEM_REF_PATHS, REF_PATH_TO_SET
 from SetAPI.generic.SetInterfaceV1 import SetInterfaceV1
@@ -74,24 +74,26 @@ class AssemblySetInterfaceV1:
         :param params: parameters to the save_set function
         :type params: dict[str, Any]
         """
-        # TODO: add checks that only one copy of each assembly is in the set
-
         if params.get("data", None) is None:
-            err_msg = data_required(self.set_items_type())
+            err_msg = param_required("data")
             raise ValueError(err_msg)
 
         # N.b. AssemblySets allow an empty items list so we don't
         # need to check that params["data"]["items"] is populated
         if "items" not in params["data"]:
-            raise ValueError(list_required(self.set_items_type()))
+            raise ValueError(list_required("items"))
 
         # add 'description' and item 'label' fields if not present:
         if "description" not in params["data"]:
             params["data"]["description"] = ""
 
+        seen_refs = set()
         for item in params["data"]["items"]:
             if "label" not in item:
                 item["label"] = ""
+            if item["ref"] in seen_refs:
+                raise ValueError(no_dupes())
+            seen_refs.add(item["ref"])
 
     def get_assembly_set(
         self: "AssemblySetInterfaceV1", _, params: dict[str, Any]
@@ -108,7 +110,7 @@ class AssemblySetInterfaceV1:
         :rtype: dict[str, Any]
         """
         checked_params = self._check_get_set_params(params)
-        return self.set_interface.get_set(checked_params)
+        return self.set_interface.get_set(**checked_params)
 
     def _check_get_set_params(
         self: "AssemblySetInterfaceV1", params: dict[str, Any]
@@ -123,7 +125,7 @@ class AssemblySetInterfaceV1:
         :rtype: dict[str, str | bool | list[str]]
         """
         if not params.get("ref", None):
-            raise ValueError(ref_required(self.set_items_type()))
+            raise ValueError(param_required("ref"))
 
         if not check_reference(params["ref"]):
             raise ValueError(ref_must_be_valid())

--- a/lib/SetAPI/differentialexpressionmatrix/DifferentialExpressionMatrixSetInterfaceV1.py
+++ b/lib/SetAPI/differentialexpressionmatrix/DifferentialExpressionMatrixSetInterfaceV1.py
@@ -47,14 +47,14 @@ class DifferentialExpressionMatrixSetInterfaceV1:
         }
 
     def _validate_save_set_data(self, params):
-        if params.get("data", None) is None:
+        if params.get("data") is None:
             err_msg = param_required("data")
             raise ValueError(err_msg)
 
         if "items" not in params["data"]:
             raise ValueError(list_required("items"))
 
-        if not params["data"].get("items", None):
+        if not params["data"].get("items"):
             raise ValueError(no_items(self.set_items_type()))
 
         # add 'description' and 'label' fields if not present in data:
@@ -77,7 +77,7 @@ class DifferentialExpressionMatrixSetInterfaceV1:
         info = self.workspace_client.get_object_info3(
             {"objects": ref_list, "includeMetadata": 1}
         )
-        num_genomes = len({item[10].get("Genome", None) for item in info["infos"]})
+        num_genomes = len({item[10].get("Genome") for item in info["infos"]})
         if num_genomes != 1:
             err_msg = same_ref(self.set_items_type())
             raise ValueError(err_msg)
@@ -87,7 +87,7 @@ class DifferentialExpressionMatrixSetInterfaceV1:
         return self.set_interface.get_set(**checked_params)
 
     def _check_get_set_params(self, params):
-        if not params.get("ref", None):
+        if not params.get("ref"):
             raise ValueError(param_required("ref"))
 
         if not check_reference(params["ref"]):

--- a/lib/SetAPI/differentialexpressionmatrix/DifferentialExpressionMatrixSetInterfaceV1.py
+++ b/lib/SetAPI/differentialexpressionmatrix/DifferentialExpressionMatrixSetInterfaceV1.py
@@ -1,9 +1,17 @@
-"""
-An interface for handling sets of Expression objects.
-"""
+"""An interface for handling sets of Expression objects."""
+from SetAPI.error_messages import (
+    include_params_valid,
+    list_required,
+    no_dupes,
+    no_items,
+    param_required,
+    ref_must_be_valid,
+    ref_path_must_be_valid,
+    same_ref,
+)
+from SetAPI.generic.constants import INC_ITEM_INFO, INC_ITEM_REF_PATHS, REF_PATH_TO_SET
 from SetAPI.generic.SetInterfaceV1 import SetInterfaceV1
 from SetAPI.util import check_reference, info_to_ref
-from SetAPI.generic.constants import INC_ITEM_INFO, INC_ITEM_REF_PATHS, REF_PATH_TO_SET
 
 
 class DifferentialExpressionMatrixSetInterfaceV1:
@@ -11,13 +19,23 @@ class DifferentialExpressionMatrixSetInterfaceV1:
         self.workspace_client = workspace_client
         self.set_interface = SetInterfaceV1(workspace_client)
 
+    @staticmethod
+    def set_type() -> str:
+        """The set type saved by this class."""
+        return "KBaseSets.DifferentialExpressionMatrixSet"
+
+    @staticmethod
+    def set_items_type() -> str:
+        """The type of object in the sets."""
+        return "DifferentialExpressionMatrix"
+
+    @staticmethod
+    def allows_empty_set() -> bool:
+        """Whether or not the class allows the creation of empty sets."""
+        return False
+
     def save_differential_expression_matrix_set(self, ctx, params):
-        if "data" in params and params["data"] is not None:
-            self._validate_differential_expression_matrix_set_data(params["data"])
-        else:
-            raise ValueError(
-                '"data" parameter field required to save a DifferentialExpressionMatrixSet'
-            )
+        self._validate_save_set_data(params)
 
         save_result = self.set_interface.save_set(
             "KBaseSets.DifferentialExpressionMatrixSet", ctx["provenance"], params
@@ -28,66 +46,65 @@ class DifferentialExpressionMatrixSetInterfaceV1:
             "set_info": info,
         }
 
-    def _validate_differential_expression_matrix_set_data(self, data):
-        # Normalize the object, make empty strings where necessary
-        if "description" not in data:
-            data["description"] = ""
+    def _validate_save_set_data(self, params):
+        if params.get("data", None) is None:
+            err_msg = param_required("data")
+            raise ValueError(err_msg)
 
-        if "items" not in data or len(data.get("items", [])) == 0:
-            raise ValueError(
-                "A DifferentialExpressionMatrixSet must contain at "
-                "least one DifferentialExpressionMatrix object reference."
-            )
+        if "items" not in params["data"]:
+            raise ValueError(list_required("items"))
 
-        refs = []
-        for item in data["items"]:
-            refs.append(item["ref"])
+        if not params["data"].get("items", None):
+            raise ValueError(no_items(self.set_items_type()))
+
+        # add 'description' and 'label' fields if not present in data:
+        if "description" not in params["data"]:
+            params["data"]["description"] = ""
+
+        seen_refs = set()
+        for item in params["data"]["items"]:
             if "label" not in item:
                 item["label"] = ""
-
-        ref_list = list([{"ref": r} for r in refs])
+            if item["ref"] in seen_refs:
+                raise ValueError(no_dupes())
+            seen_refs.add(item["ref"])
 
         # Get all the genome ids from our DifferentialExpressionMatrix references (it's the
         # Genome key in the object metadata). Make a set out of them.
         # If there's more than 1 item in the set, then either those items are bad, or they're
         # aligned against different genomes.
+        ref_list = [{"ref": ref} for ref in seen_refs]
         info = self.workspace_client.get_object_info3(
             {"objects": ref_list, "includeMetadata": 1}
         )
-        num_genomes = len(set([item[10].get("Genome", None) for item in info["infos"]]))
-        if num_genomes > 1:
-            raise ValueError(
-                "All Differential Expression Matrix objects in the set must use "
-                "the same genome reference."
-            )
+        num_genomes = len({item[10].get("Genome", None) for item in info["infos"]})
+        if num_genomes != 1:
+            err_msg = same_ref(self.set_items_type())
+            raise ValueError(err_msg)
 
     def get_differential_expression_matrix_set(self, ctx, params):
-        self._check_get_differential_expression_matrix_set_params(params)
+        checked_params = self._check_get_set_params(params)
+        return self.set_interface.get_set(**checked_params)
 
-        include_item_info = True if params.get(INC_ITEM_INFO, 0) == 1 else False
+    def _check_get_set_params(self, params):
+        if not params.get("ref", None):
+            raise ValueError(param_required("ref"))
 
-        include_set_item_ref_paths = (
-            True if params.get(INC_ITEM_REF_PATHS, 0) == 1 else False
-        )
+        if not check_reference(params["ref"]):
+            raise ValueError(ref_must_be_valid())
 
         ref_path_to_set = params.get(REF_PATH_TO_SET, [])
+        for path in ref_path_to_set:
+            if not check_reference(path):
+                raise ValueError(ref_path_must_be_valid())
 
-        set_data = self.set_interface.get_set(
-            params["ref"],
-            include_item_info,
-            ref_path_to_set,
-            include_set_item_ref_paths,
-        )
-        return set_data
+        for param in [INC_ITEM_INFO, INC_ITEM_REF_PATHS]:
+            if param in params and params[param] not in [0, 1]:
+                raise ValueError(include_params_valid(param))
 
-    def _check_get_differential_expression_matrix_set_params(self, params):
-        if "ref" not in params or params["ref"] is None:
-            raise ValueError(
-                '"ref" parameter field specifying the DifferentialExpressionMatrix set is required'
-            )
-        if not check_reference(params["ref"]):
-            raise ValueError('"ref" parameter must be a valid workspace reference')
-        if INC_ITEM_INFO in params and params[INC_ITEM_INFO] not in [0, 1]:
-            raise ValueError(
-                '"include_item_info" parameter field can only be set to 0 or 1'
-            )
+        return {
+            "ref": params["ref"],
+            INC_ITEM_INFO: params.get(INC_ITEM_INFO, 0) == 1,
+            INC_ITEM_REF_PATHS: params.get(INC_ITEM_REF_PATHS, 0) == 1,
+            REF_PATH_TO_SET: ref_path_to_set,
+        }

--- a/lib/SetAPI/error_messages.py
+++ b/lib/SetAPI/error_messages.py
@@ -1,32 +1,34 @@
 """Functions to construct common error messages."""
 
 
-def data_required(set_items_type: str) -> str:
-    return f'The "data" parameter is required to save {set_items_type}Sets'
-
-
 def include_params_valid(param_name) -> str:
-    return f'The "{param_name}" parameter can only be set to 0 or 1'
+    return f'The "{param_name}" parameter can only be set to 0 or 1.'
 
 
-def list_required(set_items_type: str, list_type: str = "items") -> str:
-    return f'An "{list_type}" list must be defined in the "data" parameter to save {set_items_type}Sets'
+def list_required(list_type: str = "items") -> str:
+    return (
+        f'An "{list_type}" list must be defined in the "data" parameter to save a set.'
+    )
+
+
+def no_dupes() -> str:
+    return "Please ensure there are no duplicate refs in the set."
 
 
 def no_items(set_items_type: str) -> str:
     return f"{set_items_type}Sets must contain at least one {set_items_type} object reference."
 
 
-def ref_required(set_items_type: str) -> str:
-    return f'The "ref" parameter specifying the {set_items_type}Set is required'
+def param_required(param_name: str) -> str:
+    return f'The "{param_name}" parameter is required.'
 
 
 def ref_must_be_valid() -> str:
-    return 'The "ref" parameter must be a valid workspace reference'
+    return 'The "ref" parameter must be a valid workspace reference.'
 
 
 def ref_path_must_be_valid() -> str:
-    return 'The "ref_path" parameter must contain valid workspace references'
+    return 'The "ref_path" parameter must contain valid workspace references.'
 
 
 def same_ref(set_items_type: str) -> str:

--- a/lib/SetAPI/expression/ExpressionSetInterfaceV1.py
+++ b/lib/SetAPI/expression/ExpressionSetInterfaceV1.py
@@ -49,14 +49,14 @@ class ExpressionSetInterfaceV1:
         }
 
     def _validate_save_set_data(self, params):
-        if params.get("data", None) is None:
+        if params.get("data") is None:
             err_msg = param_required("data")
             raise ValueError(err_msg)
 
         if "items" not in params["data"]:
             raise ValueError(list_required("items"))
 
-        if not params["data"].get("items", None):
+        if not params["data"].get("items"):
             raise ValueError(no_items(self.set_items_type()))
 
         # add 'description' and item 'label' fields if not present:
@@ -124,7 +124,7 @@ class ExpressionSetInterfaceV1:
             {"objects": expression_items, "includeMetadata": 1}
         )["infos"]
         for idx, _ in enumerate(expression_items):
-            expression_items[idx]["label"] = item_infos[idx][10].get("condition", None)
+            expression_items[idx]["label"] = item_infos[idx][10].get("condition")
             if checked_params[INC_ITEM_INFO]:
                 expression_items[idx]["info"] = item_infos[idx]
 
@@ -137,7 +137,7 @@ class ExpressionSetInterfaceV1:
         }
 
     def _check_get_set_params(self, params):
-        if not params.get("ref", None):
+        if not params.get("ref"):
             raise ValueError(param_required("ref"))
 
         if not check_reference(params["ref"]):

--- a/lib/SetAPI/expression/ExpressionSetInterfaceV1.py
+++ b/lib/SetAPI/expression/ExpressionSetInterfaceV1.py
@@ -1,10 +1,22 @@
-"""
-An interface for handling sets of Expression objects.
-"""
-from SetAPI import util
-from SetAPI.generic.SetInterfaceV1 import SetInterfaceV1
-from SetAPI.util import info_to_ref
+"""An interface for handling sets of Expression objects."""
+from SetAPI.error_messages import (
+    include_params_valid,
+    list_required,
+    no_dupes,
+    no_items,
+    param_required,
+    ref_must_be_valid,
+    ref_path_must_be_valid,
+    same_ref,
+)
 from SetAPI.generic.constants import INC_ITEM_INFO, INC_ITEM_REF_PATHS, REF_PATH_TO_SET
+from SetAPI.generic.SetInterfaceV1 import SetInterfaceV1
+from SetAPI.util import (
+    build_ws_obj_selector,
+    check_reference,
+    info_to_ref,
+    populate_item_object_ref_paths,
+)
 
 
 class ExpressionSetInterfaceV1:
@@ -12,11 +24,20 @@ class ExpressionSetInterfaceV1:
         self.workspace_client = workspace_client
         self.set_interface = SetInterfaceV1(workspace_client)
 
+    @staticmethod
+    def set_type() -> str:
+        return "KBaseSets.ExpressionSet"
+
+    @staticmethod
+    def set_items_type() -> str:
+        return "Expression"
+
+    @staticmethod
+    def allows_empty_set() -> bool:
+        return False
+
     def save_expression_set(self, ctx, params):
-        if "data" in params and params["data"] is not None:
-            self._validate_expression_set_data(params["data"])
-        else:
-            raise ValueError('"data" parameter field required to save an ExpressionSet')
+        self._validate_save_set_data(params)
 
         save_result = self.set_interface.save_set(
             "KBaseSets.ExpressionSet", ctx["provenance"], params
@@ -27,115 +48,113 @@ class ExpressionSetInterfaceV1:
             "set_info": info,
         }
 
-    def _validate_expression_set_data(self, data):
-        # Normalize the object, make empty strings where necessary
-        if "description" not in data:
-            data["description"] = ""
+    def _validate_save_set_data(self, params):
+        if params.get("data", None) is None:
+            err_msg = param_required("data")
+            raise ValueError(err_msg)
 
-        if "items" not in data or len(data.get("items", [])) == 0:
-            raise ValueError(
-                "An ExpressionSet must contain at "
-                "least one Expression object reference."
-            )
+        if "items" not in params["data"]:
+            raise ValueError(list_required("items"))
 
-        refs = []
-        for item in data["items"]:
-            refs.append(item["ref"])
+        if not params["data"].get("items", None):
+            raise ValueError(no_items(self.set_items_type()))
+
+        # add 'description' and item 'label' fields if not present:
+        if "description" not in params["data"]:
+            params["data"]["description"] = ""
+
+        seen_refs = set()
+        for item in params["data"]["items"]:
             if "label" not in item:
                 item["label"] = ""
-
-        ref_list = list([{"ref": r} for r in refs])
+            if item["ref"] in seen_refs:
+                raise ValueError(no_dupes())
+            seen_refs.add(item["ref"])
 
         # Get all the genome ids from our Expression references (it's the genome_id key in
         # the object metadata). Make a set out of them.
         # If there's 0 or more than 1 item in the set, then either those items are bad, or they're
         # aligned against different genomes.
+        ref_list = [{"ref": ref} for ref in seen_refs]
         info = self.workspace_client.get_object_info3(
             {"objects": ref_list, "includeMetadata": 1}
         )
-        num_genomes = len(set([item[10]["genome_id"] for item in info["infos"]]))
-        if num_genomes == 0 or num_genomes > 1:
-            raise ValueError(
-                "All Expression objects in the set must use "
-                "the same genome reference."
-            )
+        num_genomes = len({item[10]["genome_id"] for item in info["infos"]})
+        if num_genomes != 1:
+            err_msg = same_ref(self.set_items_type())
+            raise ValueError(err_msg)
 
     def get_expression_set(self, ctx, params):
-        set_type, obj_spec = self._check_get_expression_set_params(params)
+        checked_params = self._check_get_set_params(params)
 
-        include_item_info = True if params.get(INC_ITEM_INFO, 0) == 1 else False
-
-        include_set_item_ref_paths = (
-            True if params.get(INC_ITEM_REF_PATHS, 0) == 1 else False
+        obj_spec = build_ws_obj_selector(
+            checked_params["ref"], checked_params[REF_PATH_TO_SET]
         )
-
-        ref_path_to_set = params.get(REF_PATH_TO_SET, [])
+        info = self.workspace_client.get_object_info3({"objects": [obj_spec]})
+        set_type = info["infos"][0][2]
 
         if "KBaseSets" in set_type:
             # If it's a KBaseSets type, then we know the usual interface will work...
-            return self.set_interface.get_set(
-                params["ref"],
-                include_item_info,
-                ref_path_to_set,
-                include_set_item_ref_paths,
-            )
+            return self.set_interface.get_set(**checked_params)
+
+        # get_rnaseq_expression_set
+        # ...otherwise, we need to fetch it directly from the workspace and tweak it into the
+        # expected return object
+
+        obj_data = self.workspace_client.get_objects2({"objects": [obj_spec]})["data"][
+            0
+        ]
+
+        obj = obj_data["data"]
+        obj_info = obj_data["info"]
+
+        if "sample_expression_ids" in obj:
+            expression_ref_list = obj["sample_expression_ids"]
         else:
-            # ...otherwise, we need to fetch it directly from the workspace and tweak it into the
-            # expected return object
+            alignments_to_expressions = obj.get("mapped_expression_ids")
 
-            obj_data = self.workspace_client.get_objects2({"objects": [obj_spec]})[
-                "data"
-            ][0]
+            refs = set()
+            for mapping in alignments_to_expressions:
+                refs.update(list(mapping.values()))
+            expression_ref_list = list(refs)
 
-            obj = obj_data["data"]
-            obj_info = obj_data["info"]
+        expression_items = [{"ref": i} for i in expression_ref_list]
 
-            if "sample_expression_ids" in obj:
-                expression_ref_list = obj["sample_expression_ids"]
-            else:
-                alignments_to_expressions = obj.get("mapped_expression_ids")
+        item_infos = self.workspace_client.get_object_info3(
+            {"objects": expression_items, "includeMetadata": 1}
+        )["infos"]
+        for idx, _ in enumerate(expression_items):
+            expression_items[idx]["label"] = item_infos[idx][10].get("condition", None)
+            if checked_params[INC_ITEM_INFO]:
+                expression_items[idx]["info"] = item_infos[idx]
 
-                refs = set()
-                for mapping in alignments_to_expressions:
-                    refs.update(list(mapping.values()))
-                expression_ref_list = list(refs)
+        if checked_params[INC_ITEM_REF_PATHS]:
+            populate_item_object_ref_paths(expression_items, obj_spec)
 
-            expression_items = [{"ref": i} for i in expression_ref_list]
+        return {
+            "data": {"items": expression_items, "description": ""},
+            "info": obj_info,
+        }
 
-            item_infos = self.workspace_client.get_object_info3(
-                {"objects": expression_items, "includeMetadata": 1}
-            )["infos"]
-            for idx, ref in enumerate(expression_items):
-                expression_items[idx]["label"] = item_infos[idx][10].get(
-                    "condition", None
-                )
-                if include_item_info:
-                    expression_items[idx]["info"] = item_infos[idx]
-            """
-            If include_set_item_ref_paths is set, then add a field ref_path in alignment items
-            """
-            if include_set_item_ref_paths:
-                util.populate_item_object_ref_paths(expression_items, obj_spec)
+    def _check_get_set_params(self, params):
+        if not params.get("ref", None):
+            raise ValueError(param_required("ref"))
 
-            return {
-                "data": {"items": expression_items, "description": ""},
-                "info": obj_info,
-            }
+        if not check_reference(params["ref"]):
+            raise ValueError(ref_must_be_valid())
 
-    def _check_get_expression_set_params(self, params):
-        if "ref" not in params or params["ref"] is None:
-            raise ValueError(
-                '"ref" parameter field specifying the expression set is required'
-            )
-        if not util.check_reference(params["ref"]):
-            raise ValueError('"ref" parameter must be a valid workspace reference')
-        if INC_ITEM_INFO in params and params[INC_ITEM_INFO] not in [0, 1]:
-            raise ValueError(
-                '"include_item_info" parameter field can only be set to 0 or 1'
-            )
-        obj_spec = util.build_ws_obj_selector(
-            params.get("ref"), params.get(REF_PATH_TO_SET, [])
-        )
-        info = self.workspace_client.get_object_info3({"objects": [obj_spec]})
+        ref_path_to_set = params.get(REF_PATH_TO_SET, [])
+        for path in ref_path_to_set:
+            if not check_reference(path):
+                raise ValueError(ref_path_must_be_valid())
 
-        return info["infos"][0][2], obj_spec
+        for param in [INC_ITEM_INFO, INC_ITEM_REF_PATHS]:
+            if param in params and params[param] not in [0, 1]:
+                raise ValueError(include_params_valid(param))
+
+        return {
+            "ref": params["ref"],
+            INC_ITEM_INFO: params.get(INC_ITEM_INFO, 0) == 1,
+            INC_ITEM_REF_PATHS: params.get(INC_ITEM_REF_PATHS, 0) == 1,
+            REF_PATH_TO_SET: ref_path_to_set,
+        }

--- a/lib/SetAPI/featureset/FeatureSetSetInterfaceV1.py
+++ b/lib/SetAPI/featureset/FeatureSetSetInterfaceV1.py
@@ -41,7 +41,7 @@ class FeatureSetSetInterfaceV1:
         }
 
     def _validate_save_set_params(self, params):
-        if params.get("data", None) is None:
+        if params.get("data") is None:
             err_msg = param_required("data")
             raise ValueError(err_msg)
 
@@ -65,7 +65,7 @@ class FeatureSetSetInterfaceV1:
         return self.set_interface.get_set(**checked_params)
 
     def _check_get_set_params(self, params):
-        if not params.get("ref", None):
+        if not params.get("ref"):
             raise ValueError(param_required("ref"))
 
         if not check_reference(params["ref"]):

--- a/lib/SetAPI/featureset/FeatureSetSetInterfaceV1.py
+++ b/lib/SetAPI/featureset/FeatureSetSetInterfaceV1.py
@@ -1,9 +1,15 @@
-"""
-An interface for saving and retrieving Sets of FeatureSets.
-"""
+"""An interface for saving and retrieving Sets of FeatureSets."""
+from SetAPI.error_messages import (
+    include_params_valid,
+    list_required,
+    no_dupes,
+    param_required,
+    ref_must_be_valid,
+    ref_path_must_be_valid,
+)
+from SetAPI.generic.constants import INC_ITEM_INFO, INC_ITEM_REF_PATHS, REF_PATH_TO_SET
 from SetAPI.generic.SetInterfaceV1 import SetInterfaceV1
 from SetAPI.util import check_reference, info_to_ref
-from SetAPI.generic.constants import INC_ITEM_INFO, INC_ITEM_REF_PATHS, REF_PATH_TO_SET
 
 
 class FeatureSetSetInterfaceV1:
@@ -11,12 +17,20 @@ class FeatureSetSetInterfaceV1:
         self.ws = workspace_client
         self.set_interface = SetInterfaceV1(workspace_client)
 
-    def save_feature_set_set(self, ctx, params):
-        if "data" in params and params["data"] is not None:
-            self._validate_feature_set_set_data(params["data"])
-        else:
-            raise ValueError('"data" parameter field required to save a FeatureSetSet')
+    @staticmethod
+    def set_type() -> str:
+        return "KBaseSets.FeatureSetSet"
 
+    @staticmethod
+    def set_items_type() -> str:
+        return "FeatureSet"
+
+    @staticmethod
+    def allows_empty_set() -> bool:
+        return True
+
+    def save_feature_set_set(self, ctx, params):
+        self._validate_save_set_params(params)
         save_result = self.set_interface.save_set(
             "KBaseSets.FeatureSetSet", ctx["provenance"], params
         )
@@ -26,54 +40,49 @@ class FeatureSetSetInterfaceV1:
             "set_info": info,
         }
 
-    def _validate_feature_set_set_data(self, data):
-        if "items" not in data:
-            raise ValueError(
-                '"items" list must be defined in data to save a FeatureSetSet'
-            )
+    def _validate_save_set_params(self, params):
+        if params.get("data", None) is None:
+            err_msg = param_required("data")
+            raise ValueError(err_msg)
 
-        # add 'description' and 'label' fields if not present in data:
-        for item in data["items"]:
+        if "items" not in params["data"]:
+            raise ValueError(list_required("items"))
+
+        # add 'description' and item 'label' fields if not present:
+        if "description" not in params["data"]:
+            params["data"]["description"] = ""
+
+        seen_refs = set()
+        for item in params["data"]["items"]:
             if "label" not in item:
                 item["label"] = ""
-        if "description" not in data:
-            data["description"] = ""
+            if item["ref"] in seen_refs:
+                raise ValueError(no_dupes())
+            seen_refs.add(item["ref"])
 
     def get_feature_set_set(self, ctx, params):
-        self._check_get_feature_set_set_params(params)
+        checked_params = self._check_get_set_params(params)
+        return self.set_interface.get_set(**checked_params)
 
-        include_item_info = True if params.get(INC_ITEM_INFO, 0) == 1 else False
+    def _check_get_set_params(self, params):
+        if not params.get("ref", None):
+            raise ValueError(param_required("ref"))
 
-        include_set_item_ref_paths = (
-            True if params.get(INC_ITEM_REF_PATHS, 0) == 1 else False
-        )
+        if not check_reference(params["ref"]):
+            raise ValueError(ref_must_be_valid())
 
         ref_path_to_set = params.get(REF_PATH_TO_SET, [])
+        for path in ref_path_to_set:
+            if not check_reference(path):
+                raise ValueError(ref_path_must_be_valid())
 
-        set_data = self.set_interface.get_set(
-            params["ref"],
-            include_item_info,
-            ref_path_to_set,
-            include_set_item_ref_paths,
-        )
-        set_data = self._normalize_feature_set_set_data(set_data)
+        for param in [INC_ITEM_INFO, INC_ITEM_REF_PATHS]:
+            if param in params and params[param] not in [0, 1]:
+                raise ValueError(include_params_valid(param))
 
-        return set_data
-
-    def _check_get_feature_set_set_params(self, params):
-        if "ref" not in params or params["ref"] is None:
-            raise ValueError(
-                '"ref" parameter field specifying the FeatureSet set is required'
-            )
-        if not check_reference(params["ref"]):
-            raise ValueError('"ref" parameter must be a valid workspace reference')
-        if INC_ITEM_INFO in params and params[INC_ITEM_INFO] not in [0, 1]:
-            raise ValueError(
-                '"include_item_info" parameter field can only be set to 0 or 1'
-            )
-
-    def _normalize_feature_set_set_data(self, set_data):
-        # make sure that optional/missing fields are filled in or are defined
-        # TODO: populate empty description field
-        # TODO?: populate empty label fields
-        return set_data
+        return {
+            "ref": params["ref"],
+            INC_ITEM_INFO: params.get(INC_ITEM_INFO, 0) == 1,
+            INC_ITEM_REF_PATHS: params.get(INC_ITEM_REF_PATHS, 0) == 1,
+            REF_PATH_TO_SET: ref_path_to_set,
+        }

--- a/lib/SetAPI/generic/GenericSetNavigator.py
+++ b/lib/SetAPI/generic/GenericSetNavigator.py
@@ -1,14 +1,13 @@
-# -*- coding: utf-8 -*-
-
+"""Generic set-related actions."""
 import time
 
+from SetAPI.generic.constants import INC_ITEM_REF_PATHS, REF_PATH_TO_SET
 from SetAPI.generic.WorkspaceListObjectsIterator import WorkspaceListObjectsIterator
 from SetAPI.util import (
-    info_to_ref,
     build_ws_obj_selector,
+    info_to_ref,
     populate_item_object_ref_paths,
 )
-from SetAPI.generic.constants import INC_ITEM_REF_PATHS, REF_PATH_TO_SET
 
 
 class GenericSetNavigator:
@@ -284,7 +283,8 @@ class GenericSetNavigator:
 
     def _get_set_info(self, set_refs):
         objects = [
-            build_ws_obj_selector(s["ref"], s.get("path_to_set", [])) for s in set_refs
+            build_ws_obj_selector(s["ref"], s.get(REF_PATH_TO_SET, []))
+            for s in set_refs
         ]
 
         if objects:

--- a/lib/SetAPI/genome/GenomeSetInterfaceV1.py
+++ b/lib/SetAPI/genome/GenomeSetInterfaceV1.py
@@ -51,7 +51,9 @@ class GenomeSetInterfaceV1:
         }
 
     def _validate_save_set_params(
-        self: "GenomeSetInterfaceV1", params: dict[str, Any], save_search_set: bool
+        self: "GenomeSetInterfaceV1",
+        params: dict[str, Any],
+        save_search_set: bool = False,
     ) -> None:
         """Perform basic validation on the save set parameters.
 
@@ -62,8 +64,7 @@ class GenomeSetInterfaceV1:
         :param save_search_set: whether the set type should be a search set or a set set
         :type save_search_set: bool
         """
-        # TODO: add checks that only one copy of each genome is in the set
-        if params.get("data", None) is None:
+        if params.get("data") is None:
             err_msg = param_required("data")
             raise ValueError(err_msg)
 
@@ -99,7 +100,7 @@ class GenomeSetInterfaceV1:
         :return: validated parameters
         :rtype: dict[str, str | bool | list[str]]
         """
-        if not params.get("ref", None):
+        if not params.get("ref"):
             raise ValueError(param_required("ref"))
 
         if not check_reference(params["ref"]):

--- a/lib/SetAPI/reads/ReadsSetInterfaceV1.py
+++ b/lib/SetAPI/reads/ReadsSetInterfaceV1.py
@@ -58,7 +58,7 @@ class ReadsSetInterfaceV1:
         :param params: parameters to the save_set function
         :type params: dict[str, Any]
         """
-        if params.get("data", None) is None:
+        if params.get("data") is None:
             err_msg = param_required("data")
             raise ValueError(err_msg)
 
@@ -76,7 +76,6 @@ class ReadsSetInterfaceV1:
             if item["ref"] in seen_refs:
                 raise ValueError(no_dupes())
             seen_refs.add(item["ref"])
-        # TODO: add checks that only one copy of each reads data is in the set
         # TODO?: add checks that reads data list is homogenous (no mixed single/paired-end libs)
 
     def get_reads_set(self, ctx, params):
@@ -117,7 +116,7 @@ class ReadsSetInterfaceV1:
         :return: validated parameters
         :rtype: dict[str, str | bool | list[str]]
         """
-        if not params.get("ref", None):
+        if not params.get("ref"):
             raise ValueError(param_required("ref"))
 
         if not check_reference(params["ref"]):

--- a/lib/SetAPI/reads/ReadsSetInterfaceV1.py
+++ b/lib/SetAPI/reads/ReadsSetInterfaceV1.py
@@ -1,26 +1,46 @@
-from SetAPI.generic.SetInterfaceV1 import SetInterfaceV1
-from SetAPI.util import (
-    populate_item_object_ref_paths,
-    check_reference,
-    build_ws_obj_selector,
-    info_to_ref,
+"""An interface for handling reads sets."""
+from typing import Any
+
+from SetAPI.error_messages import (
+    include_params_valid,
+    list_required,
+    no_dupes,
+    param_required,
+    ref_must_be_valid,
+    ref_path_must_be_valid,
 )
 from SetAPI.generic.constants import INC_ITEM_INFO, INC_ITEM_REF_PATHS, REF_PATH_TO_SET
+from SetAPI.generic.SetInterfaceV1 import SetInterfaceV1
+from SetAPI.util import (
+    build_ws_obj_selector,
+    check_reference,
+    info_to_ref,
+    populate_item_object_ref_paths,
+)
 
 
 class ReadsSetInterfaceV1:
     def __init__(self, workspace_client):
-        self.ws = workspace_client
+        self.workspace_client = workspace_client
         self.set_interface = SetInterfaceV1(workspace_client)
 
+    @staticmethod
+    def set_type() -> str:
+        return "KBaseSets.ReadsSet"
+
+    @staticmethod
+    def set_items_type() -> str:
+        return "Reads"
+
+    @staticmethod
+    def allows_empty_set() -> bool:
+        return True
+
     def save_reads_set(self, ctx, params):
-        if "data" in params:
-            self._validate_reads_set_data(params["data"])
-        else:
-            raise ValueError('"data" parameter field required to save a ReadsSet')
+        self._validate_save_set_params(params)
 
         save_result = self.set_interface.save_set(
-            "KBaseSets.ReadsSet", ctx["provenance"], params
+            self.set_type(), ctx["provenance"], params
         )
         info = save_result[0]
         return {
@@ -28,107 +48,149 @@ class ReadsSetInterfaceV1:
             "set_info": info,
         }
 
-    def _validate_reads_set_data(self, data):
+    def _validate_save_set_params(
+        self: "ReadsSetInterfaceV1", params: dict[str, Any]
+    ) -> None:
+        """Perform basic validation on the save set parameters.
+
+        :param self: this class
+        :type self: ReadsSetInterfaceV1
+        :param params: parameters to the save_set function
+        :type params: dict[str, Any]
+        """
+        if params.get("data", None) is None:
+            err_msg = param_required("data")
+            raise ValueError(err_msg)
+
+        if "items" not in params["data"]:
+            raise ValueError(list_required("items"))
+
+        # add 'description' and 'label' fields if not present in data:
+        if "description" not in params["data"]:
+            params["data"]["description"] = ""
+
+        seen_refs = set()
+        for item in params["data"]["items"]:
+            if "label" not in item:
+                item["label"] = ""
+            if item["ref"] in seen_refs:
+                raise ValueError(no_dupes())
+            seen_refs.add(item["ref"])
         # TODO: add checks that only one copy of each reads data is in the set
         # TODO?: add checks that reads data list is homogenous (no mixed single/paired-end libs)
 
-        if "items" not in data:
-            raise ValueError('"items" list must be defined in data to save a ReadsSet')
-
-        # add 'description' and 'label' fields if not present in data:
-        for item in data["items"]:
-            if "label" not in item:
-                item["label"] = ""
-        if "description" not in data:
-            data["description"] = ""
-
     def get_reads_set(self, ctx, params):
-        set_type, obj_spec = self._check_get_reads_set_params(params)
+        checked_params = self._check_get_set_params(params)
 
-        include_item_info = True if params.get(INC_ITEM_INFO, 0) == 1 else False
-
-        include_set_item_ref_paths = (
-            True if params.get(INC_ITEM_REF_PATHS, 0) == 1 else False
+        # check the type of the set itself
+        obj_ref_dict = build_ws_obj_selector(
+            checked_params["ref"], checked_params[REF_PATH_TO_SET]
         )
 
-        ref_path_to_set = params.get(REF_PATH_TO_SET, [])
+        info = self.workspace_client.get_object_info3({"objects": [obj_ref_dict]})
+        set_type = info["infos"][0][2]
 
-        # If this is a KBaseSets.ReadsSet, do as normal.
         if "KBaseSets" in set_type:
-            set_data = self.set_interface.get_set(
-                params["ref"],
-                include_item_info,
-                ref_path_to_set,
-                include_set_item_ref_paths,
-            )
-            return self._normalize_read_set_data(set_data)
+            # If it's a KBaseSets type, then we know the usual interface will work...
+            return self.set_interface.get_set(**checked_params)
 
         # Otherwise, fetch the SampleSet info from the workspace and go on from there.
-        elif "KBaseRNASeq.RNASeqSampleSet" in set_type:
-            obj_data = self.ws.get_objects2({"objects": [obj_spec]})["data"][0]
-            obj = obj_data["data"]
-            obj_info = obj_data["info"]
-            desc = obj.get("sampleset_desc", "")
-            obj_info[10]["description"] = desc
-            obj_info[10]["item_count"] = len(obj.get("sample_ids", []))
-            set_data = {"data": {"items": [], "description": desc}, "info": obj_info}
+        if "KBaseRNASeq.RNASeqSampleSet" in set_type:
+            return self.get_rnaseq_sample_set(
+                obj_ref_dict,
+                checked_params[INC_ITEM_INFO],
+                checked_params[INC_ITEM_REF_PATHS],
+            )
 
-            reads_items = []
-            if len(obj.get("sample_ids")) != len(obj.get("condition")):
-                raise RuntimeError(
-                    "Invalid RNASeqSampleSet! The number of conditions \
-                                    doesn't match the number of reads objects."
-                )
-            if len(obj.get("sample_ids", [])) == 0:
-                return set_data
-            for idx, ref in enumerate(obj["sample_ids"]):
-                reads_items.append(
-                    {"ref": obj["sample_ids"][idx], "label": obj["condition"][idx]}
-                )
-            if include_item_info:
-                reads_obj_specs = [{"ref": i["ref"]} for i in reads_items]
-                infos = self.ws.get_object_info3(
-                    {"objects": reads_obj_specs, "includeMetadata": 1}
-                )["infos"]
-                for idx, info in enumerate(infos):
-                    reads_items[idx]["info"] = info
-            """
-            If include_set_item_ref_paths is set, then add a field ref_path in alignment items
-            """
-            if include_set_item_ref_paths:
-                populate_item_object_ref_paths(reads_items, obj_spec)
-
-            set_data["data"]["items"] = reads_items
-            return set_data
         # Otherwise-otherwise, it's not the right type for this getter.
-        else:
-            raise ValueError(
-                "The object type {} is invalid for get_reads_set_v1".format(set_type)
-            )
+        raise ValueError(f"The object type {set_type} is invalid for get_reads_set_v1")
 
-    def _check_get_reads_set_params(self, params):
-        if "ref" not in params:
-            raise ValueError(
-                '"ref" parameter field specifying the reads set is required'
-            )
+    def _check_get_set_params(
+        self: "ReadsSetInterfaceV1", params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Perform basic validation on the get_set parameters.
+
+        :param self: this class
+        :type self: ReadsSetInterfaceV1
+        :param params: method params
+        :type params: dict[str, Any]
+        :return: validated parameters
+        :rtype: dict[str, str | bool | list[str]]
+        """
+        if not params.get("ref", None):
+            raise ValueError(param_required("ref"))
+
         if not check_reference(params["ref"]):
-            raise ValueError('"ref" parameter must be a valid workspace reference')
-        if INC_ITEM_INFO in params:
-            if params[INC_ITEM_INFO] not in [0, 1]:
-                raise ValueError(
-                    '"include_item_info" parameter field can only be set to 0 or 1'
-                )
+            raise ValueError(ref_must_be_valid())
 
-        obj_spec = build_ws_obj_selector(
-            params.get("ref"), params.get(REF_PATH_TO_SET, [])
-        )
+        ref_path_to_set = params.get(REF_PATH_TO_SET, [])
+        for path in ref_path_to_set:
+            if not check_reference(path):
+                raise ValueError(ref_path_must_be_valid())
 
-        info = self.ws.get_object_info3({"objects": [obj_spec]})
+        for param in [INC_ITEM_INFO, INC_ITEM_REF_PATHS]:
+            if param in params and params[param] not in [0, 1]:
+                raise ValueError(include_params_valid(param))
 
-        return info["infos"][0][2], obj_spec
+        return {
+            "ref": params["ref"],
+            INC_ITEM_INFO: params.get(INC_ITEM_INFO, 0) == 1,
+            INC_ITEM_REF_PATHS: params.get(INC_ITEM_REF_PATHS, 0) == 1,
+            REF_PATH_TO_SET: ref_path_to_set,
+        }
 
-    def _normalize_read_set_data(self, set_data):
-        # make sure that optional/missing fields are filled in or are defined
-        # TODO: populate empty description field
-        # TODO?: populate empty label fields
+    def get_rnaseq_sample_set(
+        self: "ReadsSetInterfaceV1",
+        obj_ref_dict: dict[str, str],
+        include_item_info: bool = False,
+        include_set_item_ref_paths: bool = False,
+    ) -> dict[str, Any]:
+        """Retrieve and reconstitute a KBase RNASeqAlignmentSet from the workspace.
+
+        :param self: this class
+        :type self: ReadsAlignmentSetInterfaceV1
+        :param obj_ref_dict: dictionary with key "ref" and value reference for the set
+        :type obj_ref_dict: dict[str, str]
+        :param include_item_info: whether info should be included for each set item
+        :type include_item_info: bool, defaults to False
+        :param include_set_item_ref_paths: whether the item ref paths should be included
+        :type include_set_item_ref_paths: bool, defaults to False
+        :return: standard set output structure
+        :rtype: dict[str, Any]
+        """
+
+        obj_data = self.workspace_client.get_objects2({"objects": [obj_ref_dict]})[
+            "data"
+        ][0]
+        obj = obj_data["data"]
+        obj_info = obj_data["info"]
+        desc = obj.get("sampleset_desc", "")
+        obj_info[10]["description"] = desc
+        obj_info[10]["item_count"] = len(obj.get("sample_ids", []))
+        set_data = {"data": {"items": [], "description": desc}, "info": obj_info}
+
+        reads_items = []
+        if len(obj.get("sample_ids")) != len(obj.get("condition")):
+            raise RuntimeError(
+                "Invalid RNASeqSampleSet! The number of conditions doesn't match the number of reads objects."
+            )
+        if len(obj.get("sample_ids", [])) == 0:
+            return set_data
+        for idx, _ in enumerate(obj["sample_ids"]):
+            reads_items.append(
+                {"ref": obj["sample_ids"][idx], "label": obj["condition"][idx]}
+            )
+
+        if include_item_info:
+            reads_obj_specs = [{"ref": i["ref"]} for i in reads_items]
+            infos = self.workspace_client.get_object_info3(
+                {"objects": reads_obj_specs, "includeMetadata": 1}
+            )["infos"]
+            for idx, info in enumerate(infos):
+                reads_items[idx]["info"] = info
+
+        if include_set_item_ref_paths:
+            populate_item_object_ref_paths(reads_items, obj_ref_dict)
+
+        set_data["data"]["items"] = reads_items
         return set_data

--- a/lib/SetAPI/readsalignment/ReadsAlignmentSetInterfaceV1.py
+++ b/lib/SetAPI/readsalignment/ReadsAlignmentSetInterfaceV1.py
@@ -80,14 +80,14 @@ class ReadsAlignmentSetInterfaceV1:
         :param params: parameters to the save_set function
         :type params: dict[str, Any]
         """
-        if params.get("data", None) is None:
+        if params.get("data") is None:
             err_msg = param_required("data")
             raise ValueError(err_msg)
 
         if "items" not in params["data"]:
             raise ValueError(list_required("items"))
 
-        if not params["data"].get("items", None):
+        if not params["data"].get("items"):
             raise ValueError(no_items(self.set_items_type()))
 
         # add 'description' and 'label' fields if not present in data:
@@ -197,7 +197,7 @@ class ReadsAlignmentSetInterfaceV1:
             {"objects": alignment_items, "includeMetadata": 1}
         )["infos"]
         for idx, _ in enumerate(alignment_items):
-            alignment_items[idx]["label"] = item_infos[idx][10].get("condition", None)
+            alignment_items[idx]["label"] = item_infos[idx][10].get("condition")
             if include_item_info:
                 alignment_items[idx]["info"] = item_infos[idx]
 
@@ -222,7 +222,7 @@ class ReadsAlignmentSetInterfaceV1:
         :return: validated parameters
         :rtype: dict[str, Any]
         """
-        if not params.get("ref", None):
+        if not params.get("ref"):
             raise ValueError(param_required("ref"))
 
         if not check_reference(params["ref"]):

--- a/lib/SetAPI/readsalignment/ReadsAlignmentSetInterfaceV1.py
+++ b/lib/SetAPI/readsalignment/ReadsAlignmentSetInterfaceV1.py
@@ -4,13 +4,13 @@ from typing import Any
 from installed_clients.WorkspaceClient import Workspace
 
 from SetAPI.error_messages import (
-    data_required,
     include_params_valid,
     list_required,
+    no_dupes,
     no_items,
+    param_required,
     ref_must_be_valid,
     ref_path_must_be_valid,
-    ref_required,
     same_ref,
 )
 from SetAPI.generic.constants import INC_ITEM_INFO, INC_ITEM_REF_PATHS, REF_PATH_TO_SET
@@ -81,11 +81,11 @@ class ReadsAlignmentSetInterfaceV1:
         :type params: dict[str, Any]
         """
         if params.get("data", None) is None:
-            err_msg = data_required(self.set_items_type())
+            err_msg = param_required("data")
             raise ValueError(err_msg)
 
         if "items" not in params["data"]:
-            raise ValueError(list_required(self.set_items_type()))
+            raise ValueError(list_required("items"))
 
         if not params["data"].get("items", None):
             raise ValueError(no_items(self.set_items_type()))
@@ -94,19 +94,23 @@ class ReadsAlignmentSetInterfaceV1:
         if "description" not in params["data"]:
             params["data"]["description"] = ""
 
+        seen_refs = set()
         for item in params["data"]["items"]:
             if "label" not in item:
                 item["label"] = ""
+            if item["ref"] in seen_refs:
+                raise ValueError(no_dupes())
+            seen_refs.add(item["ref"])
 
         # Get all the genome ids from our ReadsAlignment references (it's the genome_id key in
         # the object metadata). Make a set out of them.
         # If there's 0 or more than 1 item in the set, then either those items are bad, or they're
         # aligned against different genomes.
-        ref_list = [{"ref": item["ref"]} for item in params["data"]["items"]]
-        info = self.workspace_client.get_object_info3(
+        ref_list = [{"ref": ref} for ref in seen_refs]
+        info_list = self.workspace_client.get_object_info3(
             {"objects": ref_list, "includeMetadata": 1}
-        )
-        num_genomes = len({item[10]["genome_id"] for item in info["infos"]})
+        )["infos"]
+        num_genomes = len({item[10]["genome_id"] for item in info_list})
         if num_genomes != 1:
             raise ValueError(same_ref(self.set_items_type()))
 
@@ -219,7 +223,7 @@ class ReadsAlignmentSetInterfaceV1:
         :rtype: dict[str, Any]
         """
         if not params.get("ref", None):
-            raise ValueError(ref_required(self.set_items_type()))
+            raise ValueError(param_required("ref"))
 
         if not check_reference(params["ref"]):
             raise ValueError(ref_must_be_valid())

--- a/lib/SetAPI/sampleset/SampleSetInterface.py
+++ b/lib/SetAPI/sampleset/SampleSetInterface.py
@@ -1,10 +1,9 @@
-"""
-An interface for handling sample sets
-"""
+"""An interface for handling sample sets."""
 
 import traceback
 from pprint import pprint
-from SetAPI.util import dfu_get_obj_data, convert_workspace_param, info_to_ref
+
+from SetAPI.util import convert_workspace_param, dfu_get_obj_data, info_to_ref
 
 
 class SampleSetInterface:
@@ -15,11 +14,8 @@ class SampleSetInterface:
         conditionset_data = dfu_get_obj_data(conditionset_ref)
         conditions = list(conditionset_data.get("conditions").keys())
 
-        if not all([x in conditions for x in matching_conditions]):
-            error_msg = "ERROR: Given conditions ({}) ".format(matching_conditions)
-            error_msg += "are not matching ConditionSet conditions: {}".format(
-                conditions
-            )
+        if not all(x in conditions for x in matching_conditions):
+            error_msg = f"ERROR: Given conditions ({matching_conditions}) are not matching ConditionSet conditions: {conditions}"
             raise ValueError(error_msg)
 
     def create_sample_set(self, ctx, params):
@@ -32,13 +28,15 @@ class SampleSetInterface:
         for item in params.get("sample_n_conditions", []):
             item_condition = item["condition"]
             if not isinstance(item_condition, (str | list)):
-                raise ValueError("ERROR: condition should be either a list or a string")
+                err_msg = "ERROR: condition should be either a list or a string"
+                raise ValueError(err_msg)
 
             if isinstance(
                 item_condition, list
             ):  # Auto populate UI puts input into an array
                 if len(item_condition) > 1:
-                    raise ValueError("ERROR: please only select 1 condition per Reads")
+                    err_msg = "ERROR: please only select 1 condition per Reads"
+                    raise ValueError(err_msg)
                 item["condition"] = item_condition[0]
 
             params["sample_ids"].extend(item["sample_id"])

--- a/lib/SetAPI/util.py
+++ b/lib/SetAPI/util.py
@@ -72,7 +72,7 @@ def convert_workspace_param(params: dict[str, int | str]) -> dict[str, int | str
     if params:
         # check the workspace_id, ws_id, and workspace fields for potential IDs or names
         ws_id_like = params.get(
-            "workspace_id", params.get("ws_id", params.get("workspace", None))
+            "workspace_id", params.get("ws_id", params.get("workspace"))
         )
         if ws_id_like:
             if str(ws_id_like).isdigit():
@@ -80,7 +80,7 @@ def convert_workspace_param(params: dict[str, int | str]) -> dict[str, int | str
             # otherwise, we probably have a workspace name posing as a workspace ID
             return {"workspace": ws_id_like}
 
-        ws_name_like = params.get("workspace_name", params.get("ws_name", None))
+        ws_name_like = params.get("workspace_name", params.get("ws_name"))
         if ws_name_like:
             return {"workspace": str(ws_name_like)}
 

--- a/lib/biokbase/log.py
+++ b/lib/biokbase/log.py
@@ -163,7 +163,7 @@ class log(object):
         self._subsystem = str(subsystem)
         self._mlog_config_file = config
         if not self._mlog_config_file:
-            self._mlog_config_file = _os.environ.get(MLOG_ENV_FILE, None)
+            self._mlog_config_file = _os.environ.get(MLOG_ENV_FILE)
         if self._mlog_config_file:
             self._mlog_config_file = str(self._mlog_config_file)
         self._user_log_level = -1

--- a/test/DifferentialExpressionMatrixSet_basic_test.py
+++ b/test/DifferentialExpressionMatrixSet_basic_test.py
@@ -1,9 +1,11 @@
 """Basic DifferentialExpressionMatrixSet tests."""
 import pytest
-from installed_clients.baseclient import ServerError
+from SetAPI.error_messages import (
+    same_ref,
+)
+from SetAPI.generic.constants import INC_ITEM_INFO, INC_ITEM_REF_PATHS
 from SetAPI.SetAPIImpl import SetAPI
 from SetAPI.util import info_to_ref
-from SetAPI.generic.constants import INC_ITEM_INFO, INC_ITEM_REF_PATHS
 
 
 def test_save_diff_exp_matrix_set(
@@ -73,7 +75,7 @@ def test_save_dem_set_mismatched_genomes(
     }
     with pytest.raises(
         ValueError,
-        match="All Differential Expression Matrix objects in the set must use the same genome reference.",
+        match=same_ref("DifferentialExpressionMatrix"),
     ):
         set_api_client.save_differential_expression_matrix_set_v1(
             context,
@@ -81,40 +83,6 @@ def test_save_dem_set_mismatched_genomes(
                 "workspace_id": ws_id,
                 "output_object_name": set_name,
                 "data": matrix_set,
-            },
-        )
-
-
-def test_save_dem_set_no_data(
-    set_api_client: SetAPI, context: dict[str, str | list], ws_id: int
-) -> None:
-    with pytest.raises(
-        ValueError,
-        match='"data" parameter field required to save a DifferentialExpressionMatrixSet',
-    ):
-        set_api_client.save_differential_expression_matrix_set_v1(
-            context,
-            {
-                "workspace_id": ws_id,
-                "output_object_name": "foo",
-                "data": None,
-            },
-        )
-
-
-def test_save_dem_set_no_dem(
-    set_api_client: SetAPI, context: dict[str, str | list], ws_id: int
-) -> None:
-    with pytest.raises(
-        ValueError,
-        match="A DifferentialExpressionMatrixSet must contain at least one DifferentialExpressionMatrix object reference.",
-    ):
-        set_api_client.save_differential_expression_matrix_set_v1(
-            context,
-            {
-                "workspace_id": ws_id,
-                "output_object_name": "foo",
-                "data": {"items": []},
             },
         )
 
@@ -203,35 +171,3 @@ def test_get_dem_set_ref_path(
         assert "label" in item
         assert "ref_path" in item
         assert item["ref_path"] == dem_set_ref + ";" + item["ref"]
-
-
-def test_get_dem_set_bad_ref(
-    set_api_client: SetAPI, context: dict[str, str | list]
-) -> None:
-    with pytest.raises(
-        ValueError, match='"ref" parameter must be a valid workspace reference'
-    ):
-        set_api_client.get_differential_expression_matrix_set_v1(
-            context, {"ref": "not_a_ref"}
-        )
-
-
-def test_get_dem_set_bad_path(
-    set_api_client: SetAPI, context: dict[str, str | list]
-) -> None:
-    with pytest.raises(
-        ServerError, match="JSONRPCError: -32500. Object 2 cannot be accessed: "
-    ):
-        set_api_client.get_differential_expression_matrix_set_v1(
-            context, {"ref": "1/2/3", "path_to_set": ["foo", "bar"]}
-        )
-
-
-def test_get_dem_set_no_ref(
-    set_api_client: SetAPI, context: dict[str, str | list]
-) -> None:
-    with pytest.raises(
-        ValueError,
-        match='"ref" parameter field specifying the DifferentialExpressionMatrix set is required',
-    ):
-        set_api_client.get_differential_expression_matrix_set_v1(context, {"ref": None})

--- a/test/ExpressionSet_basic_test.py
+++ b/test/ExpressionSet_basic_test.py
@@ -2,10 +2,9 @@
 from test.util import log_this
 
 import pytest
-from installed_clients.baseclient import ServerError
+from SetAPI.generic.constants import INC_ITEM_INFO, INC_ITEM_REF_PATHS
 from SetAPI.SetAPIImpl import SetAPI
 from SetAPI.util import info_to_ref
-from SetAPI.generic.constants import INC_ITEM_INFO, INC_ITEM_REF_PATHS
 
 DEBUG = False
 
@@ -14,7 +13,7 @@ def test_save_expression_set(
     set_api_client: SetAPI,
     context: dict[str, str | list],
     ws_id: int,
-    expression_refs,
+    expression_refs: list[str],
 ) -> None:
     expression_set_name = "test_expression_set"
     expression_items = [{"label": "foo", "ref": ref} for ref in expression_refs]
@@ -61,39 +60,6 @@ def test_save_expression_set_mismatched_genomes(
                 "workspace_id": ws_id,
                 "output_object_name": set_name,
                 "data": expression_set,
-            },
-        )
-
-
-def test_save_expression_set_no_data(
-    set_api_client: SetAPI, context: dict[str, str | list], ws_id: int
-) -> None:
-    with pytest.raises(
-        ValueError, match='"data" parameter field required to save an ExpressionSet'
-    ):
-        set_api_client.save_expression_set_v1(
-            context,
-            {
-                "workspace_id": ws_id,
-                "output_object_name": "foo",
-                "data": None,
-            },
-        )
-
-
-def test_save_expression_set_no_expressions(
-    set_api_client: SetAPI, context: dict[str, str | list], ws_id: int
-) -> None:
-    with pytest.raises(
-        ValueError,
-        match="An ExpressionSet must contain at least one Expression object reference.",
-    ):
-        set_api_client.save_expression_set_v1(
-            context,
-            {
-                "workspace_id": ws_id,
-                "output_object_name": "foo",
-                "data": {"items": []},
             },
         )
 
@@ -206,33 +172,3 @@ def test_get_created_rnaseq_expression_set_ref_path(
             "get_created_rnaseq_expression_set_ref_path",
             fetched_set_with_ref_path,
         )
-
-
-def test_get_expression_set_bad_ref(
-    set_api_client: SetAPI, context: dict[str, str | list]
-) -> None:
-    with pytest.raises(
-        ValueError, match='"ref" parameter must be a valid workspace reference'
-    ):
-        set_api_client.get_expression_set_v1(context, {"ref": "not_a_ref"})
-
-
-def test_get_expression_set_bad_path(
-    set_api_client: SetAPI, context: dict[str, str | list]
-) -> None:
-    with pytest.raises(
-        ServerError, match="JSONRPCError: -32500. Object 2 cannot be accessed: "
-    ):
-        set_api_client.get_expression_set_v1(
-            context, {"ref": "1/2/3", "path_to_set": ["foo", "bar"]}
-        )
-
-
-def test_get_expression_set_no_ref(
-    set_api_client: SetAPI, context: dict[str, str | list]
-) -> None:
-    with pytest.raises(
-        ValueError,
-        match='"ref" parameter field specifying the expression set is required',
-    ):
-        set_api_client.get_expression_set_v1(context, {"ref": None})

--- a/test/GenomeSet_basic_test.py
+++ b/test/GenomeSet_basic_test.py
@@ -1,8 +1,8 @@
 """Basic GenomeSet tests."""
 from test.util import INFO_LENGTH
 
-from SetAPI.SetAPIImpl import SetAPI
 from SetAPI.generic.constants import INC_ITEM_INFO, INC_ITEM_REF_PATHS
+from SetAPI.SetAPIImpl import SetAPI
 
 
 def test_basic_save_and_get(

--- a/test/ReadsAlignmentSet_basic_test.py
+++ b/test/ReadsAlignmentSet_basic_test.py
@@ -1,13 +1,7 @@
 """Basic ReadsAlignmentSet tests."""
-from test.common_checks import (
-    check_get_set_bad_path,
-    check_get_set_bad_ref,
-    check_get_set_no_ref,
+from test.common_test import (
     check_get_set_output,
     check_save_set_mismatched_genomes,
-    check_save_set_no_data,
-    check_save_set_no_items_list,
-    check_save_set_no_objects,
     check_save_set_output,
 )
 from typing import Any
@@ -56,7 +50,7 @@ def alignment_set(
 
 
 def test_save_reads_alignment_set(
-    alignment_set,
+    alignment_set: dict[str, Any],
 ) -> None:
     check_save_set_output(**alignment_set)
 
@@ -64,7 +58,6 @@ def test_save_reads_alignment_set(
 def test_save_reads_alignment_set_mismatched_genomes(
     set_api_client: SetAPI,
     context: dict[str, str | list],
-    ws_id: int,
     alignment_mismatched_genome_refs: list[str],
 ) -> None:
     alignment_set_items = [
@@ -72,39 +65,10 @@ def test_save_reads_alignment_set_mismatched_genomes(
     ]
     check_save_set_mismatched_genomes(
         context=context,
-        save_method=set_api_client.save_reads_alignment_set_v1,
+        set_api_client=set_api_client,
+        set_type="reads_alignment",
         set_items=alignment_set_items,
         set_items_type=API_CLASS.set_items_type(),
-    )
-
-
-def test_save_reads_alignment_set_no_data(
-    set_api_client: SetAPI, context: dict[str, str | list], ws_id: int
-) -> None:
-    check_save_set_no_data(
-        context,
-        set_api_client.save_reads_alignment_set_v1,
-        API_CLASS.set_items_type(),
-    )
-
-
-def test_save_reads_alignment_set_no_items_list(
-    set_api_client: SetAPI, context: dict[str, str | list], ws_id: int
-) -> None:
-    check_save_set_no_items_list(
-        context,
-        set_api_client.save_reads_alignment_set_v1,
-        API_CLASS.set_items_type(),
-    )
-
-
-def test_save_reads_alignment_set_no_alignments(
-    set_api_client: SetAPI, context: dict[str, str | list], ws_id: int
-) -> None:
-    check_save_set_no_objects(
-        context,
-        set_api_client.save_reads_alignment_set_v1,
-        API_CLASS.set_items_type(),
     )
 
 
@@ -263,23 +227,3 @@ def test_get_rnaseq_alignment_set(
             **params,
             is_fake_set=True,
         )
-
-
-def test_get_reads_alignment_set_bad_ref(
-    set_api_client: SetAPI, context: dict[str, str | list]
-) -> None:
-    check_get_set_bad_ref(context, set_api_client.get_reads_alignment_set_v1)
-
-
-def test_get_reads_alignment_set_bad_path(
-    set_api_client: SetAPI, context: dict[str, str | list]
-) -> None:
-    check_get_set_bad_path(context, set_api_client.get_reads_alignment_set_v1)
-
-
-def test_get_reads_alignment_set_no_ref(
-    set_api_client: SetAPI, context: dict[str, str | list]
-) -> None:
-    check_get_set_no_ref(
-        context, set_api_client.get_reads_alignment_set_v1, API_CLASS.set_items_type()
-    )

--- a/test/ReadsSet_basic_test.py
+++ b/test/ReadsSet_basic_test.py
@@ -1,9 +1,8 @@
 """Basic ReadsSet tests."""
 from test.util import INFO_LENGTH
 
-import pytest
-from SetAPI.SetAPIImpl import SetAPI
 from SetAPI.generic.constants import INC_ITEM_INFO, INC_ITEM_REF_PATHS
+from SetAPI.SetAPIImpl import SetAPI
 
 
 def test_basic_save_and_get(
@@ -176,19 +175,3 @@ def test_get_sampleset_as_readsset(
                 assert len(item["info"]) == INFO_LENGTH
             else:
                 assert "info" not in item
-
-
-def test_get_reads_set_bad_ref(
-    set_api_client: SetAPI, context: dict[str, str | list]
-) -> None:
-    with pytest.raises(
-        ValueError, match='"ref" parameter must be a valid workspace reference'
-    ):
-        set_api_client.get_reads_set_v1(context, {"ref": "not_a_ref"})
-
-
-def test_get_reads_set_bad_type(
-    reads_refs: list[str], set_api_client: SetAPI, context: dict[str, str | list]
-) -> None:
-    with pytest.raises(ValueError, match="is invalid for get_reads_set_v1"):
-        set_api_client.get_reads_set_v1(context, {"ref": reads_refs[0]})

--- a/test/SampleSet_basic_test.py
+++ b/test/SampleSet_basic_test.py
@@ -1,10 +1,10 @@
 """Basic tests of the SampleSet API."""
-from test.util import info_to_name, log_this, INFO_LENGTH
 from copy import deepcopy
+from test.util import INFO_LENGTH, info_to_name, log_this
 
 import pytest
-from SetAPI.SetAPIImpl import SetAPI
 from SetAPI.generic.constants import INC_ITEM_INFO, INC_ITEM_REF_PATHS
+from SetAPI.SetAPIImpl import SetAPI
 
 DESCRIPTION = "first pass at testing something or other"
 DEBUG = False

--- a/test/common_test.py
+++ b/test/common_test.py
@@ -156,8 +156,8 @@ def check_second_item(
     :type expected_item_data: dict[str, str]
     """
     second_item = obj["data"]["items"][1]
-    assert second_item.get("ref", None) == expected_item_data["ref"]
-    assert second_item.get("label", None) == expected_item_data["label"]
+    assert second_item.get("ref") == expected_item_data["ref"]
+    assert second_item.get("label") == expected_item_data["label"]
 
 
 def check_get_set_output(

--- a/test/common_test.py
+++ b/test/common_test.py
@@ -1,5 +1,5 @@
-import pytest
-from typing import Callable, Any
+"""General tests to be performed on most or all classes."""
+from collections.abc import Callable
 from test.util import (
     INFO_LENGTH,
     info_to_name,
@@ -7,6 +7,45 @@ from test.util import (
     info_to_type,
     info_to_usermeta,
 )
+from typing import Any
+
+import pytest
+from SetAPI.assembly.AssemblySetInterfaceV1 import AssemblySetInterfaceV1
+from SetAPI.differentialexpressionmatrix.DifferentialExpressionMatrixSetInterfaceV1 import (
+    DifferentialExpressionMatrixSetInterfaceV1,
+)
+from SetAPI.error_messages import (
+    include_params_valid,
+    list_required,
+    no_dupes,
+    no_items,
+    param_required,
+    ref_must_be_valid,
+    ref_path_must_be_valid,
+    same_ref,
+)
+from SetAPI.expression.ExpressionSetInterfaceV1 import ExpressionSetInterfaceV1
+from SetAPI.featureset.FeatureSetSetInterfaceV1 import FeatureSetSetInterfaceV1
+from SetAPI.generic.constants import INC_ITEM_INFO, INC_ITEM_REF_PATHS
+from SetAPI.genome.GenomeSetInterfaceV1 import GenomeSetInterfaceV1
+from SetAPI.reads.ReadsSetInterfaceV1 import ReadsSetInterfaceV1
+from SetAPI.readsalignment.ReadsAlignmentSetInterfaceV1 import (
+    ReadsAlignmentSetInterfaceV1,
+)
+from SetAPI.SetAPIImpl import SetAPI
+
+SET_TYPE_TO_CLASS = {
+    "assembly": AssemblySetInterfaceV1,
+    "differential_expression_matrix": DifferentialExpressionMatrixSetInterfaceV1,
+    "expression": ExpressionSetInterfaceV1,
+    "feature_set": FeatureSetSetInterfaceV1,
+    "genome": GenomeSetInterfaceV1,
+    "reads": ReadsSetInterfaceV1,
+    "reads_alignment": ReadsAlignmentSetInterfaceV1,
+}
+SET_TYPES = list(SET_TYPE_TO_CLASS.keys())
+FAKE_WS_ID = 123456789
+KBASE_UPA = "1/2/3"
 
 
 def is_info_object(
@@ -191,18 +230,17 @@ def check_get_set_output(
         check_second_item(obj, second_set_item)
 
 
-FAKE_WS_ID = 123456789
-
-
 def check_save_set_mismatched_genomes(
     context: dict[str, str | list],
-    save_method: Callable,
+    set_api_client: SetAPI,
+    set_type: str,
     set_items: list[dict[str, str]],
     set_items_type: str,
 ) -> None:
+    save_method = getattr(set_api_client, f"save_{set_type}_set_v1")
     with pytest.raises(
         ValueError,
-        match=f"All {set_items_type} objects in the set must use the same genome reference.",
+        match=same_ref(set_items_type),
     ):
         save_method(
             context,
@@ -217,10 +255,11 @@ def check_save_set_mismatched_genomes(
         )
 
 
-def check_save_set_no_data(
+@pytest.mark.parametrize("set_type", SET_TYPES)
+def test_save_set_no_data(
     context: dict[str, str | list],
-    save_method: Callable,
-    set_items_type: str,
+    set_api_client: SetAPI,
+    set_type: str,
 ) -> None:
     """Check that a set cannot be created without a "data" parameter.
 
@@ -231,9 +270,10 @@ def check_save_set_no_data(
     :param set_items_type: type of item in the set
     :type set_items_type: str
     """
+    save_method = getattr(set_api_client, f"save_{set_type}_set_v1")
     with pytest.raises(
         ValueError,
-        match=f'The "data" parameter is required to save {set_items_type}Sets',
+        match=param_required("data"),
     ):
         save_method(
             context,
@@ -245,10 +285,11 @@ def check_save_set_no_data(
         )
 
 
-def check_save_set_no_items_list(
+@pytest.mark.parametrize("set_type", SET_TYPES)
+def test_save_set_no_items_list(
     context: dict[str, str | list],
-    save_method: Callable,
-    set_items_type: str,
+    set_api_client: SetAPI,
+    set_type: str,
 ) -> None:
     """Check that a set cannot be created without an "items" key under the "data" parameter.
 
@@ -259,9 +300,10 @@ def check_save_set_no_items_list(
     :param set_items_type: string with the item type
     :type set_items_type: str
     """
+    save_method = getattr(set_api_client, f"save_{set_type}_set_v1")
     with pytest.raises(
         ValueError,
-        match=f'An "items" list must be defined in the "data" parameter to save {set_items_type}Sets',
+        match=list_required("items"),
     ):
         save_method(
             context,
@@ -273,10 +315,11 @@ def check_save_set_no_items_list(
         )
 
 
-def check_save_set_no_objects(
+@pytest.mark.parametrize("set_type", SET_TYPES)
+def test_save_set_no_objects(
     context: dict[str, str | list],
-    save_method: Callable,
-    set_items_type: str,
+    set_api_client: SetAPI,
+    set_type: str,
 ) -> None:
     """For classes that don't allow empty sets to be created.
 
@@ -287,9 +330,16 @@ def check_save_set_no_objects(
     :param set_items_type: string with the item type
     :type set_items_type: str
     """
+    klass = SET_TYPE_TO_CLASS[set_type]
+    if klass.allows_empty_set():
+        pytest.skip(f"{klass} allows the creation of empty sets")
+
+    save_method = getattr(set_api_client, f"save_{set_type}_set_v1")
+    set_items_type = SET_TYPE_TO_CLASS[set_type].set_items_type()
+
     with pytest.raises(
         ValueError,
-        match=f"{set_items_type}Sets must contain at least one {set_items_type} object reference.",
+        match=no_items(set_items_type),
     ):
         save_method(
             context,
@@ -301,34 +351,76 @@ def check_save_set_no_objects(
         )
 
 
-def check_get_set_bad_ref(
+@pytest.mark.parametrize("set_type", SET_TYPES)
+def test_save_set_with_dupes(
     context: dict[str, str | list],
-    get_method: Callable,
+    set_api_client: SetAPI,
+    set_type: str,
+):
+    save_method = getattr(set_api_client, f"save_{set_type}_set_v1")
+    # create a set with two identical refs
+    with pytest.raises(ValueError, match=no_dupes()):
+        save_method(
+            context,
+            {
+                "workspace_id": FAKE_WS_ID,
+                "output_object_name": "foo",
+                "data": {
+                    "items": [{"ref": KBASE_UPA}, {"ref": "4/5/6"}, {"ref": KBASE_UPA}]
+                },
+            },
+        )
+
+
+@pytest.mark.parametrize("set_type", SET_TYPES)
+def test_get_set_bad_ref(
+    context: dict[str, str | list], set_api_client: SetAPI, set_type: str
 ) -> None:
-    with pytest.raises(
-        ValueError, match='The "ref" parameter must be a valid workspace reference'
-    ):
+    """Check that the client throws an error with a dodgy ref."""
+    get_method = getattr(set_api_client, f"get_{set_type}_set_v1")
+    with pytest.raises(ValueError, match=ref_must_be_valid()):
         get_method(context, {"ref": "not_a_ref"})
 
 
-def check_get_set_bad_path(
-    context: dict[str, str | list],
-    get_method: Callable,
+@pytest.mark.parametrize("set_type", SET_TYPES)
+def test_get_set_bad_path(
+    context: dict[str, str | list], set_api_client: SetAPI, set_type: str
 ) -> None:
+    """Check that the client throws an error with a dodgy ref_path."""
+    get_method = getattr(set_api_client, f"get_{set_type}_set_v1")
     with pytest.raises(
         ValueError,
-        match='The "ref_path" parameter must contain valid workspace references',
+        match=ref_path_must_be_valid(),
     ):
-        get_method(context, {"ref": "1/2/3", "ref_path_to_set": ["foo", "bar"]})
+        get_method(context, {"ref": KBASE_UPA, "ref_path_to_set": ["foo", "bar"]})
 
 
-def check_get_set_no_ref(
+@pytest.mark.parametrize("set_type", SET_TYPES)
+@pytest.mark.parametrize("none_type", ["", None])
+def test_get_set_no_ref(
     context: dict[str, str | list],
-    get_method: Callable,
-    set_items_type: str,
+    set_api_client: SetAPI,
+    set_type: str,
+    none_type: None | str,
 ) -> None:
+    """Check that the client throws an error with no ref supplied."""
+    get_method = getattr(set_api_client, f"get_{set_type}_set_v1")
     with pytest.raises(
         ValueError,
-        match=f'The "ref" parameter specifying the {set_items_type}Set is required',
+        match=param_required("ref"),
     ):
-        get_method(context, {"ref": None})
+        get_method(context, {"ref": none_type})
+
+
+@pytest.mark.parametrize("set_type", SET_TYPES)
+@pytest.mark.parametrize("inc_arg", [INC_ITEM_INFO, INC_ITEM_REF_PATHS])
+def test_get_set_invalid_args(
+    context: dict[str, str | list],
+    set_api_client: SetAPI,
+    set_type: str,
+    inc_arg: str,
+) -> None:
+    """Check that the client throws an error with incorrect get args."""
+    get_method = getattr(set_api_client, f"get_{set_type}_set_v1")
+    with pytest.raises(ValueError, match=include_params_valid(inc_arg)):
+        get_method(context, {"ref": KBASE_UPA, inc_arg: 666})

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,21 +3,21 @@ import json
 import os
 import shutil
 import time
+from collections.abc import Generator
 from configparser import ConfigParser
 from test import TEST_BASE_DIR
 from test.util import (
     log_this,
     make_fake_alignment,
     make_fake_annotation,
+    make_fake_diff_exp_matrix,
     make_fake_expression,
+    make_fake_feature_set,
     make_fake_rnaseq_alignment_set,
     make_fake_rnaseq_expression_set,
     make_fake_sampleset,
-    make_fake_feature_set,
-    make_fake_diff_exp_matrix,
 )
 from typing import Any
-from collections.abc import Generator
 
 import pytest
 from installed_clients.AssemblyUtilClient import AssemblyUtil
@@ -176,6 +176,7 @@ def set_api_client(config: dict[str, str]) -> SetAPI:
 @pytest.fixture(scope="session", autouse=True)
 def clients(test_workspaces: dict[str, Any]) -> dict[str, Any]:
     """Set up other clients needed during the tests.
+
     The workspace client is included here because the WS needs to be
     set up before any of the other clients can be used -- otherwise,
     they will attempt to access a workspace that does not exist.
@@ -350,7 +351,6 @@ def assembly_refs(clients: dict[str, Any], ws_id: int, scratch_dir: str) -> list
     :return: list of KBase UPAs
     :rtype: list[str]
     """
-
     # use the seq.fna file that was copied to the scratch dir
     fna_path = os.path.join(scratch_dir, "seq.fna")
     assembly_refs = [

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -33,7 +33,7 @@ CONFIG_FILE = os.environ.get(
     "KB_DEPLOYMENT_CONFIG", os.path.join(TEST_BASE_DIR, "./deploy.cfg")
 )
 
-TOKEN = os.environ.get("KB_AUTH_TOKEN", None)
+TOKEN = os.environ.get("KB_AUTH_TOKEN")
 SDK_CALLBACK_URL = os.environ["SDK_CALLBACK_URL"]
 
 

--- a/test/util_test.py
+++ b/test/util_test.py
@@ -1,10 +1,12 @@
+"""Tests for the various SetAPI utils."""
 from typing import Any
+
 import pytest
 from SetAPI.util import (
-    check_reference,
     build_ws_obj_selector,
-    populate_item_object_ref_paths,
+    check_reference,
     convert_workspace_param,
+    populate_item_object_ref_paths,
 )
 
 bad_upas = [
@@ -46,7 +48,7 @@ bad_upas = [
 
 
 @pytest.mark.parametrize("upa", [pytest.param(upa) for upa in bad_upas])
-def test_check_reference_fail(upa):
+def test_check_reference_fail(upa: None | str):
     assert check_reference(upa) is False
 
 
@@ -62,7 +64,7 @@ good_upas = [
 
 
 @pytest.mark.parametrize("upa", [pytest.param(upa) for upa in good_upas])
-def test_check_reference_good_refs(upa) -> None:
+def test_check_reference_good_refs(upa: str) -> None:
     assert check_reference(upa) is True
 
 
@@ -106,9 +108,7 @@ WS_NAME = "some_string"
         ),
     ],
 )
-def test_convert_workspace_param(
-    params_key: str, args: dict[str, dict[str, int | str]]
-) -> None:
+def test_convert_workspace_param(params_key: str, args: dict[str, Any]) -> None:
     assert convert_workspace_param({params_key: args["value"]}) == args["expected"]
 
 
@@ -145,9 +145,7 @@ def test_convert_workspace_param(
         ),
     ],
 )
-def test_convert_workspace_param_ws_name(
-    params_key: str, args: dict[str, str | int | dict[str, int | str]]
-) -> None:
+def test_convert_workspace_param_ws_name(params_key: str, args: dict[str, Any]) -> None:
     assert convert_workspace_param({params_key: args["value"]}) == args["expected"]
 
 


### PR DESCRIPTION
This implements most of the suggestions from the previous PR; the next one will tidy up the remainder.

- use standard error messages in tests
- add in a check that there aren't duplicate items in the set
- use standard methods for validation save_set and get_set params
- use standard tests for testing errors in save_set and get_set params
- probably a few misc fixes along the way

Codecov failed.